### PR TITLE
8241138: http.nonProxyHosts=* causes StringIndexOutOfBoundsException in DefaultProxySelector

### DIFF
--- a/src/java.base/share/classes/sun/net/spi/DefaultProxySelector.java
+++ b/src/java.base/share/classes/sun/net/spi/DefaultProxySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -391,7 +391,9 @@ public class DefaultProxySelector extends ProxySelector {
      */
     static String disjunctToRegex(String disjunct) {
         String regex;
-        if (disjunct.startsWith("*") && disjunct.endsWith("*")) {
+        if (disjunct.equals("*")) {
+            regex = ".*";
+        } else if (disjunct.startsWith("*") && disjunct.endsWith("*")) {
             regex = ".*" + quote(disjunct.substring(1, disjunct.length() - 1)) + ".*";
         } else if (disjunct.startsWith("*")) {
             regex = ".*" + quote(disjunct.substring(1));

--- a/test/jdk/java/net/ProxySelector/B8035158.java
+++ b/test/jdk/java/net/ProxySelector/B8035158.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8035158 8145732 8144300
+ * @bug 8035158 8145732 8144300 8241138
  * @run main/othervm B8035158
  */
 
@@ -155,6 +155,12 @@ public class B8035158 {
                 false));
         t.add(new TestCase("*google.*", "http://google.co.uk",
                 false));
+        t.add(new TestCase("*", "http://google.co.uk",false));
+        t.add(new TestCase("localhost|*", "http://google.co.uk",false));
+        t.add(new TestCase("*|oracle.com", "http://google.co.uk",false));
+        t.add(new TestCase("*|oracle.com|*", "http://google.co.uk",false));
+        t.add(new TestCase("*|*", "http://google.co.uk",false));
+
 
         t.add(new TestCase("*oracle.com", "http://my.oracle.com", false));
         t.add(new TestCase("google.com|bing.com|yahoo.com", "http://127.0.0.1", false));


### PR DESCRIPTION
Patch applies clean with different copyright year in context. Because of that, it perhaps would need an approval.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241138](https://bugs.openjdk.java.net/browse/JDK-8241138): http.nonProxyHosts=* causes StringIndexOutOfBoundsException in DefaultProxySelector

### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/26/head:pull/26`
`$ git checkout pull/26`
