### PR TITLE
8249183: JVM crash in "AwtFrame::WmSize" method

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
@@ -32,6 +32,7 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dialog;
 import java.awt.Dimension;
+import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
@@ -58,6 +59,7 @@ import sun.awt.AWTAccessor;
 import sun.awt.AppContext;
 import sun.awt.DisplayChangedListener;
 import sun.awt.SunToolkit;
+import sun.awt.TimedWindowEvent;
 import sun.awt.Win32GraphicsConfig;
 import sun.awt.Win32GraphicsDevice;
 import sun.awt.Win32GraphicsEnvironment;
@@ -385,6 +387,40 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
                 }
             }
         }
+    }
+
+    private void notifyWindowStateChanged(int oldState, int newState) {
+        int changed = oldState ^ newState;
+        if (changed == 0) {
+            return;
+        }
+        if (log.isLoggable(PlatformLogger.Level.FINE)) {
+            log.fine("Reporting state change %x -> %x", oldState, newState);
+        }
+
+        if (target instanceof Frame) {
+            // Sync target with peer.
+            AWTAccessor.getFrameAccessor().setExtendedState((Frame) target,
+                newState);
+        }
+
+        // Report (de)iconification to old clients.
+        if ((changed & Frame.ICONIFIED) > 0) {
+            if ((newState & Frame.ICONIFIED) > 0) {
+                postEvent(new TimedWindowEvent((Window) target,
+                        WindowEvent.WINDOW_ICONIFIED, null, 0, 0,
+                        System.currentTimeMillis()));
+            } else {
+                postEvent(new TimedWindowEvent((Window) target,
+                        WindowEvent.WINDOW_DEICONIFIED, null, 0, 0,
+                        System.currentTimeMillis()));
+            }
+        }
+
+        // New (since 1.4) state change event.
+        postEvent(new TimedWindowEvent((Window) target,
+                WindowEvent.WINDOW_STATE_CHANGED, null, oldState, newState,
+                System.currentTimeMillis()));
     }
 
     synchronized void addWindowListener(WindowListener l) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Frame.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Frame.h
@@ -54,7 +54,6 @@ public:
     /* sun.awt.windows.WEmbeddedFrame fields and method IDs */
     static jfieldID handleID;
 
-    static jmethodID setExtendedStateMID;
     static jmethodID getExtendedStateMID;
 
     /* method id for WEmbeddedFrame.requestActivate() method */
@@ -87,8 +86,6 @@ public:
     /* Returns whether this window is in zoomed state. */
     INLINE BOOL isZoomed() { return m_zoomed; }
     INLINE void setZoomed(BOOL b) { m_zoomed = b; }
-
-    void SendWindowStateEvent(int oldState, int newState);
 
     void Show();
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -184,6 +184,7 @@ jfieldID AwtWindow::sysYID;
 jfieldID AwtWindow::sysWID;
 jfieldID AwtWindow::sysHID;
 jfieldID AwtWindow::windowTypeID;
+jmethodID AwtWindow::notifyWindowStateChangedMID;
 
 jmethodID AwtWindow::getWarningStringMID;
 jmethodID AwtWindow::calculateSecurityWarningPositionMID;
@@ -1639,6 +1640,16 @@ void AwtWindow::SendWindowEvent(jint id, HWND opposite,
     SendEvent(event);
 
     env->DeleteLocalRef(event);
+}
+
+void AwtWindow::NotifyWindowStateChanged(jint oldState, jint newState)
+{
+    JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+    jobject peer = GetPeer(env);
+    if (peer != NULL) {
+        env->CallVoidMethod(peer, AwtWindow::notifyWindowStateChangedMID,
+            oldState, newState);
+    }
 }
 
 BOOL AwtWindow::AwtSetActiveWindow(BOOL isMouseEventCause, UINT hittest)
@@ -3343,6 +3354,11 @@ Java_sun_awt_windows_WWindowPeer_initIDs(JNIEnv *env, jclass cls)
 
     AwtWindow::windowTypeID = env->GetFieldID(cls, "windowType",
             "Ljava/awt/Window$Type;");
+
+    AwtWindow::notifyWindowStateChangedMID =
+        env->GetMethodID(cls, "notifyWindowStateChanged", "(II)V");
+    DASSERT(AwtWindow::notifyWindowStateChangedMID);
+    CHECK_NULL(AwtWindow::notifyWindowStateChangedMID);
 
     CATCH_BAD_ALLOC;
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.h
@@ -57,6 +57,7 @@ public:
     static jfieldID securityWarningWidthID;
     static jfieldID securityWarningHeightID;
 
+    /* sun.awt.windows.WWindowPeer field and method IDs */
     // The coordinates at the peer.
     static jfieldID sysXID;
     static jfieldID sysYID;
@@ -64,7 +65,9 @@ public:
     static jfieldID sysHID;
 
     static jfieldID windowTypeID;
+    static jmethodID notifyWindowStateChangedMID;
 
+    /* java.awt.Window method IDs */
     static jmethodID getWarningStringMID;
     static jmethodID calculateSecurityWarningPositionMID;
     static jmethodID windowTypeNameMID;
@@ -149,6 +152,7 @@ public:
     void SendComponentEvent(jint eventId);
     void SendWindowEvent(jint id, HWND opposite = NULL,
                          jint oldState = 0, jint newState = 0);
+    void NotifyWindowStateChanged(jint oldState, jint newState);
 
     BOOL IsFocusableWindow();
 


### PR DESCRIPTION
should be downported to 13u as well. Patch applies clean, relevant tests do pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8249183](https://bugs.openjdk.java.net/browse/JDK-8249183): JVM crash in "AwtFrame::WmSize" method

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/35/head:pull/35`
`$ git checkout pull/35`
