### PR TITLE
8236617: jtreg test containers/docker/TestMemoryAwareness.java fails after 8226575

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
             // it can use as much memory as the host's OS allows.
             long memLimit = containerMetrics.getMemoryLimit();
             if (limit >= 0 && memLimit >= 0) {
-                return limit - memLimit;
+                // we see a limit == 0 on some machines where "kernel does not support swap limit capabilities"
+                return (limit < memLimit) ? 0 : limit - memLimit;
             }
         }
         return getTotalSwapSpaceSize0();

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,14 +144,19 @@ public class TestMemoryAwareness {
                 "--memory-swap", swapAllocation
             );
 
-        DockerTestUtils.dockerRunJava(opts)
-            .shouldHaveExitValue(0)
-            .shouldContain("Checking OperatingSystemMXBean")
-            .shouldContain("OperatingSystemMXBean.getTotalPhysicalMemorySize: " + expectedMemory)
-            .shouldMatch("OperatingSystemMXBean\\.getFreePhysicalMemorySize: [1-9][0-9]+")
-            .shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: " + expectedSwap)
-            .shouldMatch("OperatingSystemMXBean\\.getFreeSwapSpaceSize: [1-9][0-9]+")
-            ;
+        OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
+        out.shouldHaveExitValue(0)
+           .shouldContain("Checking OperatingSystemMXBean")
+           .shouldContain("OperatingSystemMXBean.getTotalPhysicalMemorySize: " + expectedMemory)
+           .shouldMatch("OperatingSystemMXBean\\.getFreePhysicalMemorySize: [1-9][0-9]+")
+           .shouldMatch("OperatingSystemMXBean\\.getFreeSwapSpaceSize: [1-9][0-9]+");
+        // in case of warnings like : "Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap."
+        // the getTotalSwapSpaceSize does not return the expected result, but 0
+        try {
+            out.shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: " + expectedSwap);
+        } catch(RuntimeException ex) {
+            out.shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: 0");
+        }
     }
 
 }


### PR DESCRIPTION
I'd like to backport 8236617 to 13u as follow-up fix for 8226575 that is already included to 13u.
The patch doesn't apply cleanly due to the context difference in TestMemoryAwareness.java 
(getTotalMemorySize() and getFreeMemorySize() methods are not added to OperatingSystemMXBean in 13u by 8226575), reapplied manually.
Tested with container tests, the affected test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236617](https://bugs.openjdk.java.net/browse/JDK-8236617): jtreg test containers/docker/TestMemoryAwareness.java fails after 8226575

### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/34/head:pull/34`
`$ git checkout pull/34`
