### PR TITLE
8236124: Minimal VM slowdebug build failed after JDK-8212160

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -396,7 +396,7 @@ public:
   void set_should_post_on_exceptions(bool val) { _thread->set_should_post_on_exceptions_flag(val ? JNI_TRUE : JNI_FALSE); }
 
   // Thread local event queue, which doesn't require taking the Service_lock.
-  void enqueue_event(JvmtiDeferredEvent* event);
+  void enqueue_event(JvmtiDeferredEvent* event) NOT_JVMTI_RETURN;
   void post_events(JvmtiEnv* env);
 };
 


### PR DESCRIPTION
I'd like to backport 8236124 to 13u as follow-up fix for JDK-8212160 that is already included to 13u.
The patch applies cleanly.
Minimal VM slowdebug build succeeded after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8236124](https://bugs.openjdk.java.net/browse/JDK-8236124): Minimal VM slowdebug build failed after JDK-8212160


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/98/head:pull/98`
`$ git checkout pull/98`
