### PR TITLE
8235584: UseProfiledLoopPredicate fails with assert(_phase->get_loop(c) == loop) failed: have to be in the same loop

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -1466,8 +1466,9 @@ bool PhaseIdealLoop::loop_predication_impl(IdealLoopTree *loop) {
     // an early loop exit. Try them with profile data.
     while (if_proj_list.size() > 0) {
       Node* proj = if_proj_list.pop();
+      float f = pf.to(proj);
       if (proj->as_Proj()->is_uncommon_trap_if_pattern(Deoptimization::Reason_none) &&
-          pf.to(proj) * loop_trip_cnt >= 1) {
+          f * loop_trip_cnt >= 1) {
         hoisted = loop_predication_impl_helper(loop, proj->as_Proj(), profile_predicate_proj, cl, zero, invar, Deoptimization::Reason_profile_predicate) | hoisted;
       }
     }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -946,19 +946,19 @@ Node *LoopNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
 #ifdef ASSERT
 void LoopNode::verify_strip_mined(int expect_skeleton) const {
-  if (!is_valid_counted_loop()) {
-    return; // Skip malformed counted loop
-  }
   const OuterStripMinedLoopNode* outer = NULL;
   const CountedLoopNode* inner = NULL;
   if (is_strip_mined()) {
+    if (!is_valid_counted_loop()) {
+      return; // Skip malformed counted loop
+    }
     assert(is_CountedLoop(), "no Loop should be marked strip mined");
     inner = as_CountedLoop();
     outer = inner->in(LoopNode::EntryControl)->as_OuterStripMinedLoop();
   } else if (is_OuterStripMinedLoop()) {
     outer = this->as_OuterStripMinedLoop();
     inner = outer->unique_ctrl_out()->as_CountedLoop();
-    assert(inner->is_valid_counted_loop(), "OuterStripMinedLoop should have been removed");
+    assert(inner->is_valid_counted_loop() && inner->is_strip_mined(), "OuterStripMinedLoop should have been removed");
     assert(!is_strip_mined(), "outer loop shouldn't be marked strip mined");
   }
   if (inner != NULL || outer != NULL) {
@@ -1240,7 +1240,7 @@ Node* CountedLoopNode::match_incr_with_optional_truncation(
 }
 
 LoopNode* CountedLoopNode::skip_strip_mined(int expect_skeleton) {
-  if (is_strip_mined()) {
+  if (is_strip_mined() && is_valid_counted_loop()) {
     verify_strip_mined(expect_skeleton);
     return in(EntryControl)->as_Loop();
   }


### PR DESCRIPTION
I'd like to port this for parity with LTS 11u. Applies clean with the current state of jdk13u.
Tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8235584](https://bugs.openjdk.java.net/browse/JDK-8235584): UseProfiledLoopPredicate fails with assert(_phase->get_loop(c) == loop) failed: have to be in the same loop


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/83/head:pull/83`
`$ git checkout pull/83`
