### PR TITLE
8204994: SA might fail to attach to process with "Windbg Error: WaitForEvent failed"

### DIFF
--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -396,6 +396,19 @@ static bool setImageAndSymbolPath(JNIEnv* env, jobject obj) {
   return true;
 }
 
+static HRESULT WaitForEvent(IDebugControl *ptrIDebugControl) {
+  HRESULT hr = ptrIDebugControl->WaitForEvent(DEBUG_WAIT_DEFAULT, INFINITE);
+  // see JDK-8204994: sometimes WaitForEvent fails with E_ACCESSDENIED,
+  // but succeeds on 2nd call.
+  // To minimize possible noise retry 3 times.
+  for (int i = 0; hr == E_ACCESSDENIED && i < 3; i++) {
+    // yield current thread use of a processor (short delay).
+    SwitchToThread();
+    hr = ptrIDebugControl->WaitForEvent(DEBUG_WAIT_DEFAULT, INFINITE);
+  }
+  return hr;
+}
+
 static bool openDumpFile(JNIEnv* env, jobject obj, jstring coreFileName) {
   // open the dump file
   AutoJavaString coreFile(env, coreFileName);
@@ -411,7 +424,7 @@ static bool openDumpFile(JNIEnv* env, jobject obj, jstring coreFileName) {
 
   IDebugControl* ptrIDebugControl = (IDebugControl*)env->GetLongField(obj, ptrIDebugControl_ID);
   CHECK_EXCEPTION_(false);
-  COM_VERIFY_OK_(ptrIDebugControl->WaitForEvent(DEBUG_WAIT_DEFAULT, INFINITE),
+  COM_VERIFY_OK_(WaitForEvent(ptrIDebugControl),
                  "Windbg Error: WaitForEvent failed!", false);
 
   return true;
@@ -448,7 +461,7 @@ static bool attachToProcess(JNIEnv* env, jobject obj, jint pid) {
   IDebugControl* ptrIDebugControl = (IDebugControl*) env->GetLongField(obj,
                                                      ptrIDebugControl_ID);
   CHECK_EXCEPTION_(false);
-  COM_VERIFY_OK_(ptrIDebugControl->WaitForEvent(DEBUG_WAIT_DEFAULT, INFINITE),
+  COM_VERIFY_OK_(WaitForEvent(ptrIDebugControl),
                  "Windbg Error: WaitForEvent failed!", false);
 
   return true;


### PR DESCRIPTION
I'd like to backport 8204994 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8204994](https://bugs.openjdk.java.net/browse/JDK-8204994): SA might fail to attach to process with "Windbg Error: WaitForEvent failed"


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/76/head:pull/76`
`$ git checkout pull/76`
