### PR TITLE
8246648: issue with OperatingSystemImpl getFreeSwapSpaceSize in docker after 8242480

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -72,13 +72,13 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
         if (containerMetrics != null) {
             long memSwapLimit = containerMetrics.getMemoryAndSwapLimit();
             long memLimit = containerMetrics.getMemoryLimit();
-            long deltaLimit = memSwapLimit - memLimit;
-            // Return 0 when memSwapLimit == memLimit, which means no swap space is allowed.
-            // And the same for memSwapLimit < memLimit.
-            if (deltaLimit <= 0) {
-                return 0;
-            }
             if (memSwapLimit >= 0 && memLimit >= 0) {
+                long deltaLimit = memSwapLimit - memLimit;
+                // Return 0 when memSwapLimit == memLimit, which means no swap space is allowed.
+                // And the same for memSwapLimit < memLimit.
+                if (deltaLimit <= 0) {
+                    return 0;
+                }
                 for (int attempt = 0; attempt < MAX_ATTEMPTS_NUMBER; attempt++) {
                     long memSwapUsage = containerMetrics.getMemoryAndSwapUsage();
                     long memUsage = containerMetrics.getMemoryUsage();


### PR DESCRIPTION
I'd like to backport 8246648 to 13u as follow-up fix for 8242480 that is already included to 13u.
The patch applies cleanly.
Tested with container tests, the affected test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8246648](https://bugs.openjdk.java.net/browse/JDK-8246648): issue with OperatingSystemImpl getFreeSwapSpaceSize in docker after 8242480

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/46/head:pull/46`
`$ git checkout pull/46`
