### PR TITLE
8248987: AOT's Linker.java seems to eagerly fail-fast on Windows.

### DIFF
--- a/src/jdk.aot/share/classes/jdk.tools.jaotc/src/jdk/tools/jaotc/Linker.java
+++ b/src/jdk.aot/share/classes/jdk.tools.jaotc/src/jdk/tools/jaotc/Linker.java
@@ -107,7 +107,7 @@ final class Linker {
                         objectFileName = name.substring(0, name.length() - ".dll".length());
                     }
                     objectFileName = objectFileName + ".obj";
-                    linkerPath = (options.linkerpath != null) ? options.linkerpath : getWindowsLinkPath();
+                    linkerPath = (options.linkerpath != null) ? options.linkerpath : getWindowsLinkPath(main);
                     if (linkerPath == null) {
                         throw new InternalError("Can't locate Microsoft Visual Studio amd64 link.exe");
                     }
@@ -127,6 +127,8 @@ final class Linker {
                 throw new InternalError(getString(p.getErrorStream()));
             }
         }
+
+        main.printer.printlnVerbose("Found linker: " + linkerPath);
     }
 
     void link() throws Exception {
@@ -159,14 +161,17 @@ final class Linker {
     /**
      * Search for Visual Studio link.exe Search Order is: VS2017+, VS2013, VS2015, VS2012.
      */
-    private static String getWindowsLinkPath() throws Exception {
+    private static String getWindowsLinkPath(Main main) throws Exception {
         try {
             Path vc141NewerLinker = getVC141AndNewerLinker();
             if (vc141NewerLinker != null) {
                 return vc141NewerLinker.toString();
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            main.printer.printlnVerbose("Could not find VC14 or newer version of linker: " + e.getMessage());
+            if (main.options.debug) {
+                e.printStackTrace();
+            }
         }
 
         String link = "\\VC\\bin\\amd64\\link.exe";
@@ -202,11 +207,12 @@ final class Linker {
     private static Path getVC141AndNewerLinker() throws Exception {
         String programFilesX86 = System.getenv("ProgramFiles(x86)");
         if (programFilesX86 == null) {
-            throw new InternalError("Could not read the ProgramFiles(x86) environment variable");
+            throw new IllegalStateException("Could not read the ProgramFiles(x86) environment variable");
         }
-        Path vswhere = Paths.get(programFilesX86 + "\\Microsoft Visual Studio\\Installer\\vswhere.exe");
+        String vswherePath = programFilesX86 + "\\Microsoft Visual Studio\\Installer\\vswhere.exe";
+        Path vswhere = Paths.get(vswherePath);
         if (!Files.exists(vswhere)) {
-            return null;
+            throw new IllegalStateException("Could not find " + vswherePath);
         }
 
         ProcessBuilder processBuilder = new ProcessBuilder(vswhere.toString(), "-requires",
@@ -220,19 +226,19 @@ final class Linker {
             if (errorMessage.isEmpty()) {
                 errorMessage = getString(process.getInputStream());
             }
-            throw new InternalError(errorMessage);
+            throw new IllegalStateException("vswhere error: " + errorMessage);
         }
 
-        String installationPath = getLines(process.getInputStream()).findFirst().orElseThrow(() -> new InternalError("Unexpected empty output from vswhere"));
+        String installationPath = getLines(process.getInputStream()).findFirst().orElseThrow(() -> new IllegalStateException("Unexpected empty output from vswhere"));
         Path vcToolsVersionFilePath = Paths.get(installationPath, "VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt");
         List<String> vcToolsVersionFileLines = Files.readAllLines(vcToolsVersionFilePath);
         if (vcToolsVersionFileLines.isEmpty()) {
-            throw new InternalError(vcToolsVersionFilePath.toString() + " is empty");
+            throw new IllegalStateException(vcToolsVersionFilePath.toString() + " is empty");
         }
         String vcToolsVersion = vcToolsVersionFileLines.get(0);
         Path linkPath = Paths.get(installationPath, "VC\\Tools\\MSVC", vcToolsVersion, "bin\\Hostx64\\x64\\link.exe");
         if (!Files.exists(linkPath)) {
-            throw new InternalError("Linker at path " + linkPath.toString() + " does not exist");
+            throw new IllegalStateException("Linker at path " + linkPath.toString() + " does not exist");
         }
 
         return linkPath;


### PR DESCRIPTION
I'd like to backport 8248987 to 13u for parity with 11u.
The patch applies cleanly.
Changes are jaotc tool specific, tested with aot tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8248987](https://bugs.openjdk.java.net/browse/JDK-8248987): AOT's Linker.java seems to eagerly fail-fast on Windows.


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/78/head:pull/78`
`$ git checkout pull/78`
