### PR TITLE
8244819: hsdis does not compile with binutils 2.34+

### DIFF
--- a/src/utils/hsdis/hsdis.c
+++ b/src/utils/hsdis/hsdis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -568,7 +568,12 @@ static void init_disassemble_info_from_bfd(struct disassemble_info* dinfo,
   dinfo->arch = bfd_get_arch(abfd);
   dinfo->mach = bfd_get_mach(abfd);
   dinfo->disassembler_options = disassembler_options;
+#if BFD_VERSION >= 234000000
+  /* bfd_octets_per_byte() has 2 args since binutils 2.34 */
+  dinfo->octets_per_byte = bfd_octets_per_byte (abfd, NULL);
+#else
   dinfo->octets_per_byte = bfd_octets_per_byte (abfd);
+#endif
   dinfo->skip_zeroes = sizeof(void*) * 2;
   dinfo->skip_zeroes_at_end = sizeof(void*)-1;
   dinfo->disassembler_needs_relocs = FALSE;


### PR DESCRIPTION
I'd like to port it, too: 2.34 is in e.g. Ubuntu 20.04, the current LTS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8244819](https://bugs.openjdk.java.net/browse/JDK-8244819): hsdis does not compile with binutils 2.34+


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/91/head:pull/91`
`$ git checkout pull/91`
