### PR TITLE
8250844: Make sure {type,obj}ArrayOopDesc accessors check the bounds

### DIFF
--- a/src/hotspot/share/oops/objArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/objArrayOop.inline.hpp
@@ -35,21 +35,23 @@ inline HeapWord* objArrayOopDesc::base() const { return (HeapWord*) arrayOopDesc
 inline HeapWord* objArrayOopDesc::base_raw() const { return (HeapWord*) arrayOopDesc::base_raw(T_OBJECT); }
 
 template <class T> T* objArrayOopDesc::obj_at_addr(int index) const {
-  assert(is_within_bounds(index), "index out of bounds");
+  assert(is_within_bounds(index), "index %d out of bounds %d", index, length());
   return &((T*)base())[index];
 }
 
 template <class T> T* objArrayOopDesc::obj_at_addr_raw(int index) const {
-  assert(is_within_bounds(index), "index out of bounds");
+  assert(is_within_bounds(index), "index %d out of bounds %d", index, length());
   return &((T*)base_raw())[index];
 }
 
 inline oop objArrayOopDesc::obj_at(int index) const {
+  assert(is_within_bounds(index), "index %d out of bounds %d", index, length());
   ptrdiff_t offset = UseCompressedOops ? obj_at_offset<narrowOop>(index) : obj_at_offset<oop>(index);
   return HeapAccess<IS_ARRAY>::oop_load_at(as_oop(), offset);
 }
 
 inline void objArrayOopDesc::obj_at_put(int index, oop value) {
+  assert(is_within_bounds(index), "index %d out of bounds %d", index, length());
   ptrdiff_t offset = UseCompressedOops ? obj_at_offset<narrowOop>(index) : obj_at_offset<oop>(index);
   HeapAccess<IS_ARRAY>::oop_store_at(as_oop(), offset, value);
 }

--- a/src/hotspot/share/oops/typeArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/typeArrayOop.inline.hpp
@@ -90,91 +90,111 @@ inline jdouble* typeArrayOopDesc::double_at_addr(int which) const {
 }
 
 inline jbyte typeArrayOopDesc::byte_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jbyte>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::byte_at_put(int which, jbyte contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jbyte>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jboolean typeArrayOopDesc::bool_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jboolean>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::bool_at_put(int which, jboolean contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jboolean>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, jboolean(contents & 1));
 }
 
 inline jchar typeArrayOopDesc::char_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jchar>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::char_at_put(int which, jchar contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jchar>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jint typeArrayOopDesc::int_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jint>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::int_at_put(int which, jint contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jint>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jshort typeArrayOopDesc::short_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jshort>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::short_at_put(int which, jshort contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jshort>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jushort typeArrayOopDesc::ushort_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jushort>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::ushort_at_put(int which, jushort contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jushort>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jlong typeArrayOopDesc::long_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jlong>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::long_at_put(int which, jlong contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jlong>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jfloat typeArrayOopDesc::float_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jfloat>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::float_at_put(int which, jfloat contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jfloat>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jdouble typeArrayOopDesc::double_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jdouble>(which);
   return HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::double_at_put(int which, jdouble contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jdouble>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
 
 inline jbyte typeArrayOopDesc::byte_at_acquire(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jbyte>(which);
   return HeapAccess<MO_ACQUIRE | IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::release_byte_at_put(int which, jbyte contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jbyte>(which);
   HeapAccess<MO_RELEASE | IS_ARRAY>::store_at(as_oop(), offset, contents);
 }
@@ -184,19 +204,23 @@ inline void typeArrayOopDesc::release_byte_at_put(int which, jbyte contents) {
 // casting
 #ifdef _LP64
 inline Symbol* typeArrayOopDesc::symbol_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jlong>(which);
   return (Symbol*)(jlong) HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::symbol_at_put(int which, Symbol* contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jlong>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, (jlong)contents);
 }
 #else
 inline Symbol* typeArrayOopDesc::symbol_at(int which) const {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jint>(which);
   return (Symbol*)(jint) HeapAccess<IS_ARRAY>::load_at(as_oop(), offset);
 }
 inline void typeArrayOopDesc::symbol_at_put(int which, Symbol* contents) {
+  assert(is_within_bounds(which), "index %d out of bounds %d", which, length());
   ptrdiff_t offset = element_offset<jint>(which);
   HeapAccess<IS_ARRAY>::store_at(as_oop(), offset, (jint)contents);
 }


### PR DESCRIPTION
We need these asserts  in 13u, too. The patch doesn't require any adjustments, tier1 tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8250844](https://bugs.openjdk.java.net/browse/JDK-8250844): Make sure {type,obj}ArrayOopDesc accessors check the bounds 

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/50/head:pull/50`
`$ git checkout pull/50`
