### PR TITLE
8254854: [cgroups v1] Metric limits not properly detected on some join controller combinations

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
@@ -184,41 +184,35 @@ public class Metrics implements jdk.internal.platform.Metrics {
      * setSubSystemPath based on the contents of /proc/self/cgroup
      */
     private static void setSubSystemPath(Metrics metric, String[] entry) {
-        String controller;
-        String base;
-        SubSystem subsystem = null;
-        SubSystem subsystem2 = null;
-
-        controller = entry[1];
-        base = entry[2];
+        String controller = entry[1];
+        String base = entry[2];
         if (controller != null && base != null) {
-            switch (controller) {
-                case "memory":
-                    subsystem = metric.MemorySubSystem();
-                    break;
-                case "cpuset":
-                    subsystem = metric.CpuSetSubSystem();
-                    break;
-                case "cpu,cpuacct":
-                case "cpuacct,cpu":
-                    subsystem = metric.CpuSubSystem();
-                    subsystem2 = metric.CpuAcctSubSystem();
-                    break;
-                case "cpuacct":
-                    subsystem = metric.CpuAcctSubSystem();
-                    break;
-                case "cpu":
-                    subsystem = metric.CpuSubSystem();
-                    break;
-                case "blkio":
-                    subsystem = metric.BlkIOSubSystem();
-                    break;
-                // Ignore subsystems that we don't support
-                default:
-                    break;
+            for (String cName: controller.split(",")) {
+                switch (cName) {
+                    case "memory":
+                        setPath(metric, metric.MemorySubSystem(), base);
+                        break;
+                    case "cpuset":
+                        setPath(metric, metric.CpuSetSubSystem(), base);
+                        break;
+                    case "cpuacct":
+                        setPath(metric, metric.CpuAcctSubSystem(), base);
+                        break;
+                    case "cpu":
+                        setPath(metric, metric.CpuSubSystem(), base);
+                        break;
+                    case "blkio":
+                        setPath(metric, metric.BlkIOSubSystem(), base);
+                        break;
+                    // Ignore subsystems that we don't support
+                    default:
+                        break;
+                }
             }
         }
+    }
 
+    private static void setPath(Metrics metric, SubSystem subsystem, String base) {
         if (subsystem != null) {
             subsystem.setPath(base);
             if (subsystem instanceof MemorySubSystem) {
@@ -229,9 +223,6 @@ public class Metrics implements jdk.internal.platform.Metrics {
                 memorySubSystem.setSwapEnabled(isSwapEnabled);
             }
             metric.setActiveSubSystems();
-        }
-        if (subsystem2 != null) {
-            subsystem2.setPath(base);
         }
     }
 


### PR DESCRIPTION
I'd like to backport 8254854 to 13u for parity with 11u.
The patch doesn't apply cleanly since 13u doesn't have cgroups v2 support (JDK-8231111), so it reapplied manually to Metrics::setSubSystemPath() method instead of CgroupV1Subsystem::setSubSystemControllerPath() from the original patch.
Tested with tier1 and container tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254854](https://bugs.openjdk.java.net/browse/JDK-8254854): [cgroups v1] Metric limits not properly detected on some join controller combinations


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/68/head:pull/68`
`$ git checkout pull/68`
