### PR TITLE
8243290: Improve diagnostic messages for class verification and redefinition failures

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -125,8 +125,15 @@ void Verifier::trace_class_resolution(Klass* resolve_class, InstanceKlass* verif
 void Verifier::log_end_verification(outputStream* st, const char* klassName, Symbol* exception_name, TRAPS) {
   if (HAS_PENDING_EXCEPTION) {
     st->print("Verification for %s has", klassName);
-    st->print_cr(" exception pending %s ",
+    oop message = java_lang_Throwable::message(PENDING_EXCEPTION);
+    if (message != NULL) {
+      char* ex_msg = java_lang_String::as_utf8_string(message);
+      st->print_cr(" exception pending '%s %s'",
+                 PENDING_EXCEPTION->klass()->external_name(), ex_msg);
+    } else {
+      st->print_cr(" exception pending %s ",
                  PENDING_EXCEPTION->klass()->external_name());
+    }
   } else if (exception_name != NULL) {
     st->print_cr("Verification for %s failed", klassName);
   }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1210,10 +1210,20 @@ jvmtiError VM_RedefineClasses::load_new_class_versions(TRAPS) {
       the_class->link_class(THREAD);
       if (HAS_PENDING_EXCEPTION) {
         Symbol* ex_name = PENDING_EXCEPTION->klass()->name();
-        log_info(redefine, class, load, exceptions)("link_class exception: '%s'", ex_name->as_C_string());
+        oop message = java_lang_Throwable::message(PENDING_EXCEPTION);
+        if (message != NULL) {
+          char* ex_msg = java_lang_String::as_utf8_string(message);
+          log_info(redefine, class, load, exceptions)("link_class exception: '%s %s'",
+                   ex_name->as_C_string(), ex_msg);
+        } else {
+          log_info(redefine, class, load, exceptions)("link_class exception: '%s'",
+                   ex_name->as_C_string());
+        }
         CLEAR_PENDING_EXCEPTION;
         if (ex_name == vmSymbols::java_lang_OutOfMemoryError()) {
           return JVMTI_ERROR_OUT_OF_MEMORY;
+        } else if (ex_name == vmSymbols::java_lang_NoClassDefFoundError()) {
+          return JVMTI_ERROR_INVALID_CLASS;
         } else {
           return JVMTI_ERROR_INTERNAL;
         }


### PR DESCRIPTION
I'd like to backport 8243290 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8243290](https://bugs.openjdk.java.net/browse/JDK-8243290): Improve diagnostic messages for class verification and redefinition failures


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/95/head:pull/95`
`$ git checkout pull/95`
