### PR TITLE
8251257: NMT: jcmd VM.native_memory scale=1 crashes target VM

### DIFF
--- a/src/hotspot/share/services/nmtCommon.cpp
+++ b/src/hotspot/share/services/nmtCommon.cpp
@@ -35,6 +35,7 @@ const char* NMTUtil::_memory_type_names[] = {
 
 const char* NMTUtil::scale_name(size_t scale) {
   switch(scale) {
+    case 1: return "";
     case K: return "KB";
     case M: return "MB";
     case G: return "GB";

--- a/test/hotspot/jtreg/runtime/NMT/JcmdScale.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdScale.java
@@ -43,6 +43,14 @@ public class JcmdScale {
     // Grab my own PID
     String pid = Long.toString(ProcessTools.getProcessId());
 
+    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "scale=1"});
+    output = new OutputAnalyzer(pb.start());
+    output.shouldContain(", committed=");
+
+    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "scale=b"});
+    output = new OutputAnalyzer(pb.start());
+    output.shouldContain(", committed=");
+
     pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "scale=KB"});
     output = new OutputAnalyzer(pb.start());
     output.shouldContain("KB, committed=");


### PR DESCRIPTION
I'd like to backport 8251257 to 13u for parity with 11u.
The patch applies cleanly.
Tested with nmt tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8251257](https://bugs.openjdk.java.net/browse/JDK-8251257): NMT: jcmd VM.native_memory scale=1 crashes target VM


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/88/head:pull/88`
`$ git checkout pull/88`
