### PR TITLE
8234687: change javap reporting on unknown attributes

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,9 +126,6 @@ public class AttributeWriter extends BasicWriter
 
     @Override
     public Void visitDefault(DefaultAttribute attr, Void ignore) {
-        if (attr.reason != null) {
-            report(attr.reason);
-        }
         byte[] data = attr.info;
         int i = 0;
         int j = 0;
@@ -140,7 +137,11 @@ public class AttributeWriter extends BasicWriter
             print("attribute name = #" + attr.attribute_name_index);
         }
         print(": ");
-        println("length = 0x" + toHex(attr.info.length));
+        print("length = 0x" + toHex(attr.info.length));
+        if (attr.reason != null) {
+            print(" (" + attr.reason + ")");
+        }
+        println();
 
         print("   ");
 

--- a/test/langtools/tools/javap/BadAttributeName.java
+++ b/test/langtools/tools/javap/BadAttributeName.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8234687
+ * @summary change javap reporting on unknown attributes
+ * @modules jdk.jdeps/com.sun.tools.javap
+ * @run main BadAttributeName
+ */
+
+
+import java.io.*;
+import java.nio.file.*;
+
+public class BadAttributeName {
+
+    public static String source = "public class Test {\n" +
+                                  "    public static void main(String[] args) {}\n" +
+                                  "}";
+
+    public static void main(String[] args) throws Exception {
+        final File srcFile = new File("Test.java");
+        Files.writeString(Path.of("Test.java"), source);
+
+        final String[] javacOpts = {"Test.java"};
+
+        if (com.sun.tools.javac.Main.compile(javacOpts) != 0) {
+            throw new Exception("Can't compile embedded test.");
+        }
+
+        RandomAccessFile raf = new RandomAccessFile("Test.class", "rw");
+        String sourceFile = "SourceFile";
+        long namePos = getConstantPoolUTF8Pos(raf, sourceFile);
+        if (namePos < 0) {
+            throw new Exception("The class file contains no SourceFile attribute.");
+        }
+
+        raf.seek(namePos); // Jump to the SourceFile name
+        // Create a "custom" attribute by reusing/renaming an unimportant existing one
+        String customAttr = "CustomAttribute".substring(0, sourceFile.length());
+        raf.writeUTF(customAttr);
+        raf.close();
+
+        String[] opts = { "-v", "Test.class" };
+        StringWriter sw = new StringWriter();
+        PrintWriter pout = new PrintWriter(sw);
+
+        com.sun.tools.javap.Main.run(opts, pout);
+        pout.flush();
+
+        String expect = customAttr + ": length = 0x2 (unknown attribute)";
+        if (sw.toString().indexOf(expect) == -1) {
+            sw.toString().lines().forEach(System.out::println);
+            throw new Exception("expected text not found: " + expect);
+        }
+    }
+
+    private static long getConstantPoolUTF8Pos(RandomAccessFile cfile, String name) throws Exception {
+        cfile.seek(0);
+        int v1, v2;
+        v1 = cfile.readInt();
+        // System.out.println("Magic: " + String.format("%X", v1));
+
+        v1 = cfile.readUnsignedShort();
+        v2 = cfile.readUnsignedShort();
+        // System.out.println("Version: " + String.format("%d.%d", v1, v2));
+
+        v1 = cfile.readUnsignedShort();
+        // System.out.println("CPool size: " + v1);
+        // Exhaust the constant pool
+        for (; v1 > 1; v1--) {
+            // System.out.print(".");
+            byte tag = cfile.readByte();
+            switch (tag) {
+                case 7  : // Class
+                case 8  : // String
+                    // Data is 2 bytes long
+                    cfile.skipBytes(2);
+                    break;
+                case 3  : // Integer
+                case 4  : // Float
+                case 9  : // FieldRef
+                case 10 : // MethodRef
+                case 11 : // InterfaceMethodRef
+                case 12 : // Name and Type
+                    // Data is 4 bytes long
+                    cfile.skipBytes(4);
+                    break;
+                case 5  : // Long
+                case 6  : // Double
+                    // Data is 8 bytes long
+                    cfile.skipBytes(8);
+                    break;
+                case 1  : // Utf8
+                    long fp = cfile.getFilePointer();
+                    String s = cfile.readUTF();
+                    if (s.equals(name)) {
+                        return fp;
+                    }
+                    break;
+                default :
+                    throw new Exception("Unexpected tag in CPool: [" + tag + "] at "
+                            + Long.toHexString(cfile.getFilePointer()));
+            }
+        }
+        // System.out.println();
+
+        // Bummer! Name not found!
+        return -1L;
+    }
+}


### PR DESCRIPTION
I'd like to backport 8234687 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1; new test fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8234687](https://bugs.openjdk.java.net/browse/JDK-8234687): change javap reporting on unknown attributes


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/92/head:pull/92`
`$ git checkout pull/92`
