### PR TITLE
8241086: Test runtime/NMT/HugeArenaTracking.java is failing on 32bit Windows

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/HugeArenaTracking.java
+++ b/test/hotspot/jtreg/runtime/NMT/HugeArenaTracking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2019, 2020, Red Hat, Inc. All rights reserved.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -25,6 +25,7 @@
  * @test
  * @key nmt jcmd
  * @library /test/lib
+ * @requires vm.bits == 64
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox


### PR DESCRIPTION
I'd like to backport test only fix 8241086 to 13u, the issue is present there too.
The patch applies almost cleanly except for minor context difference in copyright comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8241086](https://bugs.openjdk.java.net/browse/JDK-8241086): Test runtime/NMT/HugeArenaTracking.java is failing on 32bit Windows


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/75/head:pull/75`
`$ git checkout pull/75`
