### PR TITLE
8226810: Failed to launch JVM because of NullPointerException occured on System.props

### DIFF
--- a/make/data/charsetmapping/stdcs-windows
+++ b/make/data/charsetmapping/stdcs-windows
@@ -2,6 +2,7 @@
 #   generate these charsets into sun.nio.cs
 #
 GBK
+GB18030
 Johab
 MS1255
 MS1256


### PR DESCRIPTION
I'd like to backport 8226810 to 13u for parity with 11u.
The patch applies cleanly, it enables the GB18030 charset to be built into java.base on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8226810](https://bugs.openjdk.java.net/browse/JDK-8226810): Failed to launch JVM because of NullPointerException occured on System.props


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/90/head:pull/90`
`$ git checkout pull/90`
