### PR TITLE
8255908: ExceptionInInitializerError due to UncheckedIOException while initializing cgroupv1 subsystem

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
@@ -26,6 +26,7 @@
 package jdk.internal.platform.cgroupv1;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -84,6 +85,8 @@ public class Metrics implements jdk.internal.platform.Metrics {
 
         } catch (IOException e) {
             return null;
+        } catch (UncheckedIOException e) {
+            return null;
         }
 
         /**
@@ -118,6 +121,8 @@ public class Metrics implements jdk.internal.platform.Metrics {
 
         } catch (IOException e) {
             return null;
+        } catch (UncheckedIOException e) {
+            return null;
         }
 
         // Return Metrics object if we found any subsystems.
@@ -135,6 +140,8 @@ public class Metrics implements jdk.internal.platform.Metrics {
         } catch (PrivilegedActionException e) {
             unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/SubSystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/SubSystem.java
@@ -27,6 +27,7 @@ package jdk.internal.platform.cgroupv1;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -110,6 +111,8 @@ public class SubSystem {
         } catch (PrivilegedActionException e) {
             Metrics.unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 
@@ -140,6 +143,8 @@ public class SubSystem {
         } catch (PrivilegedActionException e) {
             Metrics.unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 
@@ -202,8 +207,9 @@ public class SubSystem {
                                            .findFirst();
 
             return result.isPresent() ? Long.parseLong(result.get()) : 0L;
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
+            return 0L;
+        } catch (UncheckedIOException e) {
             return 0L;
         }
     }


### PR DESCRIPTION
I'd like to backport 8255908 to 13u for parity with 11u.
The patch doesn't apply cleanly since 13u doesn't have cgroups v2 support (JDK-8231111), so it reapplied manually to similar places in cgroupv1/Metrics.java and cgroupv1/SubSystem.java.
Tested with tier1 and container tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255908](https://bugs.openjdk.java.net/browse/JDK-8255908): ExceptionInInitializerError due to UncheckedIOException while initializing cgroupv1 subsystem


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/82/head:pull/82`
`$ git checkout pull/82`
