### PR TITLE
8259707: LDAP channel binding does not work with StartTLS extension

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,6 +351,7 @@ final public class StartTlsResponseImpl extends StartTlsResponse {
                 System.out.println(
                         "StartTLS: Calling sslSocket.startHandshake");
             }
+            ldapConnection.setHandshakeCompletedListener(sslSocket);
             sslSocket.startHandshake();
             if (debug) {
                 System.out.println(


### PR DESCRIPTION
I'd like to port this fix to 13u. Applied clean, all relevant tests run as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259707](https://bugs.openjdk.java.net/browse/JDK-8259707): LDAP channel binding does not work with StartTLS extension


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/131/head:pull/131`
`$ git checkout pull/131`
