### PR TITLE
8240603: Windows 32bit compile error after 8238676

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/atExit/libatExit.c
+++ b/test/hotspot/jtreg/runtime/jni/atExit/libatExit.c
@@ -104,7 +104,8 @@ void at_exit_handler(void) {
   // else test has already failed
 }
 
-jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved) {
   printf("JNI_OnLoad: registering atexit handler\n");
   jvm = vm;
   atexit(at_exit_handler);


### PR DESCRIPTION
I'd like to backport 8240603 to 13u as follow-up fix for JDK-8238676 that is already included to 13u.
The patch applies cleanly and resolves the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8240603](https://bugs.openjdk.java.net/browse/JDK-8240603): Windows 32bit compile error after 8238676

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/22/head:pull/22`
`$ git checkout pull/22`
