### PR TITLE
8239000: handle ContendedPaddingWidth in vm_version_ppc

### DIFF
--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -218,6 +218,10 @@ void VM_Version::initialize() {
 
   assert(AllocatePrefetchStyle >= 0, "AllocatePrefetchStyle should be positive");
 
+  if (FLAG_IS_DEFAULT(ContendedPaddingWidth) && (cache_line_size > ContendedPaddingWidth)) {
+    ContendedPaddingWidth = cache_line_size;
+  }
+
   // If running on Power8 or newer hardware, the implementation uses the available vector instructions.
   // In all other cases, the implementation uses only generally available instructions.
   if (!UseCRC32Intrinsics) {
@@ -525,6 +529,13 @@ bool VM_Version::use_biased_locking() {
 
 void VM_Version::print_features() {
   tty->print_cr("Version: %s L1_data_cache_line_size=%d", features_string(), L1_data_cache_line_size());
+
+  if (Verbose) {
+    if (ContendedPaddingWidth > 0) {
+      tty->cr();
+      tty->print_cr("ContendedPaddingWidth " INTX_FORMAT, ContendedPaddingWidth);
+    }
+  }
 }
 
 #ifdef COMPILER2


### PR DESCRIPTION
I'd like to backport JDK-8239000 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
Tested with tier1, tier2, tier3. No regression in tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8239000](https://bugs.openjdk.java.net/browse/JDK-8239000): handle ContendedPaddingWidth in vm_version_ppc


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/61/head:pull/61`
`$ git checkout pull/61`
