### PR TITLE
8255226: (tz) Upgrade time-zone data to tzdata2020d

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2020c
+tzdata2020d

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -3244,13 +3244,40 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 
 # From Sharef Mustafa (2019-10-18):
 # Palestine summer time will end on midnight Oct 26th 2019 ...
-# http://www.palestinecabinet.gov.ps/website/ar/ViewDetails?ID=43948
+#
+# From Steffen Thorsen (2020-10-20):
+# Some sources such as these say, and display on clocks, that DST ended at
+# midnight last year...
+# https://www.amad.ps/ar/post/320006
+#
+# From Tim Parenti (2020-10-20):
+# The report of the Palestinian Cabinet meeting of 2019-10-14 confirms
+# a decision on (translated): "The start of the winter time in Palestine, by
+# delaying the clock by sixty minutes, starting from midnight on Friday /
+# Saturday corresponding to 26/10/2019."
+# http://www.palestinecabinet.gov.ps/portal/meeting/details/43948
+
+# From Sharef Mustafa (2020-10-20):
+# As per the palestinian cabinet announcement yesterday , the day light saving
+# shall [end] on Oct 24th 2020 at 01:00AM by delaying the clock by 60 minutes.
+# http://www.palestinecabinet.gov.ps/portal/Meeting/Details/51584
+
+# From Tim Parenti (2020-10-20):
+# Predict future fall transitions at 01:00 on the Saturday preceding October's
+# last Sunday (i.e., Sat>=24).  This is consistent with our predictions since
+# 2016, although the time of the change differed slightly in 2019.
+
+# From Pierre Cashon (2020-10-20):
+# The summer time this year started on March 28 at 00:00.
+# https://wafa.ps/ar_page.aspx?id=GveQNZa872839351758aGveQNZ
+# http://www.palestinecabinet.gov.ps/portal/meeting/details/50284
+# The winter time in 2015 started on October 23 at 01:00.
+# https://wafa.ps/ar_page.aspx?id=CgpCdYa670694628582aCgpCdY
+# http://www.palestinecabinet.gov.ps/portal/meeting/details/27583
 #
 # From Paul Eggert (2019-04-10):
-# For now, guess spring-ahead transitions are March's last Friday at 00:00.
-#
-# From Tim Parenti (2016-10-19):
-# Predict fall transitions on October's last Saturday at 01:00 from now on.
+# For now, guess spring-ahead transitions are at 00:00 on the Saturday
+# preceding March's last Sunday (i.e., Sat>=24).
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule EgyptAsia	1957	only	-	May	10	0:00	1:00	S
@@ -3266,10 +3293,10 @@ Rule Palestine	2004	only	-	Oct	 1	1:00	0	-
 Rule Palestine	2005	only	-	Oct	 4	2:00	0	-
 Rule Palestine	2006	2007	-	Apr	 1	0:00	1:00	S
 Rule Palestine	2006	only	-	Sep	22	0:00	0	-
-Rule Palestine	2007	only	-	Sep	Thu>=8	2:00	0	-
+Rule Palestine	2007	only	-	Sep	13	2:00	0	-
 Rule Palestine	2008	2009	-	Mar	lastFri	0:00	1:00	S
 Rule Palestine	2008	only	-	Sep	 1	0:00	0	-
-Rule Palestine	2009	only	-	Sep	Fri>=1	1:00	0	-
+Rule Palestine	2009	only	-	Sep	 4	1:00	0	-
 Rule Palestine	2010	only	-	Mar	26	0:00	1:00	S
 Rule Palestine	2010	only	-	Aug	11	0:00	0	-
 Rule Palestine	2011	only	-	Apr	 1	0:01	1:00	S
@@ -3278,12 +3305,16 @@ Rule Palestine	2011	only	-	Aug	30	0:00	1:00	S
 Rule Palestine	2011	only	-	Sep	30	0:00	0	-
 Rule Palestine	2012	2014	-	Mar	lastThu	24:00	1:00	S
 Rule Palestine	2012	only	-	Sep	21	1:00	0	-
-Rule Palestine	2013	only	-	Sep	Fri>=21	0:00	0	-
-Rule Palestine	2014	2015	-	Oct	Fri>=21	0:00	0	-
-Rule Palestine	2015	only	-	Mar	lastFri	24:00	1:00	S
+Rule Palestine	2013	only	-	Sep	27	0:00	0	-
+Rule Palestine	2014	only	-	Oct	24	0:00	0	-
+Rule Palestine	2015	only	-	Mar	28	0:00	1:00	S
+Rule Palestine	2015	only	-	Oct	23	1:00	0	-
 Rule Palestine	2016	2018	-	Mar	Sat>=24	1:00	1:00	S
-Rule Palestine	2016	max	-	Oct	lastSat	1:00	0	-
-Rule Palestine	2019	max	-	Mar	lastFri	0:00	1:00	S
+Rule Palestine	2016	2018	-	Oct	Sat>=24	1:00	0	-
+Rule Palestine	2019	only	-	Mar	29	0:00	1:00	S
+Rule Palestine	2019	only	-	Oct	Sat>=24	0:00	0	-
+Rule Palestine	2020	max	-	Mar	Sat>=24	0:00	1:00	S
+Rule Palestine	2020	max	-	Oct	Sat>=24	1:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -1052,17 +1052,16 @@ Zone	Europe/Prague	0:57:44 -	LMT	1850
 # Denmark, Faroe Islands, and Greenland
 
 # From Jesper Nørgaard Welen (2005-04-26):
-# http://www.hum.aau.dk/~poe/tid/tine/DanskTid.htm says that the law
-# [introducing standard time] was in effect from 1894-01-01....
-# The page http://www.retsinfo.dk/_GETDOCI_/ACCN/A18930008330-REGL
+# the law [introducing standard time] was in effect from 1894-01-01....
+# The page https://www.retsinformation.dk/eli/lta/1893/83
 # confirms this, and states that the law was put forth 1893-03-29.
 #
 # The EU [actually, EEC and Euratom] treaty with effect from 1973:
-# http://www.retsinfo.dk/_GETDOCI_/ACCN/A19722110030-REGL
+# https://www.retsinformation.dk/eli/lta/1972/21100
 #
 # This provoked a new law from 1974 to make possible summer time changes
 # in subsequent decrees with the law
-# http://www.retsinfo.dk/_GETDOCI_/ACCN/A19740022330-REGL
+# https://www.retsinformation.dk/eli/lta/1974/223
 #
 # It seems however that no decree was set forward until 1980.  I have
 # not found any decree, but in another related law, the effecting DST
@@ -1074,7 +1073,7 @@ Zone	Europe/Prague	0:57:44 -	LMT	1850
 # The law is about the management of the extra hour, concerning
 # working hours reported and effect on obligatory-rest rules (which
 # was suspended on that night):
-# http://www.retsinfo.dk/_GETDOCI_/ACCN/C19801120554-REGL
+# https://web.archive.org/web/20140104053304/https://www.retsinformation.dk/Forms/R0710.aspx?id=60267
 
 # From Jesper Nørgaard Welen (2005-06-11):
 # The Herning Folkeblad (1980-09-26) reported that the night between

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -573,8 +573,12 @@ public final class ZoneInfoFile {
                     // we can then pass in the dom = -1, dow > 0 into ZoneInfo
                     //
                     // hacking, assume the >=24 is the result of ZRB optimization for
-                    // "last", it works for now.
-                    if (dom < 0 || dom >= 24) {
+                    // "last", it works for now. From tzdata2020d this hacking
+                    // will not work for Asia/Gaza and Asia/Hebron which follow
+                    // Palestine DST rules.
+                    if (dom < 0 || dom >= 24 &&
+                                   !(zoneId.equals("Asia/Gaza") ||
+                                     zoneId.equals("Asia/Hebron"))) {
                         params[1] = -1;
                         params[2] = toCalendarDOW[dow];
                     } else {
@@ -596,7 +600,9 @@ public final class ZoneInfoFile {
                     params[7] = 0;
                 } else {
                     // hacking: see comment above
-                    if (dom < 0 || dom >= 24) {
+                    if (dom < 0 || dom >= 24 &&
+                                   !(zoneId.equals("Asia/Gaza") ||
+                                     zoneId.equals("Asia/Hebron"))) {
                         params[6] = -1;
                         params[7] = toCalendarDOW[dow];
                     } else {


### PR DESCRIPTION
Request to backport tzdata2020d. Applies cleanly, no regressions found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255226](https://bugs.openjdk.java.net/browse/JDK-8255226): (tz) Upgrade time-zone data to tzdata2020d


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/59/head:pull/59`
`$ git checkout pull/59`
