### PR TITLE
8210527: JShell: NullPointerException in jdk.jshell.Eval.translateExceptionStack

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -488,9 +488,9 @@ Display information about using the jshell tool.\n\
 /help\n\t\
      List the jshell tool commands and help subjects\n\n\
 /help <command>\n\t\
-     Display information about the specified command. The slash must be included.\n\t\
-     Only the first few letters of the command are needed -- if more than one\n\t\
-     each will be displayed.  Example:  /help /li\n\n\
+     Display information about the specified command.\n\t\
+     Only the first few letters of the command are needed -- if there is more than\n\t\
+     one match, each will be displayed.  Example:  /help /li\n\n\
 /help <subject>\n\t\
      Display information about the specified help subject. Example: /help intro
 
@@ -529,9 +529,9 @@ Display information about using the jshell tool (abbreviation for /help).\n\
 /?\n\t\
      Display list of commands and help subjects\n\
 /? <command>\n\t\
-     Display information about the specified command. The slash must be included.\n\t\
-     Only the first few letters of the command are needed -- if more than one\n\t\
-     match, each will be displayed.  Example:  /? /li\n\
+     Display information about the specified command.\n\t\
+     Only the first few letters of the command are needed -- if there is more than\n\t\
+     one match, each will be displayed.  Example:  /? /li\n\n\
 /? <subject>\n\t\
      Display information about the specified help subject. Example: /? intro
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Eval.java
@@ -1106,7 +1106,7 @@ class Eval {
                 Snippet sn = outer.wrapLineToSnippet(wln);
                 String file = "#" + sn.id();
                 elems[i] = new StackTraceElement(klass, method, file, line);
-            } else if (r.getFileName().equals("<none>")) {
+            } else if ("<none>".equals(r.getFileName())) {
                 elems[i] = new StackTraceElement(r.getClassName(), r.getMethodName(), null, r.getLineNumber());
             } else {
                 elems[i] = r;

--- a/test/langtools/jdk/jshell/ExceptionsTest.java
+++ b/test/langtools/jdk/jshell/ExceptionsTest.java
@@ -24,8 +24,13 @@
 /*
  * @test
  * @summary Tests for exceptions
- * @bug 8198801 8212167
- * @build KullaTesting TestingInputStream
+ * @bug 8198801 8212167 8210527
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.javap
+ * @library /tools/lib
+ * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
+ * @build KullaTesting TestingInputStream Compiler
  * @run testng ExceptionsTest
  */
 
@@ -38,12 +43,18 @@ import jdk.jshell.Snippet;
 import jdk.jshell.SnippetEvent;
 import jdk.jshell.UnresolvedReferenceException;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 @Test
 public class ExceptionsTest extends KullaTesting {
+
+    private final Compiler compiler = new Compiler();
+    private final Path outDir = Paths.get("test_class_path");
 
     public void throwUncheckedException() {
         String message = "error_message";
@@ -207,6 +218,36 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr2.snippet(), 1)));
     }
 
+    // test 8210527
+    public void throwFromWithoutSource() {
+        String message = "show this";
+        SnippetEvent se = assertEvalException("java.lang.reflect.Proxy.newProxyInstance(" +
+                "Thread.currentThread().getContextClassLoader(), new Class[] {}," +
+                "(p, m, a) -> { throw new IllegalStateException(\"" + message + "\"); }).hashCode()");
+        assertExceptionMatch(se,
+                new ExceptionInfo(IllegalStateException.class, message,
+                        newStackTraceElement("", "lambda$do_it$$0", se.snippet(), 1),
+                        new StackTraceElement("com.sun.proxy.$Proxy0", "hashCode", null, -1),
+                        newStackTraceElement("", "", se.snippet(), 1)));
+    }
+
+    // test 8210527
+    public void throwFromNoSource() {
+        Path path = outDir.resolve("fail");
+        compiler.compile(path,
+                "package fail;\n" +
+                        "public class Fail {\n" +
+                        "  static { int x = 1 / 0; }\n" +
+                        "}\n");
+        addToClasspath(compiler.getPath(path));
+        SnippetEvent se = assertEvalException("Class.forName(\"fail.Fail\")");
+        assertExceptionMatch(se,
+                new ExceptionInfo(ExceptionInInitializerError.class, null,
+                        new StackTraceElement("java.lang.Class", "forName0",  "Class.java", -2),
+                        new StackTraceElement("java.lang.Class", "forName", "Class.java", -2),
+                        newStackTraceElement("", "", se.snippet(), 1)));
+    }
+
     // test 8212167
     public void throwLineFormat1() {
         SnippetEvent se = assertEvalException(
@@ -367,17 +408,19 @@ public class ExceptionsTest extends KullaTesting {
                 for (int i = 0; i < actual.length; ++i) {
                     StackTraceElement actualElement = actual[i];
                     StackTraceElement expectedElement = expected[i];
-                    assertEquals(actualElement.getClassName(), expectedElement.getClassName(), message + " : class names");
+                    assertEquals(actualElement.getClassName(), expectedElement.getClassName(), message + " : class names [" + i + "]");
                     String expectedMethodName = expectedElement.getMethodName();
                     if (expectedMethodName.startsWith("lambda$")) {
                         assertTrue(actualElement.getMethodName().startsWith("lambda$"), message + " : method names");
                     } else {
-                        assertEquals(actualElement.getMethodName(), expectedElement.getMethodName(), message + " : method names");
+                        assertEquals(actualElement.getMethodName(), expectedElement.getMethodName(), message + " : method names [" + i + "]");
                     }
-                    assertEquals(actualElement.getFileName(), expectedElement.getFileName(), message + " : file names");
-                    assertEquals(actualElement.getLineNumber(), expectedElement.getLineNumber(), message + " : line numbers"
-                        + " -- actual: " + actualElement.getLineNumber() + ", expected: " + expectedElement.getLineNumber() +
-                            " -- in: " + actualElement.getClassName());
+                    assertEquals(actualElement.getFileName(), expectedElement.getFileName(), message + " : file names [" + i + "]");
+                    if (expectedElement.getLineNumber() >= 0) {
+                        assertEquals(actualElement.getLineNumber(), expectedElement.getLineNumber(), message + " : line numbers [" + i + "]"
+                                + " -- actual: " + actualElement.getLineNumber() + ", expected: " + expectedElement.getLineNumber() +
+                                " -- in: " + actualElement.getClassName());
+                    }
                 }
             }
         }


### PR DESCRIPTION
I'd like to backport 8210527 and 8232855 to 13u for parity with 11u.
The patch contains both fixes and applies cleanly.
Tested with tier1 and jdk/jshell tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8210527](https://bugs.openjdk.java.net/browse/JDK-8210527): JShell: NullPointerException in jdk.jshell.Eval.translateExceptionStack
 * [JDK-8232855](https://bugs.openjdk.java.net/browse/JDK-8232855): jshell missing word in /help help


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/70/head:pull/70`
`$ git checkout pull/70`
