### PR TITLE
8242480: Negative value may be returned by getFreeSwapSpaceSize() in the docker

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/GetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/GetFreeSwapSpaceSize.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import com.sun.management.OperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+
+public class GetFreeSwapSpaceSize {
+    public static void main(String[] args) {
+        System.out.println("TestGetFreeSwapSpaceSize");
+        OperatingSystemMXBean osBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+        for (int i = 0; i < 100; i++) {
+            long size = osBean.getFreeSwapSpaceSize();
+            if (size < 0) {
+                System.out.println("Error: getFreeSwapSpaceSize returns " + size);
+                System.exit(-1);
+            }
+        }
+    }
+}

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8242480
+ * @requires docker.support
+ * @library /test/lib
+ * @build GetFreeSwapSpaceSize
+ * @run driver TestGetFreeSwapSpaceSize
+ */
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerRunOptions;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestGetFreeSwapSpaceSize {
+    private static final String imageName = Common.imageName("memory");
+
+    public static void main(String[] args) throws Exception {
+        if (!DockerTestUtils.canTestDocker()) {
+            return;
+        }
+
+        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+
+        try {
+            testGetFreeSwapSpaceSize(
+                "150M", Integer.toString(((int) Math.pow(2, 20)) * 150),
+                "150M", Integer.toString(0)
+            );
+        } finally {
+            if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
+                DockerTestUtils.removeDockerImage(imageName);
+            }
+        }
+    }
+
+    private static void testGetFreeSwapSpaceSize(String memoryAllocation, String expectedMemory,
+            String swapAllocation, String expectedSwap) throws Exception {
+        Common.logNewTestCase("TestGetFreeSwapSpaceSize");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "GetFreeSwapSpaceSize")
+            .addDockerOpts(
+                "--memory", memoryAllocation,
+                "--memory-swap", swapAllocation
+            );
+
+        OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
+        out.shouldHaveExitValue(0)
+           .shouldContain("TestGetFreeSwapSpaceSize");
+    }
+}


### PR DESCRIPTION
I'd like to backport 8242480 to 13u for parity with 11u.
The patch applies cleanly.
Tested with container tests, the only failure is containers/docker/TestMemoryAwareness.java which is fixed by follow-up JDK-8246648, the plan is to push them together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8242480](https://bugs.openjdk.java.net/browse/JDK-8242480): Negative value may be returned by getFreeSwapSpaceSize() in the docker

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/44/head:pull/44`
`$ git checkout pull/44`
