### PR TITLE
8235456: Minimal VM is broken after JDK-8212160

### DIFF
--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -526,7 +526,7 @@ class JvmtiDeferredEventQueue : public CHeapObj<mtInternal> {
   JvmtiDeferredEvent dequeue() NOT_JVMTI_RETURN_(JvmtiDeferredEvent());
 
   // Post all events in the queue for the current Jvmti environment
-  void post(JvmtiEnv* env) NOT_JVMTI_RETURN_(false);
+  void post(JvmtiEnv* env) NOT_JVMTI_RETURN;
   void enqueue(JvmtiDeferredEvent event) NOT_JVMTI_RETURN;
 
   // Sweeper support to keep nmethods from being zombied while in the queue.


### PR DESCRIPTION
I'd like to backport 8235456 to 13u as follow-up fix for JDK-8212160 that is already included to 13u.
The patch applies cleanly.
Minimal VM is built successfully after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8235456](https://bugs.openjdk.java.net/browse/JDK-8235456): Minimal VM is broken after JDK-8212160


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/97/head:pull/97`
`$ git checkout pull/97`
