### PR TITLE
8226575: OperatingSystemMXBean should be made container aware

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
@@ -29,6 +29,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.stream.Stream;
 
 import jdk.internal.platform.cgroupv1.SubSystem.MemorySubSystem;
@@ -70,7 +73,7 @@ public class Metrics implements jdk.internal.platform.Metrics {
          * 34 28 0:29 / /sys/fs/cgroup/MemorySubSystem rw,nosuid,nodev,noexec,relatime shared:16 - cgroup cgroup rw,MemorySubSystem
          */
         try (Stream<String> lines =
-             Files.lines(Paths.get("/proc/self/mountinfo"))) {
+             readFilePrivileged(Paths.get("/proc/self/mountinfo"))) {
 
             lines.filter(line -> line.contains(" - cgroup "))
                  .map(line -> line.split(" "))
@@ -104,7 +107,7 @@ public class Metrics implements jdk.internal.platform.Metrics {
          *
          */
         try (Stream<String> lines =
-             Files.lines(Paths.get("/proc/self/cgroup"))) {
+             readFilePrivileged(Paths.get("/proc/self/cgroup"))) {
 
             lines.map(line -> line.split(":"))
                  .filter(line -> (line.length >= 3))
@@ -122,6 +125,25 @@ public class Metrics implements jdk.internal.platform.Metrics {
         return null;
     }
 
+    static Stream<String> readFilePrivileged(Path path) throws IOException {
+        try {
+            PrivilegedExceptionAction<Stream<String>> pea = () -> Files.lines(path);
+            return AccessController.doPrivileged(pea);
+        } catch (PrivilegedActionException e) {
+            unwrapIOExceptionAndRethrow(e);
+            throw new InternalError(e.getCause());
+        }
+    }
+
+    static void unwrapIOExceptionAndRethrow(PrivilegedActionException pae) throws IOException {
+        Throwable x = pae.getCause();
+        if (x instanceof IOException)
+            throw (IOException) x;
+        if (x instanceof RuntimeException)
+            throw (RuntimeException) x;
+        if (x instanceof Error)
+            throw (Error) x;
+    }
     /**
      * createSubSystem objects and initialize mount points
      */

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -208,6 +208,8 @@ module java.base {
         java.management,
         jdk.management.agent,
         jdk.internal.jvmstat;
+    exports jdk.internal.platform to
+        jdk.management;
     exports jdk.internal.ref to
         java.desktop;
     exports jdk.internal.reflect to

--- a/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,4 +42,18 @@ Java_com_sun_management_internal_OperatingSystemImpl_getProcessCpuLoad0
 (JNIEnv *env, jobject dummy)
 {
     return -1.0;
+}
+
+JNIEXPORT jdouble JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
+(JNIEnv *env, jobject dummy, jint cpu_number)
+{
+    return -1.0;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
+(JNIEnv *env, jobject mbean)
+{
+    return -1;
 }

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,17 +198,19 @@ static int get_jvmticks(ticks *pticks) {
  * This method must be called first, before any data can be gathererd.
  */
 int perfInit() {
-    static int initialized=1;
+    static int initialized = 0;
 
     if (!initialized) {
         int  i;
-
-        int n = sysconf(_SC_NPROCESSORS_ONLN);
+        // We need to allocate counters for all CPUs, including ones that
+        // are currently offline as they could be turned online later.
+        int n = sysconf(_SC_NPROCESSORS_CONF);
         if (n <= 0) {
             n = 1;
         }
 
         counters.cpus = calloc(n,sizeof(ticks));
+        counters.nProcs = n;
         if (counters.cpus != NULL)  {
             // For the CPU load
             get_totalticks(-1, &counters.cpuTicks);
@@ -323,7 +325,7 @@ JNIEXPORT jdouble JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getSystemCpuLoad0
 (JNIEnv *env, jobject dummy)
 {
-    if(perfInit() == 0) {
+    if (perfInit() == 0) {
         return get_cpu_load(-1);
     } else {
         return -1.0;
@@ -334,9 +336,31 @@ JNIEXPORT jdouble JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getProcessCpuLoad0
 (JNIEnv *env, jobject dummy)
 {
-    if(perfInit() == 0) {
+    if (perfInit() == 0) {
         return get_process_load();
     } else {
         return -1.0;
+    }
+}
+
+JNIEXPORT jdouble JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
+(JNIEnv *env, jobject mbean, jint cpu_number)
+{
+    if (perfInit() == 0 && cpu_number >= 0 && cpu_number < counters.nProcs) {
+        return get_cpu_load(cpu_number);
+    } else {
+        return -1.0;
+    }
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
+(JNIEnv *env, jobject mbean)
+{
+    if (perfInit() == 0) {
+        return counters.nProcs;
+    } else {
+       return -1;
     }
 }

--- a/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,3 +159,17 @@ Java_com_sun_management_internal_OperatingSystemImpl_getProcessCpuLoad0
 
     return cpu;
  }
+
+JNIEXPORT jdouble JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
+(JNIEnv *env, jobject dummy, jint cpu_number)
+{
+    return -1.0;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
+(JNIEnv *env, jobject mbean)
+{
+    return -1;
+}

--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,12 @@ package com.sun.management;
 /**
  * Platform-specific management interface for the operating system
  * on which the Java virtual machine is running.
+ *
+ * <p>
+ * This interface provides information about the operating environment
+ * on which the Java virtual machine is running. That might be a native
+ * operating system, a virtualized operating system environment, or a
+ * container-managed environment.
  *
  * <p>
  * The {@code OperatingSystemMXBean} object returned by

--- a/src/jdk.management/solaris/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/solaris/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,3 +239,16 @@ Java_com_sun_management_internal_OperatingSystemImpl_getProcessCpuLoad0
     return get_process_load();
 }
 
+JNIEXPORT jdouble JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
+(JNIEnv *env, jobject mbean, jint cpu_number)
+{
+    return -1.0;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
+(JNIEnv *env, jobject mbean)
+{
+    return -1;
+}

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
 
 package com.sun.management.internal;
 
+import jdk.internal.platform.Metrics;
 import sun.management.BaseOperatingSystemImpl;
 import sun.management.VMManagement;
+
+import java.util.concurrent.TimeUnit;
 /**
  * Implementation class for the operating system.
  * Standard and committed hotspot-specific metrics if any.
@@ -37,8 +40,12 @@ import sun.management.VMManagement;
 class OperatingSystemImpl extends BaseOperatingSystemImpl
     implements com.sun.management.UnixOperatingSystemMXBean {
 
+    private static final int MAX_ATTEMPTS_NUMBER = 10;
+    private final Metrics containerMetrics;
+
     OperatingSystemImpl(VMManagement vm) {
         super(vm);
+        this.containerMetrics = jdk.internal.platform.Container.metrics();
     }
 
     public long getCommittedVirtualMemorySize() {
@@ -46,10 +53,39 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     }
 
     public long getTotalSwapSpaceSize() {
+        if (containerMetrics != null) {
+            long limit = containerMetrics.getMemoryAndSwapLimit();
+            // The memory limit metrics is not available if JVM runs on Linux host (not in a docker container)
+            // or if a docker container was started without specifying a memory limit (without '--memory='
+            // Docker option). In latter case there is no limit on how much memory the container can use and
+            // it can use as much memory as the host's OS allows.
+            long memLimit = containerMetrics.getMemoryLimit();
+            if (limit >= 0 && memLimit >= 0) {
+                return limit - memLimit;
+            }
+        }
         return getTotalSwapSpaceSize0();
     }
 
     public long getFreeSwapSpaceSize() {
+        if (containerMetrics != null) {
+            long memSwapLimit = containerMetrics.getMemoryAndSwapLimit();
+            long memLimit = containerMetrics.getMemoryLimit();
+            if (memSwapLimit >= 0 && memLimit >= 0) {
+                for (int attempt = 0; attempt < MAX_ATTEMPTS_NUMBER; attempt++) {
+                    long memSwapUsage = containerMetrics.getMemoryAndSwapUsage();
+                    long memUsage = containerMetrics.getMemoryUsage();
+                    if (memSwapUsage > 0 && memUsage > 0) {
+                        // We read "memory usage" and "memory and swap usage" not atomically,
+                        // and it's possible to get the negative value when subtracting these two.
+                        // If this happens just retry the loop for a few iterations.
+                        if ((memSwapUsage - memUsage) >= 0) {
+                            return memSwapLimit - memLimit - (memSwapUsage - memUsage);
+                        }
+                    }
+                }
+            }
+        }
         return getFreeSwapSpaceSize0();
     }
 
@@ -58,10 +94,23 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     }
 
     public long getFreePhysicalMemorySize() {
+        if (containerMetrics != null) {
+            long usage = containerMetrics.getMemoryUsage();
+            long limit = containerMetrics.getMemoryLimit();
+            if (usage > 0 && limit >= 0) {
+                return limit - usage;
+            }
+        }
         return getFreePhysicalMemorySize0();
     }
 
     public long getTotalPhysicalMemorySize() {
+        if (containerMetrics != null) {
+            long limit = containerMetrics.getMemoryLimit();
+            if (limit >= 0) {
+                return limit;
+            }
+        }
         return getTotalPhysicalMemorySize0();
     }
 
@@ -74,11 +123,57 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     }
 
     public double getSystemCpuLoad() {
+        if (containerMetrics != null) {
+            long quota = containerMetrics.getCpuQuota();
+            if (quota > 0) {
+                long periodLength = containerMetrics.getCpuPeriod();
+                long numPeriods = containerMetrics.getCpuNumPeriods();
+                long usageNanos = containerMetrics.getCpuUsage();
+                if (periodLength > 0 && numPeriods > 0 && usageNanos > 0) {
+                    long elapsedNanos = TimeUnit.MICROSECONDS.toNanos(periodLength * numPeriods);
+                    double systemLoad = (double) usageNanos / elapsedNanos;
+                    // Ensure the return value is in the range 0.0 -> 1.0
+                    systemLoad = Math.max(0.0, systemLoad);
+                    systemLoad = Math.min(1.0, systemLoad);
+                    return systemLoad;
+                }
+                return -1;
+            } else {
+                // If CPU quotas are not active then find the average system load for
+                // all online CPUs that are allowed to run this container.
+
+                // If the cpuset is the same as the host's one there is no need to iterate over each CPU
+                if (isCpuSetSameAsHostCpuSet()) {
+                    return getSystemCpuLoad0();
+                } else {
+                    int[] cpuSet = containerMetrics.getEffectiveCpuSetCpus();
+                    if (cpuSet != null && cpuSet.length > 0) {
+                        double systemLoad = 0.0;
+                        for (int cpu : cpuSet) {
+                            double cpuLoad = getSingleCpuLoad0(cpu);
+                            if (cpuLoad < 0) {
+                                return -1;
+                            }
+                            systemLoad += cpuLoad;
+                        }
+                        return systemLoad / cpuSet.length;
+                    }
+                    return -1;
+                }
+            }
+        }
         return getSystemCpuLoad0();
     }
 
     public double getProcessCpuLoad() {
         return getProcessCpuLoad0();
+    }
+
+    private boolean isCpuSetSameAsHostCpuSet() {
+        if (containerMetrics != null) {
+            return containerMetrics.getCpuSetCpus().length == getHostConfiguredCpuCount0();
+        }
+        return false;
     }
 
     /* native methods */
@@ -92,6 +187,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private native double getSystemCpuLoad0();
     private native long getTotalPhysicalMemorySize0();
     private native long getTotalSwapSpaceSize0();
+    private native double getSingleCpuLoad0(int cpuNum);
+    private native int getHostConfiguredCpuCount0();
 
     static {
         initialize0();

--- a/test/hotspot/jtreg/containers/docker/CheckOperatingSystemMXBean.java
+++ b/test/hotspot/jtreg/containers/docker/CheckOperatingSystemMXBean.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import com.sun.management.OperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+
+public class CheckOperatingSystemMXBean {
+
+    public static void main(String[] args) {
+        System.out.println("Checking OperatingSystemMXBean");
+
+        OperatingSystemMXBean osBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+        System.out.println(String.format("Runtime.availableProcessors: %d", Runtime.getRuntime().availableProcessors()));
+        System.out.println(String.format("OperatingSystemMXBean.getAvailableProcessors: %d", osBean.getAvailableProcessors()));
+        System.out.println(String.format("OperatingSystemMXBean.getTotalPhysicalMemorySize: %d", osBean.getTotalPhysicalMemorySize()));
+        System.out.println(String.format("OperatingSystemMXBean.getFreePhysicalMemorySize: %d", osBean.getFreePhysicalMemorySize()));
+        System.out.println(String.format("OperatingSystemMXBean.getTotalSwapSpaceSize: %d", osBean.getTotalSwapSpaceSize()));
+        System.out.println(String.format("OperatingSystemMXBean.getFreeSwapSpaceSize: %d", osBean.getFreeSwapSpaceSize()));
+        System.out.println(String.format("OperatingSystemMXBean.getSystemCpuLoad: %f", osBean.getSystemCpuLoad()));
+    }
+
+}

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -30,6 +30,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.jartool/sun.tools.jar
+ * @build PrintContainerInfo CheckOperatingSystemMXBean
  * @run driver TestCPUAwareness
  */
 import java.util.List;
@@ -76,8 +77,18 @@ public class TestCPUAwareness {
             testCpuQuotaAndPeriod(150*1000, 100*1000);
             testCpuQuotaAndPeriod(400*1000, 100*1000);
 
+            testOperatingSystemMXBeanAwareness("0.5", "1");
+            testOperatingSystemMXBeanAwareness("1.0", "1");
+            if (availableCPUs > 2) {
+                testOperatingSystemMXBeanAwareness("1.2", "2");
+                testOperatingSystemMXBeanAwareness("1.8", "2");
+                testOperatingSystemMXBeanAwareness("2.0", "2");
+            }
+
         } finally {
-            DockerTestUtils.removeDockerImage(imageName);
+            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
+                DockerTestUtils.removeDockerImage(imageName);
+            }
         }
     }
 
@@ -205,5 +216,22 @@ public class TestCPUAwareness {
         Common.run(opts)
             .shouldMatch("CPU Shares is.*" + shares)
             .shouldMatch("active_processor_count.*" + expectedAPC);
+    }
+
+    private static void testOperatingSystemMXBeanAwareness(String cpuAllocation, String expectedCpus) throws Exception {
+        Common.logNewTestCase("Check OperatingSystemMXBean");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "CheckOperatingSystemMXBean")
+            .addDockerOpts(
+                "--cpus", cpuAllocation
+            );
+
+        DockerTestUtils.dockerRunJava(opts)
+            .shouldHaveExitValue(0)
+            .shouldContain("Checking OperatingSystemMXBean")
+            .shouldContain("Runtime.availableProcessors: " + expectedCpus)
+            .shouldContain("OperatingSystemMXBean.getAvailableProcessors: " + expectedCpus)
+            .shouldMatch("OperatingSystemMXBean\\.getSystemCpuLoad: [0-9]+\\.[0-9]+")
+            ;
     }
 }

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -30,7 +30,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.jartool/sun.tools.jar
- * @build AttemptOOM sun.hotspot.WhiteBox PrintContainerInfo
+ * @build AttemptOOM sun.hotspot.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean
  * @run driver ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run driver TestMemoryAwareness
  */
@@ -62,8 +62,22 @@ public class TestMemoryAwareness {
             // Add extra 10 Mb to allocator limit, to be sure to cause OOM
             testOOM("256m", 256 + 10);
 
+            testOperatingSystemMXBeanAwareness(
+                "100M", Integer.toString(((int) Math.pow(2, 20)) * 100),
+                "150M", Integer.toString(((int) Math.pow(2, 20)) * (150 - 100))
+            );
+            testOperatingSystemMXBeanAwareness(
+                "128M", Integer.toString(((int) Math.pow(2, 20)) * 128),
+                "256M", Integer.toString(((int) Math.pow(2, 20)) * (256 - 128))
+            );
+            testOperatingSystemMXBeanAwareness(
+                "1G", Integer.toString(((int) Math.pow(2, 20)) * 1024),
+                "1500M", Integer.toString(((int) Math.pow(2, 20)) * (1500 - 1024))
+            );
         } finally {
-            DockerTestUtils.removeDockerImage(imageName);
+            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
+                DockerTestUtils.removeDockerImage(imageName);
+            }
         }
     }
 
@@ -118,6 +132,26 @@ public class TestMemoryAwareness {
         out.shouldContain("Entering AttemptOOM main")
            .shouldNotContain("AttemptOOM allocation successful")
            .shouldContain("java.lang.OutOfMemoryError");
+    }
+
+    private static void testOperatingSystemMXBeanAwareness(String memoryAllocation, String expectedMemory,
+            String swapAllocation, String expectedSwap) throws Exception {
+        Common.logNewTestCase("Check OperatingSystemMXBean");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "CheckOperatingSystemMXBean")
+            .addDockerOpts(
+                "--memory", memoryAllocation,
+                "--memory-swap", swapAllocation
+            );
+
+        DockerTestUtils.dockerRunJava(opts)
+            .shouldHaveExitValue(0)
+            .shouldContain("Checking OperatingSystemMXBean")
+            .shouldContain("OperatingSystemMXBean.getTotalPhysicalMemorySize: " + expectedMemory)
+            .shouldMatch("OperatingSystemMXBean\\.getFreePhysicalMemorySize: [1-9][0-9]+")
+            .shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: " + expectedSwap)
+            .shouldMatch("OperatingSystemMXBean\\.getFreeSwapSpaceSize: [1-9][0-9]+")
+            ;
     }
 
 }


### PR DESCRIPTION
The patch applies cleanly, but it requires some modifications.
The original patch added new methods to OperatingSystemMXBean according to CSR JDK-8228428. Backporting them to 13u is not suitable. 
Similar to 11u/8u, existing methods have been changed to return the container values instead.
CSR for 13u is filed: JDK-8255834, it's similar to 11u/8u CSR JDK-8248804.

Tested with tier1 and container tests on Linux and Windows, the only failure is containers/docker/TestMemoryAwareness.java which is fixed by follow-up JDK-8236617, the plan is to push them together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8226575](https://bugs.openjdk.java.net/browse/JDK-8226575): OperatingSystemMXBean should be made container aware

### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/8/head:pull/8`
`$ git checkout pull/8`
