### PR TITLE
8246027: Minimal fastdebug build broken after JDK-8245801

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2996,7 +2996,7 @@ void InstanceKlass::add_osr_nmethod(nmethod* n) {
 #ifndef PRODUCT
   if (TieredCompilation) {
     nmethod* prev = lookup_osr_nmethod(n->method(), n->osr_entry_bci(), n->comp_level(), true);
-    assert(prev == NULL || !prev->is_in_use() || StressRecompilation,
+    assert(prev == NULL || !prev->is_in_use() COMPILER2_PRESENT(|| StressRecompilation),
            "redundant OSR recompilation detected. memory leak in CodeCache!");
   }
 #endif


### PR DESCRIPTION
I'd like to backport JDK-8246027 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8246027](https://bugs.openjdk.java.net/browse/JDK-8246027): Minimal fastdebug build broken after JDK-8245801


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/129/head:pull/129`
`$ git checkout pull/129`
