### PR TITLE
8213535: Windows HiDPI html lightweight tooltips are truncated

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/6800513/bug6800513.java
+++ b/test/jdk/javax/swing/JPopupMenu/6800513/bug6800513.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 Red Hat, Inc.  All Rights Reserved.
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,6 +131,7 @@ public class bug6800513 {
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setJMenuBar(menuBar);
         frame.setSize(500, 500);
+        frame.setLocationRelativeTo(null);
 
         PopupListener listener = new PopupListener();
         menu.getPopupMenu().addPropertyChangeListener(listener);

--- a/test/jdk/javax/swing/JToolTip/4846413/bug4846413.java
+++ b/test/jdk/javax/swing/JToolTip/4846413/bug4846413.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,7 @@ public class bug4846413 {
         JFrame frame = new JFrame("Test");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
 
         button = new JButton("Press me");
         button.setToolTipText("test");

--- a/test/jdk/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
+++ b/test/jdk/javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ public class NonOpaquePopupMenuTest extends JFrame {
         fileMenu.getPopupMenu().setOpaque(false);
 
         setSize(new Dimension(640, 480));
+        setLocationRelativeTo(null);
         setVisible(true);
     }
 


### PR DESCRIPTION
I'd like to backport 8213535 to 13u.
The original patch applies cleanly and fixes the problem.
Tested with jdk/javax/swing, no regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8213535](https://bugs.openjdk.java.net/browse/JDK-8213535): Windows HiDPI html lightweight tooltips are truncated

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/28/head:pull/28`
`$ git checkout pull/28`
