### PR TITLE
8250928: JFR: Improve hash algorithm for stack traces

### DIFF
--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -235,6 +235,7 @@ bool JfrStackTrace::record_safe(JavaThread* thread, int skip) {
     vfs.next();
   }
 
+  _hash = 1;
   while (!vfs.at_end()) {
     if (count >= _max_frames) {
       _reached_root = false;
@@ -250,8 +251,9 @@ bool JfrStackTrace::record_safe(JavaThread* thread, int skip) {
     else {
       bci = vfs.bci();
     }
-    // Can we determine if it's inlined?
-    _hash = (_hash << 2) + (unsigned int)(((size_t)mid >> 2) + (bci << 4) + type);
+    _hash = (_hash * 31) + mid;
+    _hash = (_hash * 31) + bci;
+    _hash = (_hash * 31) + type;
     _frames[count] = JfrStackFrame(mid, bci, type, method);
     vfs.next();
     count++;


### PR DESCRIPTION
I would like to backport 8250928 to 13u, it's already included into 11u.

The patch applies almost cleanly except for the second hunk of jfrStackTrace.cpp due to different context (8236743 is not in 13u), reapplied manually.

Tested with tier1 and jdk/jfr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250928](https://bugs.openjdk.java.net/browse/JDK-8250928): JFR: Improve hash algorithm for stack traces


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/12/head:pull/12`
`$ git checkout pull/12`
