### PR TITLE
8223940: Private key not supported by chosen signature algorithm

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateVerify.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateVerify.java
@@ -31,6 +31,7 @@ import java.security.*;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
 import sun.security.ssl.SSLHandshake.HandshakeMessage;
 import sun.security.ssl.X509Authentication.X509Credentials;
 import sun.security.ssl.X509Authentication.X509Possession;
@@ -585,31 +586,28 @@ final class CertificateVerify {
 
             // This happens in client side only.
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
-            this.signatureScheme = SignatureScheme.getPreferableAlgorithm(
+            Map.Entry<SignatureScheme, Signature> schemeAndSigner =
+                    SignatureScheme.getSignerOfPreferableAlgorithm(
                     chc.algorithmConstraints,
                     chc.peerRequestedSignatureSchemes,
                     x509Possession,
                     chc.negotiatedProtocol);
-            if (signatureScheme == null) {
+            if (schemeAndSigner == null) {
                 // Unlikely, the credentials generator should have
                 // selected the preferable signature algorithm properly.
                 throw chc.conContext.fatal(Alert.INTERNAL_ERROR,
-                    "No preferred signature algorithm for CertificateVerify");
+                    "No supported CertificateVerify signature algorithm for " +
+                    x509Possession.popPrivateKey.getAlgorithm() +
+                    "  key");
             }
 
+            this.signatureScheme = schemeAndSigner.getKey();
             byte[] temproary = null;
             try {
-                Signature signer =
-                    signatureScheme.getSignature(x509Possession.popPrivateKey);
+                Signature signer = schemeAndSigner.getValue();
                 signer.update(chc.handshakeHash.archived());
                 temproary = signer.sign();
-            } catch (NoSuchAlgorithmException |
-                    InvalidAlgorithmParameterException nsae) {
-                throw chc.conContext.fatal(Alert.INTERNAL_ERROR,
-                        "Unsupported signature algorithm (" +
-                        signatureScheme.name +
-                        ") used in CertificateVerify handshake message", nsae);
-            } catch (InvalidKeyException | SignatureException ikse) {
+            } catch (SignatureException ikse) {
                 throw chc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "Cannot produce CertificateVerify signature", ikse);
             }
@@ -669,7 +667,7 @@ final class CertificateVerify {
             this.signature = Record.getBytes16(m);
             try {
                 Signature signer =
-                    signatureScheme.getSignature(x509Credentials.popPublicKey);
+                    signatureScheme.getVerifier(x509Credentials.popPublicKey);
                 signer.update(shc.handshakeHash.archived());
                 if (!signer.verify(signature)) {
                     throw shc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
@@ -898,17 +896,22 @@ final class CertificateVerify {
                 X509Possession x509Possession) throws IOException {
             super(context);
 
-            this.signatureScheme = SignatureScheme.getPreferableAlgorithm(
+            Map.Entry<SignatureScheme, Signature> schemeAndSigner =
+                    SignatureScheme.getSignerOfPreferableAlgorithm(
                     context.algorithmConstraints,
                     context.peerRequestedSignatureSchemes,
                     x509Possession,
                     context.negotiatedProtocol);
-            if (signatureScheme == null) {
+            if (schemeAndSigner == null) {
                 // Unlikely, the credentials generator should have
                 // selected the preferable signature algorithm properly.
                 throw context.conContext.fatal(Alert.INTERNAL_ERROR,
-                    "No preferred signature algorithm for CertificateVerify");
+                    "No supported CertificateVerify signature algorithm for " +
+                    x509Possession.popPrivateKey.getAlgorithm() +
+                    "  key");
             }
+
+            this.signatureScheme = schemeAndSigner.getKey();
 
             byte[] hashValue = context.handshakeHash.digest();
             byte[] contentCovered;
@@ -926,17 +929,10 @@ final class CertificateVerify {
 
             byte[] temproary = null;
             try {
-                Signature signer =
-                    signatureScheme.getSignature(x509Possession.popPrivateKey);
+                Signature signer = schemeAndSigner.getValue();
                 signer.update(contentCovered);
                 temproary = signer.sign();
-            } catch (NoSuchAlgorithmException |
-                    InvalidAlgorithmParameterException nsae) {
-                throw context.conContext.fatal(Alert.INTERNAL_ERROR,
-                        "Unsupported signature algorithm (" +
-                        signatureScheme.name +
-                        ") used in CertificateVerify handshake message", nsae);
-            } catch (InvalidKeyException | SignatureException ikse) {
+            } catch (SignatureException ikse) {
                 throw context.conContext.fatal(Alert.HANDSHAKE_FAILURE,
                         "Cannot produce CertificateVerify signature", ikse);
             }
@@ -1007,7 +1003,7 @@ final class CertificateVerify {
 
             try {
                 Signature signer =
-                    signatureScheme.getSignature(x509Credentials.popPublicKey);
+                    signatureScheme.getVerifier(x509Credentials.popPublicKey);
                 signer.update(contentCovered);
                 if (!signer.verify(signature)) {
                     throw context.conContext.fatal(Alert.HANDSHAKE_FAILURE,

--- a/src/java.base/share/classes/sun/security/ssl/DHServerKeyExchange.java
+++ b/src/java.base/share/classes/sun/security/ssl/DHServerKeyExchange.java
@@ -42,6 +42,7 @@ import java.security.SignatureException;
 import java.text.MessageFormat;
 import java.util.EnumSet;
 import java.util.Locale;
+import java.util.Map;
 import javax.crypto.interfaces.DHPublicKey;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.DHPublicKeySpec;
@@ -124,25 +125,22 @@ final class DHServerKeyExchange {
                         shc.negotiatedProtocol.useTLS12PlusSpec();
                 Signature signer = null;
                 if (useExplicitSigAlgorithm) {
-                    signatureScheme = SignatureScheme.getPreferableAlgorithm(
-                            shc.algorithmConstraints,
-                            shc.peerRequestedSignatureSchemes,
-                            x509Possession,
-                            shc.negotiatedProtocol);
-                    if (signatureScheme == null) {
+                    Map.Entry<SignatureScheme, Signature> schemeAndSigner =
+                            SignatureScheme.getSignerOfPreferableAlgorithm(
+                                    shc.algorithmConstraints,
+                                    shc.peerRequestedSignatureSchemes,
+                                    x509Possession,
+                                    shc.negotiatedProtocol);
+                    if (schemeAndSigner == null) {
                         // Unlikely, the credentials generator should have
                         // selected the preferable signature algorithm properly.
                         throw shc.conContext.fatal(Alert.INTERNAL_ERROR,
-                            "No preferred signature algorithm");
-                    }
-                    try {
-                        signer = signatureScheme.getSignature(
-                                x509Possession.popPrivateKey);
-                    } catch (NoSuchAlgorithmException | InvalidKeyException |
-                            InvalidAlgorithmParameterException nsae) {
-                        throw shc.conContext.fatal(Alert.INTERNAL_ERROR,
-                            "Unsupported signature algorithm: " +
-                            signatureScheme.name, nsae);
+                                "No supported signature algorithm for " +
+                                x509Possession.popPrivateKey.getAlgorithm() +
+                                "  key");
+                    } else {
+                        signatureScheme = schemeAndSigner.getKey();
+                        signer = schemeAndSigner.getValue();
                     }
                 } else {
                     signatureScheme = null;
@@ -241,7 +239,7 @@ final class DHServerKeyExchange {
             Signature signer;
             if (useExplicitSigAlgorithm) {
                 try {
-                    signer = signatureScheme.getSignature(
+                    signer = signatureScheme.getVerifier(
                             x509Credentials.popPublicKey);
                 } catch (NoSuchAlgorithmException | InvalidKeyException |
                         InvalidAlgorithmParameterException nsae) {

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -30,6 +30,7 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,6 +38,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import sun.security.ssl.NamedGroup.NamedGroupSpec;
 import sun.security.ssl.SupportedGroupsExtension.SupportedGroups;
@@ -458,7 +460,7 @@ enum SignatureScheme {
         return null;
     }
 
-    static SignatureScheme getPreferableAlgorithm(
+    static Map.Entry<SignatureScheme, Signature> getSignerOfPreferableAlgorithm(
             AlgorithmConstraints constraints,
             List<SignatureScheme> schemes,
             X509Possession x509Possession,
@@ -485,7 +487,10 @@ enum SignatureScheme {
                             x509Possession.getECParameterSpec();
                     if (params != null &&
                             ss.namedGroup == NamedGroup.valueOf(params)) {
-                        return ss;
+                        Signature signer = ss.getSigner(signingKey);
+                        if (signer != null) {
+                            return new SimpleImmutableEntry<>(ss, signer);
+                        }
                     }
 
                     if (SSLLogger.isOn &&
@@ -510,7 +515,10 @@ enum SignatureScheme {
                         NamedGroup keyGroup = NamedGroup.valueOf(params);
                         if (keyGroup != null &&
                                 SupportedGroups.isSupported(keyGroup)) {
-                            return ss;
+                            Signature signer = ss.getSigner(signingKey);
+                            if (signer != null) {
+                                return new SimpleImmutableEntry<>(ss, signer);
+                            }
                         }
                     }
 
@@ -521,7 +529,10 @@ enum SignatureScheme {
                             "), unsupported EC parameter spec: " + params);
                     }
                 } else {
-                    return ss;
+                    Signature signer = ss.getSigner(signingKey);
+                    if (signer != null) {
+                        return new SimpleImmutableEntry<>(ss, signer);
+                    }
                 }
             }
         }
@@ -542,24 +553,49 @@ enum SignatureScheme {
         return new String[0];
     }
 
-    Signature getSignature(Key key) throws NoSuchAlgorithmException,
+    // This method is used to get the signature instance of this signature
+    // scheme for the specific public key.  Unlike getSigner(), the exception
+    // is bubbled up.  If the public key does not support this signature
+    // scheme, it normally means the TLS handshaking cannot continue and
+    // the connection should be terminated.
+    Signature getVerifier(PublicKey publicKey) throws NoSuchAlgorithmException,
             InvalidAlgorithmParameterException, InvalidKeyException {
         if (!isAvailable) {
             return null;
         }
 
-        Signature signer = Signature.getInstance(algorithm);
-        if (key instanceof PublicKey) {
-            SignatureUtil.initVerifyWithParam(signer, (PublicKey)key,
-                    (signAlgParams != null ?
-                            signAlgParams.parameterSpec : null));
-        } else {
-            SignatureUtil.initSignWithParam(signer, (PrivateKey)key,
-                    (signAlgParams != null ?
-                            signAlgParams.parameterSpec : null),
-                    null);
+        Signature verifier = Signature.getInstance(algorithm);
+        SignatureUtil.initVerifyWithParam(verifier, publicKey,
+                (signAlgParams != null ? signAlgParams.parameterSpec : null));
+
+        return verifier;
+    }
+
+    // This method is also used to choose preferable signature scheme for the
+    // specific private key.  If the private key does not support the signature
+    // scheme, {@code null} is returned, and the caller may fail back to next
+    // available signature scheme.
+    private Signature getSigner(PrivateKey privateKey) {
+        if (!isAvailable) {
+            return null;
         }
 
-        return signer;
+        try {
+            Signature signer = Signature.getInstance(algorithm);
+            SignatureUtil.initSignWithParam(signer, privateKey,
+                (signAlgParams != null ? signAlgParams.parameterSpec : null),
+                null);
+            return signer;
+        } catch (NoSuchAlgorithmException | InvalidKeyException |
+                InvalidAlgorithmParameterException nsae) {
+            if (SSLLogger.isOn &&
+                    SSLLogger.isOn("ssl,handshake,verbose")) {
+                SSLLogger.finest(
+                    "Ignore unsupported signature algorithm (" +
+                    this.name + ")", nsae);
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
applicable to 13u as well and should be downported. Patch applies clean at this moment; all relevant regtests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8223940](https://bugs.openjdk.java.net/browse/JDK-8223940): Private key not supported by chosen signature algorithm

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/36/head:pull/36`
`$ git checkout pull/36`
