### PR TITLE
8230767: FlightRecorderListener returns null recording

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -480,7 +480,10 @@ public final class PlatformRecording implements AutoCloseable {
         }
         for (FlightRecorderListener cl : PlatformRecorder.getListeners()) {
             try {
-                cl.recordingStateChanged(getRecording());
+                // Skip internal recordings
+                if (recording != null) {
+                    cl.recordingStateChanged(recording);
+                }
             } catch (RuntimeException re) {
                 Logger.log(JFR, WARN, "Error notifying recorder listener:" + re.getMessage());
             }

--- a/test/jdk/jdk/jfr/api/recorder/TestRecorderListenerWithDump.java
+++ b/test/jdk/jdk/jfr/api/recorder/TestRecorderListenerWithDump.java
@@ -1,0 +1,37 @@
+package jdk.jfr.api.recorder;
+
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.FlightRecorderListener;
+import jdk.jfr.Recording;
+/**
+ * @test TestRecorderListenerWithDump
+ *
+ * @key jfr
+ * @requires vm.hasJFR
+ * @run main/othervm jdk.jfr.api.recorder.TestRecorderListenerWithDump
+ */
+public class TestRecorderListenerWithDump {
+
+    public static void main(String... args) throws Exception {
+        AtomicBoolean nullRecording = new AtomicBoolean();
+        FlightRecorder.addListener(new FlightRecorderListener() {
+            public void recordingStateChanged(Recording r) {
+                if (r == null) {
+                    nullRecording.set(true);
+                } else {
+                    System.out.println("Recording " + r.getName() + " " + r.getState());
+                }
+            }
+        });
+        try (Recording r = new Recording()) {
+            r.start();
+            r.dump(Paths.get("dump.jfr"));
+        }
+        if (nullRecording.get()) {
+            throw new Exception("FlightRecorderListener returned null recording");
+        }
+    }
+}


### PR DESCRIPTION
I'd like to backport 8230767 to 13u.
The original patch applies cleanly and fixes the problem.
Tested with tier1 and jdk/jfr. The added test fails without the patch and passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8230767](https://bugs.openjdk.java.net/browse/JDK-8230767): FlightRecorderListener returns null recording

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/30/head:pull/30`
`$ git checkout pull/30`
