### PR TITLE
8233027: OopMapSet::all_do does oms.next() twice during iteration

### DIFF
--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -335,7 +335,6 @@ void OopMapSet::all_do(const frame *fr, const RegisterMap *reg_map,
       if (base_loc != NULL && *base_loc != NULL && !CompressedOops::is_base(*base_loc)) {
         derived_oop_fn(base_loc, derived_loc);
       }
-      oms.next();
     }
   }
 


### PR DESCRIPTION
I'd like to backport JDK-8233027 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
Tested with tier1. No regression in tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8233027](https://bugs.openjdk.java.net/browse/JDK-8233027): OopMapSet::all_do does oms.next() twice during iteration


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/89/head:pull/89`
`$ git checkout pull/89`
