### PR TITLE
8258396: SIGILL in jdk.jfr.internal.PlatformRecorder.rotateDisk()

### DIFF
--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -489,7 +489,7 @@ BufferPtr JfrStorage::flush(BufferPtr cur, size_t used, size_t req, bool native,
 
 BufferPtr JfrStorage::flush_regular(BufferPtr cur, const u1* const cur_pos, size_t used, size_t req, bool native, Thread* t) {
   debug_only(assert_flush_regular_precondition(cur, cur_pos, used, req, t);)
-  // A flush is needed before memcpy since a non-large buffer is thread stable
+  // A flush is needed before memmove since a non-large buffer is thread stable
   // (thread local). The flush will not modify memory in addresses above pos()
   // which is where the "used / uncommitted" data resides. It is therefore both
   // possible and valid to migrate data after the flush. This is however only
@@ -501,7 +501,8 @@ BufferPtr JfrStorage::flush_regular(BufferPtr cur, const u1* const cur_pos, size
   if (cur->free_size() >= req) {
     // simplest case, no switching of buffers
     if (used > 0) {
-      memcpy(cur->pos(), (void*)cur_pos, used);
+      // source and destination may overlap so memmove must be used instead of memcpy
+      memmove(cur->pos(), (void*)cur_pos, used);
     }
     assert(native ? t->jfr_thread_local()->native_buffer() == cur : t->jfr_thread_local()->java_buffer() == cur, "invariant");
     return cur;


### PR DESCRIPTION
I'd like to backport 8258396, the issue is present there too.
The patch applies cleanly.
Tested with tier1 and jdk/jfr tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258396](https://bugs.openjdk.java.net/browse/JDK-8258396): SIGILL in jdk.jfr.internal.PlatformRecorder.rotateDisk()


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/80/head:pull/80`
`$ git checkout pull/80`
