### PR TITLE
8234541: C1 emits an empty message when it inlines successfully

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -3810,7 +3810,7 @@ bool GraphBuilder::try_inline_full(ciMethod* callee, bool holder_known, bool ign
       INLINE_BAILOUT("total inlining greater than DesiredMethodLimit");
     }
     // printing
-    print_inlining(callee);
+    print_inlining(callee, "inline", /*success*/ true);
   }
 
   // NOTE: Bailouts from this point on, which occur at the
@@ -4332,16 +4332,11 @@ static void post_inlining_event(EventCompilerInlining* event,
 void GraphBuilder::print_inlining(ciMethod* callee, const char* msg, bool success) {
   CompileLog* log = compilation()->log();
   if (log != NULL) {
+    assert(msg != NULL, "inlining msg should not be null!");
     if (success) {
-      if (msg != NULL)
-        log->inline_success(msg);
-      else
-        log->inline_success("receiver is statically known");
+      log->inline_success(msg);
     } else {
-      if (msg != NULL)
-        log->inline_fail(msg);
-      else
-        log->inline_fail("reason unknown");
+      log->inline_fail(msg);
     }
   }
   EventCompilerInlining event;

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -381,7 +381,7 @@ class GraphBuilder {
   void append_unsafe_get_and_set_obj(ciMethod* callee, bool is_add);
   void append_char_access(ciMethod* callee, bool is_store);
 
-  void print_inlining(ciMethod* callee, const char* msg = NULL, bool success = true);
+  void print_inlining(ciMethod* callee, const char* msg, bool success = true);
 
   void profile_call(ciMethod* callee, Value recv, ciKlass* predicted_holder, Values* obj_args, bool inlined);
   void profile_return_type(Value ret, ciMethod* callee, ciMethod* m = NULL, int bci = -1);


### PR DESCRIPTION
Backport fix for bug JDK-8234541. Tested with tier1 and tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8234541](https://bugs.openjdk.java.net/browse/JDK-8234541): C1 emits an empty message when it inlines successfully


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/104/head:pull/104`
`$ git checkout pull/104`
