### PR TITLE
8252754: Hash code calculation of JfrStackTrace is inconsistent

### DIFF
--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -178,6 +178,7 @@ bool JfrStackTrace::record_thread(JavaThread& thread, frame& frame) {
   u4 count = 0;
   _reached_root = true;
 
+  _hash = 1;
   while (!st.at_end()) {
     if (count >= _max_frames) {
       _reached_root = false;
@@ -199,7 +200,9 @@ bool JfrStackTrace::record_thread(JavaThread& thread, frame& frame) {
     }
     const int lineno = method->line_number_from_bci(bci);
     // Can we determine if it's inlined?
-    _hash = (_hash << 2) + (unsigned int)(((size_t)mid >> 2) + (bci << 4) + type);
+    _hash = (_hash * 31) + mid;
+    _hash = (_hash * 31) + bci;
+    _hash = (_hash * 31) + type;
     _frames[count] = JfrStackFrame(mid, bci, type, method);
     st.samples_next();
     count++;


### PR DESCRIPTION
I would like to backport 8252754 to 13u as follow-up fix for 8250928, that is approved for 13u.

The patch applies almost cleanly except for the second hunk of jfrStackTrace.cpp due to different context (8236743 is not in 13u), reapplied manually.

Tested with tier1 and jdk/jfr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252754](https://bugs.openjdk.java.net/browse/JDK-8252754): Hash code calculation of JfrStackTrace is inconsistent


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/14/head:pull/14`
`$ git checkout pull/14`
