### PR TITLE
8245283: JFR: Can't handle constant dynamic used by Jacoco agent

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -683,6 +683,10 @@ static u2 position_stream_after_cp(const ClassFileStream* stream) {
         }
       }
       continue;
+      case JVM_CONSTANT_Dynamic:
+        stream->skip_u2_fast(1);
+        stream->skip_u2_fast(1);
+      continue;
       default:
         assert(false, "error in skip logic!");
         break;


### PR DESCRIPTION
I'd like to backport JDK-8245283 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1 and jdk/jfr tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8245283](https://bugs.openjdk.java.net/browse/JDK-8245283): JFR: Can't handle constant dynamic used by Jacoco agent


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/132/head:pull/132`
`$ git checkout pull/132`
