### PR TITLE
8210977: jdk/jfr/event/oldobject/TestThreadLocalLeak.java fails to find ThreadLocalObject

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestThreadLocalLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestThreadLocalLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,14 +57,18 @@ public class TestThreadLocalLeak {
     public static void main(String[] args) throws Exception {
         WhiteBox.setWriteAllObjectSamples(true);
 
-        try (Recording r = new Recording()) {
-            r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
-            r.start();
-            allocateThreadLocal();
-            r.stop();
-            List<RecordedEvent> events = Events.fromRecording(r);
-            if (OldObjects.countMatchingEvents(events, ThreadLocalObject[].class, null, null, -1, "allocateThreadLocal") == 0) {
-                throw new Exception("Could not find thread local object " + ThreadLocalObject.class);
+        while (true) {
+            try (Recording r = new Recording()) {
+                r.enable(EventNames.OldObjectSample).withStackTrace().with("cutoff", "infinity");
+                r.start();
+                allocateThreadLocal();
+                r.stop();
+                List<RecordedEvent> events = Events.fromRecording(r);
+                if (OldObjects.countMatchingEvents(events, ThreadLocalObject[].class, null, null, -1, "allocateThreadLocal") > 0) {
+                    return;
+                }
+                System.out.println("Failed to find ThreadLocalObject leak. Retrying.");
+                threadLocal.get().clear();
             }
         }
     }


### PR DESCRIPTION
I'd like to backport 8210977 to 13u. This is a test only change that increases tests stability.
The original patch applies cleanly.
The affected test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8210977](https://bugs.openjdk.java.net/browse/JDK-8210977): jdk/jfr/event/oldobject/TestThreadLocalLeak.java fails to find ThreadLocalObject

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/27/head:pull/27`
`$ git checkout pull/27`
