### PR TITLE
8239886: Minimal VM build fails after JDK-8237499

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3833,11 +3833,14 @@ static void post_thread_start_event(const JavaThread* jt) {
   if (event.should_commit()) {
     event.set_thread(JFR_THREAD_ID(jt));
     event.set_parentThread((traceid)0);
+#if INCLUDE_JFR
     if (EventThreadStart::is_stacktrace_enabled()) {
       jt->jfr_thread_local()->set_cached_stack_trace_id((traceid)0);
       event.commit();
       jt->jfr_thread_local()->clear_cached_stack_trace();
-    } else {
+    } else
+#endif
+    {
       event.commit();
     }
   }


### PR DESCRIPTION
I'd like to backport 8239886 to 13u as follow-up fix for JDK-8237499 that is already included to 13u.
The patch applies cleanly.
Minimal VM variant are built successfully after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8239886](https://bugs.openjdk.java.net/browse/JDK-8239886): Minimal VM build fails after JDK-8237499


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/63/head:pull/63`
`$ git checkout pull/63`
