### PR TITLE
8238579: HttpsURLConnection drops the timeout and hangs forever in read

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,10 +87,16 @@ public abstract class AbstractDelegateHttpsURLConnection extends
      */
     public void setNewClient (URL url, boolean useCache)
         throws IOException {
+        int readTimeout = getReadTimeout();
         http = HttpsClient.New (getSSLSocketFactory(),
                                 url,
                                 getHostnameVerifier(),
-                                useCache, this);
+                                null,
+                                -1,
+                                useCache,
+                                getConnectTimeout(),
+                                this);
+        http.setReadTimeout(readTimeout);
         ((HttpsClient)http).afterConnect();
     }
 
@@ -132,10 +138,16 @@ public abstract class AbstractDelegateHttpsURLConnection extends
             boolean useCache) throws IOException {
         if (connected)
             return;
+        int readTimeout = getReadTimeout();
         http = HttpsClient.New (getSSLSocketFactory(),
                                 url,
                                 getHostnameVerifier(),
-                                proxyHost, proxyPort, useCache, this);
+                                proxyHost,
+                                proxyPort,
+                                useCache,
+                                getConnectTimeout(),
+                                this);
+        http.setReadTimeout(readTimeout);
         connected = true;
     }
 


### PR DESCRIPTION
Should be fixed in 13u, too. Patch applies clean, all relevant regtests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8238579](https://bugs.openjdk.java.net/browse/JDK-8238579): HttpsURLConnection drops the timeout and hangs forever in read

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/25/head:pull/25`
`$ git checkout pull/25`
