### PR TITLE
8255603: Memory/Performance regression after JDK-8210985

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,8 +265,7 @@ class MemoryCache<K,V> extends Cache<K,V> {
         else
             this.queue = null;
 
-        int buckets = (int)(maxSize / LOAD_FACTOR) + 1;
-        cacheMap = new LinkedHashMap<>(buckets, LOAD_FACTOR, true);
+        cacheMap = new LinkedHashMap<>(1, LOAD_FACTOR, true);
     }
 
     /**


### PR DESCRIPTION
Request to backport 8255603 to 13u. The patch applies cleanly.
Tested with jdk_security test group.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255603](https://bugs.openjdk.java.net/browse/JDK-8255603): Memory/Performance regression after JDK-8210985


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/67/head:pull/67`
`$ git checkout pull/67`
