### PR TITLE
8234058: runtime/CompressedOops/CompressedClassPointers.java fails with 'Narrow klass base: 0x0000000000000000' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8024927
  * @summary Testing address of compressed class pointer space as best as possible.
- * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true
+ * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true & os.family != "windows"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
I'd like to backport JDK-8234058 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
Tested via jtreg with the tests in /runtime/CompressedOops.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8234058](https://bugs.openjdk.java.net/browse/JDK-8234058): runtime/CompressedOops/CompressedClassPointers.java fails with 'Narrow klass base: 0x0000000000000000' missing from stdout/stderr


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/107/head:pull/107`
`$ git checkout pull/107`
