### PR TITLE
8248347: windows build broken by JDK-8243114

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3782,7 +3782,7 @@ montgomery_multiply(julong a[], julong b[], julong n[],
   julong t0 = 0, t1 = 0, t2 = 0; // Triple-precision accumulator
   int i;
 
-  assert(inv * n[0] == -1ULL, "broken inverse in Montgomery multiply");
+  assert(inv * n[0] == ULLONG_MAX, "broken inverse in Montgomery multiply");
 
   for (i = 0; i < len; i++) {
     int j;
@@ -3824,7 +3824,7 @@ montgomery_square(julong a[], julong n[],
   julong t0 = 0, t1 = 0, t2 = 0; // Triple-precision accumulator
   int i;
 
-  assert(inv * n[0] == -1ULL, "broken inverse in Montgomery square");
+  assert(inv * n[0] == ULLONG_MAX, "broken inverse in Montgomery square");
 
   for (i = 0; i < len; i++) {
     int j;


### PR DESCRIPTION
I would like to backport 8248347 to 13u as follow-up fix for 8243114 that is already included to 13.
The patch applies cleanly.
Debug configurations are built successfully after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8248347](https://bugs.openjdk.java.net/browse/JDK-8248347): windows build broken by JDK-8243114

### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/58/head:pull/58`
`$ git checkout pull/58`
