### PR TITLE
8235183: Remove the "HACK CODE" in comment

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
+++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
@@ -254,10 +254,10 @@ enum NamedGroup {
         AlgorithmParameters algParams = null;
         boolean mediator = (keAlgParamSpec != null);
 
-        // HACK CODE
-        //
         // An EC provider, for example the SunEC provider, may support
         // AlgorithmParameters but not KeyPairGenerator or KeyAgreement.
+        //
+        // Note: Please be careful if removing this block!
         if (mediator && (namedGroupSpec == NamedGroupSpec.NAMED_GROUP_ECDHE)) {
             mediator = JsseJce.isEcAvailable();
         }
@@ -277,10 +277,10 @@ enum NamedGroup {
                             "No AlgorithmParameters for " + name, exp);
                     }
                 } else {
-                    // HACK CODE
-                    //
                     // Please remove the following code if the XDH/X25519/X448
                     // AlgorithmParameters algorithms are supported in JDK.
+                    //
+                    // Note: Please be careful if removing this block!
                     algParams = null;
                     try {
                         KeyAgreement.getInstance(name);

--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineInputRecord.java
@@ -390,7 +390,7 @@ final class SSLEngineInputRecord extends InputRecord implements SSLRecord {
                             "Requested to negotiate unsupported SSLv2!");
                 }
 
-                // hack code, the exception is caught in SSLEngineImpl
+                // Note that the exception is caught in SSLEngineImpl
                 // so that SSLv2 error message can be delivered properly.
                 throw new UnsupportedOperationException(        // SSLv2Hello
                         "Unsupported SSL v2.0 ClientHello");

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -274,10 +274,10 @@ enum SignatureScheme {
                 Arrays.asList(handshakeSupportedProtocols);
 
         boolean mediator = true;
-        // HACK CODE
-        //
         // An EC provider, for example the SunEC provider, may support
         // AlgorithmParameters but not KeyPairGenerator or Signature.
+        //
+        // Note: Please be careful if removing this block!
         if ("EC".equals(keyAlgorithm)) {
             mediator = JsseJce.isEcAvailable();
         }


### PR DESCRIPTION
I'd like to backport JDK-8235183 to jdk13u for parity with jdk11.
There is modification only in comments. 
The original patch applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8235183](https://bugs.openjdk.java.net/browse/JDK-8235183): Remove the "HACK CODE" in comment

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/37/head:pull/37`
`$ git checkout pull/37`
