### PR TITLE
6532025: GIF reader throws misleading exception with truncated images

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/gif/GIFImageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,6 +350,10 @@ public class GIFImageReader extends ImageReader {
                     int off = 0;
                     while (left > 0) {
                         int nbytes = stream.read(block, off, left);
+                        if (nbytes == -1) {
+                            throw new IIOException("Invalid block length for " +
+                                    "LZW encoded image data");
+                        }
                         off += nbytes;
                         left -= nbytes;
                     }
@@ -930,6 +934,10 @@ public class GIFImageReader extends ImageReader {
             int off = 0;
             while (left > 0) {
                 int nbytes = stream.read(block, off, left);
+                if (nbytes == -1) {
+                    throw new IIOException("Invalid block length for " +
+                            "LZW encoded image data");
+                }
                 left -= nbytes;
                 off += nbytes;
             }

--- a/test/jdk/javax/imageio/plugins/gif/TruncatedGIFTest.java
+++ b/test/jdk/javax/imageio/plugins/gif/TruncatedGIFTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6532025
+ * @summary Test verifies that we dont throw IOOBE for truncated
+ *          GIF image
+ */
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import javax.imageio.IIOException;
+
+public class TruncatedGIFTest {
+    public static void main(String[] args) throws IOException {
+        // GIFF stream with no GCT/LCT but one truncated LZW
+        // image block
+        byte[] ba = new byte[] { (byte)0x47, (byte) 0x49,
+                (byte)0x46, (byte)0x38, (byte)0x39, (byte)0x61,
+                (byte)0x01, (byte)0x00, (byte)0x01, (byte)0x00,
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x2c,
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,
+                (byte)0x01, (byte)0x00, (byte)0x01, (byte)0x00,
+                (byte)0x00, (byte)0x04, (byte)0x0A, (byte)0x00};
+
+        try {
+            BufferedImage img = ImageIO.read(new ByteArrayInputStream(ba));
+        } catch (IIOException e) {
+            // do nothing we expect IIOException but we should not
+            // throw IndexOutOfBoundsException
+            System.out.println(e.toString());
+            System.out.println("Caught IIOException ignore it");
+            System.out.println("Test passed");
+        }
+    }
+}
+


### PR DESCRIPTION
I'd like to backport 6532025 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1; new test fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-6532025](https://bugs.openjdk.java.net/browse/JDK-6532025): GIF reader throws misleading exception with truncated images


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/96/head:pull/96`
`$ git checkout pull/96`
