### PR TITLE
8196969: JTreg Failure: serviceability/sa/ClhsdbJstack.java causes NPE

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/NMethod.java
@@ -306,12 +306,17 @@ public class NMethod extends CompiledMethod {
   /** This is only for use by the debugging system, and is only
       intended for use in the topmost frame, where we are not
       guaranteed to be at a PC for which we have a PCDesc. It finds
-      the PCDesc with realPC closest to the current PC. */
+      the PCDesc with realPC closest to the current PC that has
+      a valid scope decode offset. */
   public PCDesc getPCDescNearDbg(Address pc) {
     PCDesc bestGuessPCDesc = null;
     long bestDistance = 0;
     for (Address p = scopesPCsBegin(); p.lessThan(scopesPCsEnd()); p = p.addOffsetTo(pcDescSize)) {
       PCDesc pcDesc = new PCDesc(p);
+      if (pcDesc.getScopeDecodeOffset() == DebugInformationRecorder.SERIALIZED_NULL) {
+        // We've observed a serialized null decode offset. Ignore this PcDesc.
+        continue;
+      }
       // In case pc is null
       long distance = -pcDesc.getRealPC(this).minus(pc);
       if ((bestGuessPCDesc == null) ||

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackXcompStress.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Utils;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/**
+ * @test
+ * @bug 8196969
+ * @requires vm.hasSAandCanAttach
+ * @library /test/lib
+ * @run main/othervm ClhsdbJstackXcompStress
+ */
+public class ClhsdbJstackXcompStress {
+
+    private static final int MAX_ITERATIONS = 20;
+    private static final boolean DEBUG = false;
+
+    private static boolean isMatchCompiledFrame(List<String> output) {
+        List<String> filtered = output.stream().filter( s -> s.contains("Compiled frame"))
+                                               .collect(Collectors.toList());
+        System.out.println("DEBUG: " + filtered);
+        return !filtered.isEmpty() &&
+               filtered.stream().anyMatch( s -> s.contains("LingeredAppWithRecComputation") );
+    }
+
+    private static void runJstackInLoop(LingeredApp app) throws Exception {
+        boolean anyMatchedCompiledFrame = false;
+        for (int i = 0; i < MAX_ITERATIONS; i++) {
+            JDKToolLauncher launcher = JDKToolLauncher
+                    .createUsingTestJDK("jhsdb");
+            launcher.addToolArg("jstack");
+            launcher.addToolArg("--pid");
+            launcher.addToolArg(Long.toString(app.getPid()));
+
+            ProcessBuilder pb = new ProcessBuilder();
+            pb.command(launcher.getCommand());
+            Process jhsdb = pb.start();
+            OutputAnalyzer out = new OutputAnalyzer(jhsdb);
+
+            jhsdb.waitFor();
+
+            if (DEBUG) {
+                System.out.println(out.getStdout());
+                System.err.println(out.getStderr());
+            }
+
+            out.stderrShouldBeEmpty(); // NPE's are reported on the err stream
+            out.stdoutShouldNotContain("Error occurred during stack walking:");
+            out.stdoutShouldContain(LingeredAppWithRecComputation.THREAD_NAME);
+            List<String> stdoutList = Arrays.asList(out.getStdout().split("\\R"));
+            anyMatchedCompiledFrame = anyMatchedCompiledFrame || isMatchCompiledFrame(stdoutList);
+        }
+        if (!anyMatchedCompiledFrame) {
+             throw new RuntimeException("Expected jstack output to contain 'Compiled frame'");
+        }
+        System.out.println("DEBUG: jhsdb jstack did not throw NPE, as expected.");
+    }
+
+    public static void main(String... args) throws Exception {
+        LingeredApp app = null;
+        try {
+            List<String> vmArgs = List.of("-Xcomp",
+                                          "-XX:CompileCommand=dontinline,LingeredAppWithRecComputation.factorial",
+                                          "-XX:CompileCommand=compileonly,LingeredAppWithRecComputation.testLoop",
+                                          "-XX:CompileCommand=compileonly,LingeredAppWithRecComputation.factorial");
+            app = new LingeredAppWithRecComputation();
+            LingeredApp.startApp(vmArgs, app);
+            System.out.println("Started LingeredAppWithRecComputation with pid " + app.getPid());
+            runJstackInLoop(app);
+            System.out.println("Test Completed");
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw e;
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithRecComputation.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithRecComputation.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.apps.LingeredApp;
+
+public class LingeredAppWithRecComputation extends LingeredApp {
+
+    public static final String THREAD_NAME = "LingeredAppWithRecComputation.factorial()";
+
+    private long factorial(int n) {
+        if (n <= 1) {
+                return 1;
+        }
+        if (n == 2) {
+                return 2;
+        }
+        return n * factorial(n - 1);
+    }
+
+    public void testLoop() {
+        long result = 0;
+        long[] lastNResults = new long[20];
+        int i = 0;
+        int j = 0;
+        while (true) {
+            result = factorial(i);
+            lastNResults[j] = result;
+            if (i % 12 == 0) {
+                    i = -1; // reset i
+            }
+            if (j % 19 == 0) {
+                    j = -1; // reset j
+            }
+            i++; j++;
+        }
+    }
+
+    public static void main(String args[]) {
+        LingeredAppWithRecComputation app = new LingeredAppWithRecComputation();
+        Thread factorial = new Thread(() -> {
+            app.testLoop();
+        });
+        factorial.setName(THREAD_NAME);
+        factorial.start();
+        LingeredApp.main(args);
+    }
+ }


### PR DESCRIPTION
I'd like to backport 8196969 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1; new test fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8196969](https://bugs.openjdk.java.net/browse/JDK-8196969): JTreg Failure: serviceability/sa/ClhsdbJstack.java causes NPE


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/113/head:pull/113`
`$ git checkout pull/113`
