### PR TITLE
8237499: JFR: Include stack trace in the ThreadStart event

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -26,8 +26,9 @@
 
 <Metadata>
 
-  <Event name="ThreadStart" category="Java Application" label="Java Thread Start" thread="true" startTime="false">
-    <Field type="Thread" name="thread" label="Java Thread" />
+  <Event name="ThreadStart" category="Java Application" label="Java Thread Start" thread="true" startTime="false" stackTrace="true">
+    <Field type="Thread" name="thread" label="New Java Thread" />
+    <Field type="Thread" name="parentThread" label="Parent Java Thread" />
   </Event>
 
   <Event name="ThreadEnd" category="Java Application" label="Java Thread End" thread="true" startTime="false">

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -55,7 +55,11 @@ JfrThreadLocal::JfrThreadLocal() :
   _stack_trace_hash(0),
   _stackdepth(0),
   _entering_suspend_flag(0),
-  _dead(false) {}
+  _dead(false) {
+
+  Thread* thread = Thread::current_or_null();
+  _parent_trace_id = thread != NULL ? thread->jfr_thread_local()->trace_id() : (traceid)0;
+}
 
 u8 JfrThreadLocal::add_data_lost(u8 value) {
   _data_lost += value;
@@ -78,6 +82,7 @@ const JfrBlobHandle& JfrThreadLocal::thread_blob() const {
 static void send_java_thread_start_event(JavaThread* jt) {
   EventThreadStart event;
   event.set_thread(jt->jfr_thread_local()->thread_id());
+  event.set_parentThread(jt->jfr_thread_local()->parent_thread_id());
   event.commit();
 }
 
@@ -88,6 +93,9 @@ void JfrThreadLocal::on_start(Thread* t) {
     if (t->is_Java_thread()) {
       send_java_thread_start_event((JavaThread*)t);
     }
+  }
+  if (t->jfr_thread_local()->has_cached_stack_trace()) {
+    t->jfr_thread_local()->clear_cached_stack_trace();
   }
 }
 

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -51,6 +51,7 @@ class JfrThreadLocal {
   mutable u4 _stackdepth;
   volatile jint _entering_suspend_flag;
   bool _dead;
+  traceid _parent_trace_id;
 
   JfrBuffer* install_native_buffer() const;
   JfrBuffer* install_java_buffer() const;
@@ -125,6 +126,10 @@ class JfrThreadLocal {
 
   void set_thread_id(traceid thread_id) {
     _trace_id = thread_id;
+  }
+
+  traceid parent_thread_id() const {
+    return _parent_trace_id;
   }
 
   void set_cached_stack_trace_id(traceid id, unsigned int hash = 0) {

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3832,7 +3832,14 @@ static void post_thread_start_event(const JavaThread* jt) {
   EventThreadStart event;
   if (event.should_commit()) {
     event.set_thread(JFR_THREAD_ID(jt));
-    event.commit();
+    event.set_parentThread((traceid)0);
+    if (EventThreadStart::is_stacktrace_enabled()) {
+      jt->jfr_thread_local()->set_cached_stack_trace_id((traceid)0);
+      event.commit();
+      jt->jfr_thread_local()->clear_cached_stack_trace();
+    } else {
+      event.commit();
+    }
   }
 }
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -93,6 +93,7 @@
 #endif
 
 #include <errno.h>
+#include <jfr/recorder/jfrRecorder.hpp>
 
 /*
   NOTE about use of any ctor or function call that can trigger a safepoint/GC:
@@ -2807,6 +2808,15 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(),
               os::native_thread_creation_failed_msg());
   }
+
+#if INCLUDE_JFR
+  if (JfrRecorder::is_recording() && EventThreadStart::is_enabled() &&
+      EventThreadStart::is_stacktrace_enabled()) {
+    JfrThreadLocal* tl = native_thread->jfr_thread_local();
+    // skip Thread.start() and Thread.start0()
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread, 2));
+  }
+#endif
 
   Thread::start(native_thread);
 

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -54,6 +54,7 @@
 
     <event name="jdk.ThreadStart">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.ThreadEnd">

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -54,6 +54,7 @@
 
     <event name="jdk.ThreadStart">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
     </event>
 
     <event name="jdk.ThreadEnd">

--- a/test/jdk/jdk/jfr/event/runtime/TestThreadStartEndEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestThreadStartEndEvents.java
@@ -25,12 +25,17 @@
 
 package jdk.jfr.event.runtime;
 
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertNotNull;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedMethod;
+import jdk.jfr.consumer.RecordedStackTrace;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
@@ -62,19 +67,27 @@ public class TestThreadStartEndEvents {
         recording.stop();
 
         int currThreadIndex = 0;
-        long currentThreadId = Thread.currentThread().getId();
         List<RecordedEvent> events = Events.fromRecording(recording);
+        events.sort((e1, e2) -> e1.getStartTime().compareTo(e2.getStartTime()));
         Events.hasEvents(events);
         for (RecordedEvent event : events) {
-            System.out.println("Event:" + event);
-            if (event.getThread().getJavaThreadId() != currentThreadId) {
+            if (!event.getThread().getJavaName().startsWith(THREAD_NAME_PREFIX)) {
                 continue;
             }
+            System.out.println("Event:" + event);
             // Threads should be started and stopped in the correct order.
             Events.assertEventThread(event, threads[currThreadIndex % threads.length]);
             String eventName = currThreadIndex < threads.length ? EVENT_NAME_THREAD_START : EVENT_NAME_THREAD_END;
             if (!eventName.equals(event.getEventType().getName())) {
-                throw new Exception("Expected event of tyoe " + eventName + " but got " + event.getEventType().getName());
+                throw new Exception("Expected event of type " + eventName + " but got " + event.getEventType().getName());
+            }
+
+            if (eventName == EVENT_NAME_THREAD_START) {
+                Events.assertEventThread(event, "parentThread", Thread.currentThread());
+                RecordedStackTrace stackTrace = event.getValue("stackTrace");
+                assertNotNull(stackTrace);
+                RecordedMethod topMethod = stackTrace.getFrames().get(0).getMethod();
+                assertEQ(topMethod.getName(), "startThread");
             }
             currThreadIndex++;
         }


### PR DESCRIPTION
I'd like to backport 8237499 to 13u for parity with 11u. The plan is to backport it together with follow-up fix 8239886.
The patch doesn't apply cleanly due to context difference in jfrThreadLocal.cpp, reapplied manually.
Tested with tier1 and jdk/jfr, no regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8237499](https://bugs.openjdk.java.net/browse/JDK-8237499): JFR: Include stack trace in the ThreadStart event


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/60/head:pull/60`
`$ git checkout pull/60`
