### PR TITLE
8233228: Disable weak named curves by default in TLS, CertPath, and Signed JAR

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -4636,7 +4636,7 @@ public final class Main {
                     rb.getString("whose.key.risk"),
                     label,
                     String.format(rb.getString("key.bit"),
-                            KeyUtil.getKeySize(key), key.getAlgorithm())));
+                            KeyUtil.getKeySize(key), fullDisplayAlgName(key))));
         }
     }
 

--- a/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,10 @@ import java.security.AccessController;
 import java.security.AlgorithmConstraints;
 import java.security.PrivilegedAction;
 import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -44,7 +48,7 @@ public abstract class AbstractAlgorithmConstraints
     }
 
     // Get algorithm constraints from the specified security property.
-    static String[] getAlgorithms(String propertyName) {
+    static List<String> getAlgorithms(String propertyName) {
         String property = AccessController.doPrivileged(
                 new PrivilegedAction<String>() {
                     @Override
@@ -68,12 +72,12 @@ public abstract class AbstractAlgorithmConstraints
 
         // map the disabled algorithms
         if (algorithmsInProperty == null) {
-            algorithmsInProperty = new String[0];
+            return Collections.emptyList();
         }
-        return algorithmsInProperty;
+        return new ArrayList<>(Arrays.asList(algorithmsInProperty));
     }
 
-    static boolean checkAlgorithm(String[] algorithms, String algorithm,
+    static boolean checkAlgorithm(List<String> algorithms, String algorithm,
             AlgorithmDecomposer decomposer) {
         if (algorithm == null || algorithm.isEmpty()) {
             throw new IllegalArgumentException("No algorithm name specified");

--- a/src/java.base/share/classes/sun/security/util/CurveDB.java
+++ b/src/java.base/share/classes/sun/security/util/CurveDB.java
@@ -153,8 +153,27 @@ public class CurveDB {
         }
     }
 
+    private static class Holder {
+        private static final Pattern nameSplitPattern = Pattern.compile(
+                SPLIT_PATTERN);
+    }
+
+    // Return all the names the EC curve could be using.
+    static String[] getNamesByOID(String oid) {
+        NamedCurve nc = oidMap.get(oid);
+        if (nc == null) {
+            return new String[0];
+        }
+        String[] list = Holder.nameSplitPattern.split(nc.getName());
+        int i = 0;
+        do {
+            list[i] = list[i].trim();
+        } while (++i < list.length);
+        return list;
+    }
+
     static {
-        Pattern nameSplitPattern = Pattern.compile(SPLIT_PATTERN);
+        Pattern nameSplitPattern = Holder.nameSplitPattern;
 
         /* SEC2 prime curves */
         add("secp112r1", "1.3.132.0.6", P,

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package sun.security.util;
 
 import sun.security.validator.Validator;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.security.CryptoPrimitive;
 import java.security.AlgorithmParameters;
 import java.security.Key;
@@ -37,6 +35,7 @@ import java.security.cert.CertPathValidatorException.BasicReason;
 import java.security.cert.X509Certificate;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -60,19 +59,23 @@ import java.util.regex.Matcher;
 public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     private static final Debug debug = Debug.getInstance("certpath");
 
-    // the known security property, jdk.certpath.disabledAlgorithms
+    // Disabled algorithm security property for certificate path
     public static final String PROPERTY_CERTPATH_DISABLED_ALGS =
             "jdk.certpath.disabledAlgorithms";
 
-    // the known security property, jdk.tls.disabledAlgorithms
+    // Disabled algorithm security property for TLS
     public static final String PROPERTY_TLS_DISABLED_ALGS =
             "jdk.tls.disabledAlgorithms";
 
-    // the known security property, jdk.jar.disabledAlgorithms
+    // Disabled algorithm security property for jar
     public static final String PROPERTY_JAR_DISABLED_ALGS =
             "jdk.jar.disabledAlgorithms";
 
-    private final String[] disabledAlgorithms;
+    // Property for disabled EC named curves
+    private static final String PROPERTY_DISABLED_EC_CURVES =
+            "jdk.disabled.namedCurves";
+
+    private final List<String> disabledAlgorithms;
     private final Constraints algorithmConstraints;
 
     /**
@@ -97,6 +100,24 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             AlgorithmDecomposer decomposer) {
         super(decomposer);
         disabledAlgorithms = getAlgorithms(propertyName);
+
+        // Check for alias
+        int ecindex = -1, i = 0;
+        for (String s : disabledAlgorithms) {
+            if (s.regionMatches(true, 0,"include ", 0, 8)) {
+                if (s.regionMatches(true, 8, PROPERTY_DISABLED_EC_CURVES, 0,
+                        PROPERTY_DISABLED_EC_CURVES.length())) {
+                    ecindex = i;
+                    break;
+                }
+            }
+            i++;
+        }
+        if (ecindex > -1) {
+            disabledAlgorithms.remove(ecindex);
+            disabledAlgorithms.addAll(ecindex,
+                    getAlgorithms(PROPERTY_DISABLED_EC_CURVES));
+        }
         algorithmConstraints = new Constraints(disabledAlgorithms);
     }
 
@@ -164,6 +185,19 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
 
     public final void permits(String algorithm, ConstraintsParameters cp)
             throws CertPathValidatorException {
+
+        // Check if named curves in the ConstraintParameters are disabled.
+        if (cp.getNamedCurve() != null) {
+            for (String curve : cp.getNamedCurve()) {
+                if (!checkAlgorithm(disabledAlgorithms, curve, decomposer)) {
+                    throw new CertPathValidatorException(
+                            "Algorithm constraints check failed on disabled " +
+                                    "algorithm: " + curve,
+                            null, null, -1, BasicReason.ALGORITHM_CONSTRAINED);
+                }
+            }
+        }
+
         algorithmConstraints.permits(algorithm, cp);
     }
 
@@ -199,6 +233,13 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             return false;
         }
 
+        // If this is an elliptic curve, check disabled the named curve.
+        for (String curve : ConstraintsParameters.getNamedCurveFromKey(key)) {
+            if (!permits(primitives, curve, null)) {
+                return false;
+            }
+        }
+
         // check the key constraints
         return algorithmConstraints.permits(key);
     }
@@ -230,7 +271,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                     "denyAfter\\s+(\\d{4})-(\\d{2})-(\\d{2})");
         }
 
-        public Constraints(String[] constraintArray) {
+        public Constraints(List<String> constraintArray) {
             for (String constraintEntry : constraintArray) {
                 if (constraintEntry == null || constraintEntry.isEmpty()) {
                     continue;
@@ -258,7 +299,9 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                             alias.toUpperCase(Locale.ENGLISH), constraintList);
                 }
 
-                if (space <= 0) {
+                // If there is no whitespace, it is a algorithm name; however,
+                // if there is a whitespace, could be a multi-word EC curve too.
+                if (space <= 0 || CurveDB.lookup(constraintEntry) != null) {
                     constraintList.add(new DisabledConstraint(algorithm));
                     continue;
                 }
@@ -357,7 +400,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             for (Constraint constraint : list) {
                 if (!constraint.permits(key)) {
                     if (debug != null) {
-                        debug.println("keySizeConstraint: failed key " +
+                        debug.println("Constraints: failed key size" +
                                 "constraint check " + KeyUtil.getKeySize(key));
                     }
                     return false;
@@ -376,7 +419,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             for (Constraint constraint : list) {
                 if (!constraint.permits(aps)) {
                     if (debug != null) {
-                        debug.println("keySizeConstraint: failed algorithm " +
+                        debug.println("Constraints: failed algorithm " +
                                 "parameters constraint check " + aps);
                     }
 
@@ -393,8 +436,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             X509Certificate cert = cp.getCertificate();
 
             if (debug != null) {
-                debug.println("Constraints.permits(): " + algorithm +
-                        " Variant: " + cp.getVariant());
+                debug.println("Constraints.permits(): " + cp.toString());
             }
 
             // Get all signature algorithms to check for constraints
@@ -408,8 +450,8 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             if (cert != null) {
                 algorithms.add(cert.getPublicKey().getAlgorithm());
             }
-            if (cp.getPublicKey() != null) {
-                algorithms.add(cp.getPublicKey().getAlgorithm());
+            if (cp.getKey() != null) {
+                algorithms.add(cp.getKey().getAlgorithm());
             }
             // Check all applicable constraints
             for (String alg : algorithms) {
@@ -548,10 +590,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
          * the constraint denies the operation.
          */
         boolean next(Key key) {
-            if (nextConstraint != null && nextConstraint.permits(key)) {
-                return true;
-            }
-            return false;
+            return nextConstraint != null && nextConstraint.permits(key);
         }
 
         String extendedMsg(ConstraintsParameters cp) {
@@ -801,8 +840,8 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         public void permits(ConstraintsParameters cp)
                 throws CertPathValidatorException {
             Key key = null;
-            if (cp.getPublicKey() != null) {
-                key = cp.getPublicKey();
+            if (cp.getKey() != null) {
+                key = cp.getKey();
             } else if (cp.getCertificate() != null) {
                 key = cp.getCertificate().getPublicKey();
             }

--- a/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,8 @@ package sun.security.util;
 import java.security.AlgorithmParameters;
 import java.security.CryptoPrimitive;
 import java.security.Key;
+import java.util.List;
 import java.util.Set;
-import static sun.security.util.AbstractAlgorithmConstraints.getAlgorithms;
 
 /**
  * Algorithm constraints for legacy algorithms.
@@ -40,7 +40,7 @@ public class LegacyAlgorithmConstraints extends AbstractAlgorithmConstraints {
     public static final String PROPERTY_TLS_LEGACY_ALGS =
             "jdk.tls.legacyAlgorithms";
 
-    private final String[] legacyAlgorithms;
+    private final List<String> legacyAlgorithms;
 
     public LegacyAlgorithmConstraints(String propertyName,
             AlgorithmDecomposer decomposer) {

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -500,6 +500,22 @@ sun.security.krb5.disableReferrals=false
 sun.security.krb5.maxReferrals=5
 
 #
+# This property contains a list of disabled EC Named Curves that can be included
+# in the jdk.[tls|certpath|jar].disabledAlgorithms properties.  To include this
+# list in any of the disabledAlgorithms properties, add the property name as
+# an entry.
+jdk.disabled.namedCurves = secp112r1, secp112r2, secp128r1, secp128r2, \
+    secp160k1, secp160r1, secp160r2, secp192k1, secp192r1, secp224k1, \
+    secp224r1, secp256k1, sect113r1, sect113r2, sect131r1, sect131r2, \
+    sect163k1, sect163r1, sect163r2, sect193r1, sect193r2, sect233k1, \
+    sect233r1, sect239k1, sect283k1, sect283r1, sect409k1, sect409r1, \
+    sect571k1, sect571r1, X9.62 c2tnb191v1, X9.62 c2tnb191v2, \
+    X9.62 c2tnb191v3, X9.62 c2tnb239v1, X9.62 c2tnb239v2, X9.62 c2tnb239v3, \
+    X9.62 c2tnb359v1, X9.62 c2tnb431r1, X9.62 prime192v2, X9.62 prime192v3, \
+    X9.62 prime239v1, X9.62 prime239v2, X9.62 prime239v3, brainpoolP256r1, \
+    brainpoolP320r1, brainpoolP384r1, brainpoolP512r1
+
+#
 # Algorithm restrictions for certification path (CertPath) processing
 #
 # In some environments, certain algorithms or key lengths may be undesirable
@@ -513,7 +529,7 @@ sun.security.krb5.maxReferrals=5
 #       " DisabledAlgorithm { , DisabledAlgorithm } "
 #
 #   DisabledAlgorithm:
-#       AlgorithmName [Constraint] { '&' Constraint }
+#       AlgorithmName [Constraint] { '&' Constraint } | IncludeProperty
 #
 #   AlgorithmName:
 #       (see below)
@@ -540,6 +556,9 @@ sun.security.krb5.maxReferrals=5
 #   UsageConstraint:
 #       usage [TLSServer] [TLSClient] [SignedJAR]
 #
+#   IncludeProperty:
+#       include <security property>
+#
 # The "AlgorithmName" is the standard algorithm name of the disabled
 # algorithm. See the Java Security Standard Algorithm Names Specification
 # for information about Standard Algorithm Names.  Matching is
@@ -551,6 +570,14 @@ sun.security.krb5.maxReferrals=5
 # the assertion algorithm name "DSA" will disable all certificate algorithms
 # that rely on DSA, such as NONEwithDSA, SHA1withDSA.  However, the assertion
 # will not disable algorithms related to "ECDSA".
+#
+# The "IncludeProperty" allows a implementation-defined security property that
+# can be included in the disabledAlgorithms properties.  These properties are
+# to help manage common actions easier across multiple disabledAlgorithm
+# properties.
+# There is one defined security property:  jdk.disabled.NamedCurves
+# See the property for more specific details.
+#
 #
 # A "Constraint" defines restrictions on the keys and/or certificates for
 # a specified AlgorithmName:
@@ -624,7 +651,8 @@ sun.security.krb5.maxReferrals=5
 #
 #
 jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
-    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224
+    RSA keySize < 1024, DSA keySize < 1024, EC keySize < 224, \
+    include jdk.disabled.namedCurves
 
 #
 # Algorithm restrictions for signed JAR files
@@ -668,7 +696,7 @@ jdk.certpath.disabledAlgorithms=MD2, MD5, SHA1 jdkCA & usage TLSServer, \
 # See "jdk.certpath.disabledAlgorithms" for syntax descriptions.
 #
 jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
-      DSA keySize < 1024
+      DSA keySize < 1024, include jdk.disabled.namedCurves
 
 #
 # Algorithm restrictions for Secure Socket Layer/Transport Layer Security
@@ -703,7 +731,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048, \
 #       rsa_pkcs1_sha1, secp224r1
 jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, DH keySize < 1024, \
-    EC keySize < 224, 3DES_EDE_CBC, anon, NULL
+    EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    include jdk.disabled.namedCurves
 
 #
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)


### PR DESCRIPTION
Hello,

I would like to create a backport of 8233228 in 13u. The backport is already in production in 11u.

The proposed 8233228 patch is exactly the same as 15u version, except for Hunk #9 at line 258(299): 

[https://github.com/openjdk/jdk13u-dev/commit/edec2fc6d79678111f97fa9da81d3bc1d2010538#diff-499d805909084ecc06c50b4706f8a2b3ec70ab9aaf55d54a6156c518f85f1bd6](https://github.com/openjdk/jdk13u-dev/commit/edec2fc6d79678111f97fa9da81d3bc1d2010538#diff-499d805909084ecc06c50b4706f8a2b3ec70ab9aaf55d54a6156c518f85f1bd6)

in which the 8244479 is already applied. In comparison, the 15u version applies 8244479 on top of 8233228, so the changes are in reverse order. Otherwise there are no code / logic changes in the code.

Thank you.

Best regards,
Sergey Chernyshev
BellSoft

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233228](https://bugs.openjdk.java.net/browse/JDK-8233228): Disable weak named curves by default in TLS, CertPath, and Signed JAR ⚠️ Issue is not open.

### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/32/head:pull/32`
`$ git checkout pull/32`
