### PR TITLE
8234662: Sweeper should keep current nmethod alive before yielding for ICStub refills

### DIFF
--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -30,6 +30,7 @@
 #include "code/codeCache.hpp"
 #include "code/icBuffer.hpp"
 #include "gc/shared/barrierSet.hpp"
+#include "gc/shared/barrierSetNMethod.hpp"
 #include "gc/shared/gcBehaviours.hpp"
 #include "interpreter/bytecode.inline.hpp"
 #include "logging/log.hpp"
@@ -533,6 +534,18 @@ void CompiledMethod::cleanup_inline_caches(bool clean_all) {
     { CompiledICLocker ic_locker(this);
       if (cleanup_inline_caches_impl(false, clean_all)) {
         return;
+      }
+    }
+    BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
+    if (bs_nm != NULL) {
+      // We want to keep an invariant that nmethods found through iterations of a Thread's
+      // nmethods found in safepoints have gone through an entry barrier and are not armed.
+      // By calling this nmethod entry barrier from the sweeper, it plays along and acts
+      // like any other nmethod found on the stack of a thread (fewer surprises).
+      nmethod* nm = as_nmethod_or_null();
+      if (nm != NULL) {
+        bool alive = bs_nm->nmethod_entry_barrier(nm);
+        assert(alive, "should be alive");
       }
     }
     InlineCacheBuffer::refill_ic_stubs();

--- a/src/hotspot/share/gc/shared/barrierSetNMethod.hpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.hpp
@@ -37,9 +37,9 @@ class BarrierSetNMethod: public CHeapObj<mtGC> {
 
 protected:
   virtual int disarmed_value() const;
-  virtual bool nmethod_entry_barrier(nmethod* nm) = 0;
 
 public:
+  virtual bool nmethod_entry_barrier(nmethod* nm) = 0;
   virtual ByteSize thread_disarmed_offset() const = 0;
 
   static int nmethod_stub_entry_barrier(address* return_address_ptr);


### PR DESCRIPTION
I'd like to backport JDK-8234662 to 13u as a prerequisite for JDK-8235829.
JDK-8234662 adds a piece of code to CompiledMethod::cleanup_inline_caches() that is extracted to separate method (CompiledMethod::run_nmethod_entry_barrier()) and widely used in JDK-8235829.
The patch doesn't apply cleanly due to minor context difference in barrierSetNMethod.hpp (JDK-8230765 is not in 13u), reapplied manually.
Tested with tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8234662](https://bugs.openjdk.java.net/browse/JDK-8234662): Sweeper should keep current nmethod alive before yielding for ICStub refills


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/115/head:pull/115`
`$ git checkout pull/115`
