### PR TITLE
8251365: Build failure on AIX after 8250636

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -154,19 +154,23 @@ char* os::iso8601_time(char* buffer, size_t buffer_length, bool utc) {
   // No offset when dealing with UTC
   time_t UTC_to_local = 0;
   if (!utc) {
-#if defined(_WINDOWS)
+#if defined(_ALLBSD_SOURCE) || defined(_GNU_SOURCE)
+    UTC_to_local = -(time_struct.tm_gmtoff);
+#elif defined(_WINDOWS)
     long zone;
     _get_timezone(&zone);
     UTC_to_local = static_cast<time_t>(zone);
+#else
+    UTC_to_local = timezone;
+#endif
 
+    // tm_gmtoff already includes adjustment for daylight saving
+#if !defined(_ALLBSD_SOURCE) && !defined(_GNU_SOURCE)
     // If daylight savings time is in effect,
     // we are 1 hour East of our time zone
     if (time_struct.tm_isdst > 0) {
       UTC_to_local = UTC_to_local - seconds_per_hour;
     }
-#else
-    // tm_gmtoff already includes adjustment for daylight saving
-    UTC_to_local = -(time_struct.tm_gmtoff);
 #endif
   }
 


### PR DESCRIPTION
Mandatory backport to fix issue introduced with 8250636.
Patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8251365](https://bugs.openjdk.java.net/browse/JDK-8251365): Build failure on AIX after 8250636

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/57/head:pull/57`
`$ git checkout pull/57`
