### PR TITLE
8242283: Can't start JVM when java home path includes non-ASCII character

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4282,7 +4282,7 @@ static void file_attribute_data_to_stat(struct stat* sbuf, WIN32_FILE_ATTRIBUTE_
 
 static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path) {
   // Get required buffer size to convert to Unicode
-  int unicode_path_len = MultiByteToWideChar(CP_THREAD_ACP,
+  int unicode_path_len = MultiByteToWideChar(CP_ACP,
                                              MB_ERR_INVALID_CHARS,
                                              char_path, -1,
                                              NULL, 0);
@@ -4292,7 +4292,7 @@ static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path) {
 
   *unicode_path = NEW_C_HEAP_ARRAY(WCHAR, unicode_path_len, mtInternal);
 
-  int result = MultiByteToWideChar(CP_THREAD_ACP,
+  int result = MultiByteToWideChar(CP_ACP,
                                    MB_ERR_INVALID_CHARS,
                                    char_path, -1,
                                    *unicode_path, unicode_path_len);


### PR DESCRIPTION
I'd like to backport JDK-8242283 to jdk13u for parity with jdk11u.
It's a partial fix related only to HotSpot. The scope of fixes is the same as for jdk11u. The reasons is the same. 
The original (partial) patch applied cleanly.

Tested manually. This patch is applied after JDK-8240197 and it fixes the following scenario for example:
    System locale: Chinese (Simplified, China) 
    Current format: English (United States) 
    Active code page: 936 
    
Before the patch:
    /cygdrive/y/projects/jdk13u-dev-fork/build/windows-x86_64-server-release_中文_/images/jdk/bin
    $ ./java -version
    Error occurred during initialization of VM
    Failed setting boot class path.
    
After the patch:
    /cygdrive/y/projects/jdk13u-dev-fork/build/windows-x86_64-server-release_中文_/images/jdk/bin
    $ ./java -version
    openjdk version "13.0.7-internal" 2021-04-20
    OpenJDK Runtime Environment (build 13.0.7-internal+0-adhoc.omikhaltsova.jdk13u-dev-fork)
    OpenJDK 64-Bit Server VM (build 13.0.7-internal+0-adhoc.omikhaltsova.jdk13u-dev-fork, mixed mode, sharing)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242283](https://bugs.openjdk.java.net/browse/JDK-8242283): Can't start JVM when java home path includes non-ASCII character


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/120/head:pull/120`
`$ git checkout pull/120`
