### PR TITLE
8235218: Minimal VM is broken after JDK-8173361

### DIFF
--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -481,9 +481,9 @@ class JvmtiDeferredEvent {
   // Actually posts the event.
   void post() NOT_JVMTI_RETURN;
   // Sweeper support to keep nmethods from being zombied while in the queue.
-  void nmethods_do(CodeBlobClosure* cf);
+  void nmethods_do(CodeBlobClosure* cf) NOT_JVMTI_RETURN;
   // GC support to keep nmethod from being unloaded while in the queue.
-  void oops_do(OopClosure* f, CodeBlobClosure* cf);
+  void oops_do(OopClosure* f, CodeBlobClosure* cf) NOT_JVMTI_RETURN;
 };
 
 /**
@@ -518,9 +518,9 @@ class JvmtiDeferredEventQueue : AllStatic {
   static void enqueue(const JvmtiDeferredEvent& event) NOT_JVMTI_RETURN;
   static JvmtiDeferredEvent dequeue() NOT_JVMTI_RETURN_(JvmtiDeferredEvent());
   // Sweeper support to keep nmethods from being zombied while in the queue.
-  static void nmethods_do(CodeBlobClosure* cf);
+  static void nmethods_do(CodeBlobClosure* cf) NOT_JVMTI_RETURN;
   // GC support to keep nmethod from being unloaded while in the queue.
-  static void oops_do(OopClosure* f, CodeBlobClosure* cf);
+  static void oops_do(OopClosure* f, CodeBlobClosure* cf) NOT_JVMTI_RETURN;
 };
 
 // Utility macro that checks for NULL pointers:


### PR DESCRIPTION
I'd like to backport 8235218 to 13u as follow-up fix for JDK-8173361 that is already included to 13u.
The patch applies cleanly.
Minimal VM is built successfully after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8235218](https://bugs.openjdk.java.net/browse/JDK-8235218): Minimal VM is broken after JDK-8173361


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/77/head:pull/77`
`$ git checkout pull/77`
