### PR TITLE
8238710: LingeredApp doesn't log stdout/stderr if exits with non-zero code

### DIFF
--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -360,13 +360,15 @@ public class LingeredApp {
     }
 
     private void finishApp() {
-        OutputBuffer output = getOutput();
-        String msg =
-            " LingeredApp stdout: [" + output.getStdout() + "];\n" +
-            " LingeredApp stderr: [" + output.getStderr() + "]\n" +
-            " LingeredApp exitValue = " + appProcess.exitValue();
+        if (appProcess != null) {
+            OutputBuffer output = getOutput();
+            String msg =
+                    " LingeredApp stdout: [" + output.getStdout() + "];\n" +
+                    " LingeredApp stderr: [" + output.getStderr() + "]\n" +
+                    " LingeredApp exitValue = " + appProcess.exitValue();
 
-        System.err.println(msg);
+            System.err.println(msg);
+        }
     }
 
     /**
@@ -380,12 +382,14 @@ public class LingeredApp {
         // an exception before the LA actually starts
         if (appProcess != null) {
             waitAppTerminate();
+
+            finishApp();
+
             int exitcode = appProcess.exitValue();
             if (exitcode != 0) {
                 throw new IOException("LingeredApp terminated with non-zero exit code " + exitcode);
             }
         }
-        finishApp();
     }
 
     /**


### PR DESCRIPTION
Backport fix for bug JDK-8238710. Tested with tier1 and tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8238710](https://bugs.openjdk.java.net/browse/JDK-8238710): LingeredApp doesn't log stdout/stderr if exits with non-zero code


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/102/head:pull/102`
`$ git checkout pull/102`
