### PR TITLE
8232616: JVMCI_lock fails to get initialized when cds is disabled

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -358,14 +358,14 @@ void mutex_init() {
 #if INCLUDE_JVMTI
   def(CDSClassFileStream_lock      , PaddedMutex  , max_nonleaf, false, Monitor::_safepoint_check_always);
 #endif
+  def(DumpTimeTable_lock           , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_never);
+#endif // INCLUDE_CDS
 
 #if INCLUDE_JVMCI
   def(JVMCI_lock                   , PaddedMonitor, nonleaf+2,   true,  Monitor::_safepoint_check_always);
   def(JVMCIGlobalAlloc_lock        , PaddedMutex  , nonleaf,     true,  Monitor::_safepoint_check_never);
   def(JVMCIGlobalActive_lock       , PaddedMutex  , nonleaf-1,   true,  Monitor::_safepoint_check_never);
 #endif
-  def(DumpTimeTable_lock           , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_never);
-#endif // INCLUDE_CDS
 }
 
 GCMutexLocker::GCMutexLocker(Monitor * mutex) {


### PR DESCRIPTION
Please review this backport of 8232616 to jdk13u, fix didn't apply cleanly, minimal mods were needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8232616](https://bugs.openjdk.java.net/browse/JDK-8232616): JVMCI_lock fails to get initialized when cds is disabled


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/5/head:pull/5`
`$ git checkout pull/5`
