### PR TITLE
8254982: (tz) Upgrade time-zone data to tzdata2020c

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2020b
+tzdata2020c

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -404,6 +404,19 @@ Zone	Indian/Cocos	6:27:40	-	LMT	1900
 # From Michael Deckers (2019-08-06):
 # https://www.laws.gov.fj/LawsAsMade/downloadfile/848
 
+# From Raymond Kumar (2020-10-08):
+# [DST in Fiji] is from December 20th 2020, till 17th January 2021.
+# From Alan Mintz (2020-10-08):
+# https://www.laws.gov.fj/LawsAsMade/GetFile/1071
+# From Tim Parenti (2020-10-08):
+# https://www.fijivillage.com/news/Daylight-saving-from-Dec-20th-this-year-to-Jan-17th-2021-8rf4x5/
+# "Minister for Employment, Parveen Bala says they had never thought of
+# stopping daylight saving. He says it was just to decide on when it should
+# start and end.  Bala says it is a short period..."
+# Since the end date is still in line with our ongoing predictions, assume for
+# now that the later-than-usual start date is a one-time departure from the
+# recent second Sunday in November pattern.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Fiji	1998	1999	-	Nov	Sun>=1	2:00	1:00	-
 Rule	Fiji	1999	2000	-	Feb	lastSun	3:00	0	-
@@ -415,7 +428,9 @@ Rule	Fiji	2012	2013	-	Jan	Sun>=18	3:00	0	-
 Rule	Fiji	2014	only	-	Jan	Sun>=18	2:00	0	-
 Rule	Fiji	2014	2018	-	Nov	Sun>=1	2:00	1:00	-
 Rule	Fiji	2015	max	-	Jan	Sun>=12	3:00	0	-
-Rule	Fiji	2019	max	-	Nov	Sun>=8	2:00	1:00	-
+Rule	Fiji	2019	only	-	Nov	Sun>=8	2:00	1:00	-
+Rule	Fiji	2020	only	-	Dec	20	2:00	1:00	-
+Rule	Fiji	2021	max	-	Nov	Sun>=8	2:00	1:00	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
 			12:00	Fiji	+12/+13

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -1612,6 +1612,8 @@ Rule	Hungary	1946	only	-	Oct	 7	 2:00	0	-
 # https://library.hungaricana.hu/hu/view/Zala_1948_09/?pg=64
 # https://library.hungaricana.hu/hu/view/SatoraljaujhelyiLeveltar_ZempleniNepujsag_1948/?pg=53
 # https://library.hungaricana.hu/hu/view/SatoraljaujhelyiLeveltar_ZempleniNepujsag_1948/?pg=160
+# https://library.hungaricana.hu/hu/view/UjSzo_1949_01-04/?pg=102
+# https://library.hungaricana.hu/hu/view/KeletMagyarorszag_1949_03/?pg=96
 # https://library.hungaricana.hu/hu/view/Delmagyarorszag_1949_09/?pg=94
 Rule	Hungary	1947	1949	-	Apr	Sun>=4	 2:00s	1:00	S
 Rule	Hungary	1947	1949	-	Oct	Sun>=1	 2:00s	0	-
@@ -1627,9 +1629,10 @@ Rule	Hungary	1955	only	-	Oct	 2	 3:00	0	-
 # https://library.hungaricana.hu/hu/view/PestMegyeiHirlap_1957_09/?pg=143
 Rule	Hungary	1956	1957	-	Jun	Sun>=1	 2:00	1:00	S
 Rule	Hungary	1956	1957	-	Sep	lastSun	 3:00	0	-
-# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1980/?pg=1227
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1980/?pg=189
 Rule	Hungary	1980	only	-	Apr	 6	 0:00	1:00	S
 Rule	Hungary	1980	only	-	Sep	28	 1:00	0	-
+# https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1980/?pg=1227
 # https://library.hungaricana.hu/hu/view/Delmagyarorszag_1981_01/?pg=79
 # https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1982/?pg=115
 # https://library.hungaricana.hu/hu/view/DTT_KOZL_TanacsokKozlonye_1983/?pg=85
@@ -1640,6 +1643,7 @@ Rule	Hungary	1981	1983	-	Sep	lastSun	 1:00	0	-
 Zone	Europe/Budapest	1:16:20 -	LMT	1890 Nov  1
 			1:00	C-Eur	CE%sT	1918
 # https://library.hungaricana.hu/hu/view/OGYK_RT_1941/?pg=1204
+# https://library.hungaricana.hu/hu/view/OGYK_RT_1942/?pg=3955
 			1:00	Hungary	CE%sT	1941 Apr  7 23:00
 			1:00	C-Eur	CE%sT	1945
 			1:00	Hungary	CE%sT	1984

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -1687,6 +1687,17 @@ public class BasicDateTime extends Basic {
 
         // Get the supported ids for GMT-08:00 (Pacific Standard Time)
         String[] ids = TimeZone.getAvailableIDs(-8 * 60 * 60 * 1000);
+        // With tzdata2020b, the test fails for the mentioned zones expecting
+        // "PST" but JDK has Zone name "MST" for JRE locale provider.
+        // Therefore excluding them as the test is only looking for a GMT-08:00
+        // time zone ID. See JDK-8254865.
+        final List<String> list =  new ArrayList<String>();
+        Collections.addAll(list, ids);
+        list.remove("America/Dawson");
+        list.remove("America/WhiteHorse");
+        list.remove("Canada/Yukon");
+        ids = list.toArray(new String[list.size()]);
+
         // Create a Pacific Standard Time time zone
         SimpleTimeZone tz = new SimpleTimeZone(-8 * 60 * 60 * 1000, ids[0]);
         // public GregorianCalendar(TimeZone zone, Locale aLocale);


### PR DESCRIPTION
It is time to backport tzdata2020c here, too. The patch applies without any adjustment. All relevant tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254982](https://bugs.openjdk.java.net/browse/JDK-8254982): (tz) Upgrade time-zone data to tzdata2020c

### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/45/head:pull/45`
`$ git checkout pull/45`
