### PR TITLE
8233954: UnsatisfiedLinkError or NoSuchAlgorithmException after removing sunec.dll

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
+++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
@@ -250,8 +250,19 @@ enum NamedGroup {
         this.supportedProtocols = supportedProtocols;
         this.keAlgParamSpec = keAlgParamSpec;
 
+        // Check if it is a supported named group.
         AlgorithmParameters algParams = null;
         boolean mediator = (keAlgParamSpec != null);
+
+        // HACK CODE
+        //
+        // An EC provider, for example the SunEC provider, may support
+        // AlgorithmParameters but not KeyPairGenerator or KeyAgreement.
+        if (mediator && (namedGroupSpec == NamedGroupSpec.NAMED_GROUP_ECDHE)) {
+            mediator = JsseJce.isEcAvailable();
+        }
+
+        // Check the specific algorithm parameters.
         if (mediator) {
             try {
                 algParams =

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -272,17 +272,28 @@ enum SignatureScheme {
                 Arrays.asList(handshakeSupportedProtocols);
 
         boolean mediator = true;
-        if (signAlgParams != null) {
-            mediator = signAlgParams.isAvailable;
-        } else {
-            try {
-                Signature.getInstance(algorithm);
-            } catch (Exception e) {
-                mediator = false;
-                if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                    SSLLogger.warning(
-                        "Signature algorithm, " + algorithm +
-                        ", is not supported by the underlying providers");
+        // HACK CODE
+        //
+        // An EC provider, for example the SunEC provider, may support
+        // AlgorithmParameters but not KeyPairGenerator or Signature.
+        if ("EC".equals(keyAlgorithm)) {
+            mediator = JsseJce.isEcAvailable();
+        }
+
+        // Check the specific algorithm and parameters.
+        if (mediator) {
+            if (signAlgParams != null) {
+                mediator = signAlgParams.isAvailable;
+            } else {
+                try {
+                    Signature.getInstance(algorithm);
+                } catch (Exception e) {
+                    mediator = false;
+                    if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                        SSLLogger.warning(
+                            "Signature algorithm, " + algorithm +
+                            ", is not supported by the underlying providers");
+                    }
                 }
             }
         }


### PR DESCRIPTION
I'd like to backport JDK-8233954 to jdk13u for parity with jdk11. 
The original patch applied cleanly. 
Jtreg tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8233954](https://bugs.openjdk.java.net/browse/JDK-8233954): UnsatisfiedLinkError or NoSuchAlgorithmException after removing sunec.dll

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/33/head:pull/33`
`$ git checkout pull/33`
