### PR TITLE
8151678: com/sun/jndi/ldap/LdapTimeoutTest.java failed due to timeout on DeadServerNoTimeoutTest is incorrect

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/DefaultLdapDnsProvider.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/DefaultLdapDnsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public class DefaultLdapDnsProvider {
         }
 
         LdapDnsProviderResult res = new LdapDnsProviderResult(domainName, endpoints);
-        if (res.getEndpoints().size() == 0 && res.getDomainName().isEmpty()) {
+        if (res.getEndpoints().isEmpty() && res.getDomainName().isEmpty()) {
             return Optional.empty();
         } else {
             return Optional.of(res);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -944,8 +944,6 @@ sun/tools/jhsdb/HeapDumpTest.java                               8193639 solaris-
 
 com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java                   8169942 linux-i586,macosx-all,windows-x64
 
-com/sun/jndi/ldap/LdapTimeoutTest.java                          8151678 generic-all
-
 com/sun/jndi/dns/ConfigTests/PortUnreachable.java               7164518 macosx-all
 
 javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-all


### PR DESCRIPTION
I would like to backport 8151678 to 13u as a follow-up of JDK-8160768.
The patch applies cleanly
This patch is also required for clean backport of JDK-8062947

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8151678](https://bugs.openjdk.java.net/browse/JDK-8151678): com/sun/jndi/ldap/LdapTimeoutTest.java failed due to timeout on DeadServerNoTimeoutTest is incorrect


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/17/head:pull/17`
`$ git checkout pull/17`
