### PR TITLE
8245801: StressRecompilation triggers assert "redundunt OSR recompilation detected. memory leak in CodeCache!"

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2995,9 +2995,9 @@ void InstanceKlass::adjust_default_methods(bool* trace_name_printed) {
 void InstanceKlass::add_osr_nmethod(nmethod* n) {
 #ifndef PRODUCT
   if (TieredCompilation) {
-      nmethod * prev = lookup_osr_nmethod(n->method(), n->osr_entry_bci(), n->comp_level(), true);
-      assert(prev == NULL || !prev->is_in_use(),
-      "redundunt OSR recompilation detected. memory leak in CodeCache!");
+    nmethod* prev = lookup_osr_nmethod(n->method(), n->osr_entry_bci(), n->comp_level(), true);
+    assert(prev == NULL || !prev->is_in_use() || StressRecompilation,
+           "redundant OSR recompilation detected. memory leak in CodeCache!");
   }
 #endif
   // only one compilation can be active

--- a/test/hotspot/jtreg/compiler/c2/TestStressRecompilation.java
+++ b/test/hotspot/jtreg/compiler/c2/TestStressRecompilation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8245801
+ * @requires vm.debug
+ * @summary Test running with StressRecompilation enabled.
+ * @run main/othervm -Xcomp -XX:+IgnoreUnrecognizedVMOptions -XX:+StressRecompilation
+ *                   compiler.c2.TestStressRecompilation
+ */
+
+package compiler.c2;
+
+public class TestStressRecompilation {
+
+    public static void main(String[] args) {
+        System.out.println("Test passed.");
+    }
+}


### PR DESCRIPTION
I'd like to backport JDK-8245801 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8245801](https://bugs.openjdk.java.net/browse/JDK-8245801): StressRecompilation triggers assert "redundunt OSR recompilation detected. memory leak in CodeCache!"


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/128/head:pull/128`
`$ git checkout pull/128`
