### PR TITLE
8236772: Fix build for windows 32-bit after 8212160 and 8234331.

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/CompiledMethodLoad/libCompiledZombie.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/CompiledMethodLoad/libCompiledZombie.cpp
@@ -67,7 +67,8 @@ void JNICALL VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     jvmti->RunAgentThread(agent_thread, GenerateEventsThread, NULL, JVMTI_THREAD_NORM_PRIORITY);
 }
 
-jint Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
+JNIEXPORT
+jint JNICALL Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
     jvmtiEnv* jvmti;
     vm->GetEnv((void**)&jvmti, JVMTI_VERSION_1_0);
 


### PR DESCRIPTION
I'd like to backport 8236772 to 13u as follow-up fix for JDK-8212160 that is already included to 13u.
The original patch contains two independent follow-up fixes for JDK-8212160 and JDK-8234331.
JDK-8234331 is not planned to be included to 13u, so only the part related to JDK-8212160 is backported.
libCompiledZombie test library is built successfully for Windows 32-bit after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236772](https://bugs.openjdk.java.net/browse/JDK-8236772): Fix build for windows 32-bit after 8212160 and 8234331.


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/99/head:pull/99`
`$ git checkout pull/99`
