### PR TITLE
8255468: JDK-8255269 incorrectly replaced average copy time

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -695,7 +695,7 @@ void G1Policy::record_collection_pause_end(double pause_time_ms, size_t cards_sc
 
     if (_collection_set->bytes_used_before() > freed_bytes) {
       size_t copied_bytes = _collection_set->bytes_used_before() - freed_bytes;
-      double average_copy_time = average_time_ms(G1GCPhaseTimes::ObjCopy);
+      double average_copy_time = average_time_ms(G1GCPhaseTimes::ObjCopy) + average_time_ms(G1GCPhaseTimes::OptObjCopy);
       double cost_per_byte_ms = average_copy_time / (double) copied_bytes;
       _analytics->report_cost_per_byte_ms(cost_per_byte_ms, collector_state()->mark_or_rebuild_in_progress());
     }


### PR DESCRIPTION
Please review this fix to the patch for JDK-8255269. Part of the average copy time calculation was left out. This line from the patch

double average_copy_time = average_time_ms(G1GCPhaseTimes::ObjCopy);

should be

double average_copy_time = average_time_ms(G1GCPhaseTimes::ObjCopy) + average_time_ms(G1GCPhaseTimes::OptObjCopy);

Thanks,
Paul

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255468](https://bugs.openjdk.java.net/browse/JDK-8255468): JDK-8255269 incorrectly replaced average copy time


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/6/head:pull/6`
`$ git checkout pull/6`
