### PR TITLE
8228448: Jconsole can't connect to itself

### DIFF
--- a/make/launcher/Launcher-jdk.jconsole.gmk
+++ b/make/launcher/Launcher-jdk.jconsole.gmk
@@ -29,6 +29,7 @@ $(eval $(call SetupBuildLauncher, jconsole, \
     MAIN_CLASS := sun.tools.jconsole.JConsole, \
     JAVA_ARGS := --add-opens java.base/java.io=jdk.jconsole \
                  --add-modules ALL-DEFAULT \
-		 -Djconsole.showOutputViewer, \
+		 -Djconsole.showOutputViewer \
+		 -Djdk.attach.allowAttachSelf=true, \
     CFLAGS_windows := -DJAVAW, \
 ))


### PR DESCRIPTION
It's a backport of JDK-8228448 to jdk13u. The fix is already included to jdk11u (JDK-8248202). 
The patch applied cleanly. Checked this fix on macOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8228448](https://bugs.openjdk.java.net/browse/JDK-8228448): Jconsole can't connect to itself


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/11/head:pull/11`
`$ git checkout pull/11`
