### PR TITLE
8231968: getCurrentThreadAllocatedBytes default implementation s/b getThreadAllocatedBytes

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/ThreadMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/ThreadMXBean.java
@@ -122,9 +122,6 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      *   {@link #getThreadAllocatedBytes getThreadAllocatedBytes}(Thread.currentThread().getId());
      * </pre></blockquote>
      *
-     * @implSpec The default implementation throws
-     * {@code UnsupportedOperationException}.
-     *
      * @return an approximation of the total memory allocated, in bytes, in
      * heap memory for the current thread
      * if thread memory allocation measurement is enabled;
@@ -141,7 +138,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @since 13.0.6
      */
     public default long getCurrentThreadAllocatedBytes() {
-        throw new UnsupportedOperationException();
+        return getThreadAllocatedBytes(Thread.currentThread().getId());
     }
 
     /**


### PR DESCRIPTION
I'd like to backport 8231968 to 13u as follow-up fix for JDK-8231209 that is already included to 13u.
CSR for 13u is approved: JDK-8257410.
The patch applies cleanly.
Tested with ThreadMXBean tests and tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8231968](https://bugs.openjdk.java.net/browse/JDK-8231968): getCurrentThreadAllocatedBytes default implementation s/b getThreadAllocatedBytes

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/47/head:pull/47`
`$ git checkout pull/47`
