### PR TITLE
8241319: WB_GetCodeBlob doesn't have ResourceMark

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1461,6 +1461,7 @@ struct CodeBlobStub {
 };
 
 static jobjectArray codeBlob2objectArray(JavaThread* thread, JNIEnv* env, CodeBlobStub* cb) {
+  ResourceMark rm;
   jclass clazz = env->FindClass(vmSymbols::java_lang_Object()->as_C_string());
   CHECK_JNI_EXCEPTION_(env, NULL);
   jobjectArray result = env->NewObjectArray(4, clazz, NULL);


### PR DESCRIPTION
I'd like to backport JDK-8241319 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8241319](https://bugs.openjdk.java.net/browse/JDK-8241319): WB_GetCodeBlob doesn't have ResourceMark


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/117/head:pull/117`
`$ git checkout pull/117`
