### PR TITLE
8248532: Every time I change keyboard language at my MacBook, Java crashes

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1335,7 +1335,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
 
     NSTextInputContext *curContxt = [NSTextInputContext currentInputContext];
     kbdLayout = curContxt.selectedKeyboardInputSource;
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [[NSNotificationCenter defaultCenter] addObserver:[AWTView class]
                                            selector:@selector(keyboardInputSourceChanged:)
                                                name:NSTextInputContextKeyboardSelectionDidChangeNotification
                                              object:nil];


### PR DESCRIPTION
I'd like to backport JDK-8248532 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
Tested with jtreg:test/jdk:jdk_awt. No regression in tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8248532](https://bugs.openjdk.java.net/browse/JDK-8248532): Every time I change keyboard language at my MacBook, Java crashes


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/64/head:pull/64`
`$ git checkout pull/64`
