### PR TITLE
8233958: Memory retention due to HttpsURLConnection finalizer that serves no purpose

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/https/DelegateHttpsURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/DelegateHttpsURLConnection.java
@@ -72,13 +72,4 @@ public class DelegateHttpsURLConnection extends AbstractDelegateHttpsURLConnecti
     protected javax.net.ssl.HostnameVerifier getHostnameVerifier() {
         return httpsURLConnection.getHostnameVerifier();
     }
-
-    /*
-     * Called by layered delegator's finalize() method to handle closing
-     * the underlying object.
-     */
-    @SuppressWarnings("deprecation")
-    protected void dispose() throws Throwable {
-        super.finalize();
-    }
 }

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsURLConnectionImpl.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsURLConnectionImpl.java
@@ -461,16 +461,6 @@ public class HttpsURLConnectionImpl
         delegate.setDefaultUseCaches(defaultusecaches);
     }
 
-    /*
-     * finalize (dispose) the delegated object.  Otherwise
-     * sun.net.www.protocol.http.HttpURLConnection's finalize()
-     * would have to be made public.
-     */
-    @SuppressWarnings("deprecation")
-    protected void finalize() throws Throwable {
-        delegate.dispose();
-    }
-
     public boolean equals(Object obj) {
         return this == obj || ((obj instanceof HttpsURLConnectionImpl) &&
             delegate.equals(((HttpsURLConnectionImpl)obj).delegate));


### PR DESCRIPTION
Should be downported here, too. The patch applies clean. Tier[123] tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8233958](https://bugs.openjdk.java.net/browse/JDK-8233958): Memory retention due to HttpsURLConnection finalizer that serves no purpose

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/39/head:pull/39`
`$ git checkout pull/39`
