### PR TITLE
8257242: [macOS] Java app crashes while switching input methods

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.h
@@ -37,9 +37,6 @@
 
     // TODO: NSMenu *contextualMenu;
 
-    // Keyboard layout
-    NSString *kbdLayout;
-
     // dnd support (see AppKit/NSDragging.h, NSDraggingSource/Destination):
     CDragSource *_dragSource;
     CDropTarget *_dropTarget;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -37,6 +37,9 @@
 #import <Carbon/Carbon.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
+// keyboard layout
+static NSString *kbdLayout;
+
 @interface AWTView()
 @property (retain) CDropTarget *_dropTarget;
 @property (retain) CDragSource *_dragSource;
@@ -998,7 +1001,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     [self abandonInput];
 }
 
-- (void)keyboardInputSourceChanged:(NSNotification *)notification
++ (void)keyboardInputSourceChanged:(NSNotification *)notification
 {
 #ifdef IM_DEBUG
     NSLog(@"keyboardInputSourceChangeNotification received");
@@ -1295,7 +1298,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     jint index = JNFCallIntMethod(env, fInputMethodLOCKABLE, jm_characterIndexForPoint, (jint)flippedLocation.x, (jint)flippedLocation.y); // AWT_THREADING Safe (AWTRunLoopMode)
 
 #ifdef IM_DEBUG
-    fprintf(stderr, "characterIndexForPoint returning %ld\n", index);
+    fprintf(stderr, "characterIndexForPoint returning %d\n", index);
 #endif // IM_DEBUG
 
     if (index == -1) {


### PR DESCRIPTION
I'd like to backport JDK-8257242 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
Tested with jtreg:test/jdk:jdk_awt. No regression in tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257242](https://bugs.openjdk.java.net/browse/JDK-8257242): [macOS] Java app crashes while switching input methods


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/69/head:pull/69`
`$ git checkout pull/69`
