### PR TITLE
8232905: JFR fails with assertion: assert(t->unflushed_size() == 0) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -419,18 +419,17 @@ void JfrStorage::discard_oldest(Thread* thread) {
       assert(oldest_age_node->identity() == NULL, "invariant");
       BufferPtr const buffer = oldest_age_node->retired_buffer();
       assert(buffer->retired(), "invariant");
-      discarded_size += buffer->unflushed_size();
+      discarded_size += buffer->discard();
+      assert(buffer->unflushed_size() == 0, "invariant");
       num_full_post_discard = control().decrement_full();
+      mspace_release_full(oldest_age_node, _age_mspace);
       if (buffer->transient()) {
         mspace_release_full(buffer, _transient_mspace);
-        mspace_release_full(oldest_age_node, _age_mspace);
         continue;
-      } else {
-        mspace_release_full(oldest_age_node, _age_mspace);
-        buffer->reinitialize();
-        buffer->release(); // publish
-        break;
       }
+      buffer->reinitialize();
+      buffer->release(); // publish
+      break;
     }
     JfrBuffer_lock->unlock();
     const size_t number_of_discards = num_full_pre_discard - num_full_post_discard;


### PR DESCRIPTION
I'd like to backport JDK-8232905 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1 and jdk/jfr tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8232905](https://bugs.openjdk.java.net/browse/JDK-8232905): JFR fails with assertion: assert(t->unflushed_size() == 0) failed: invariant


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/134/head:pull/134`
`$ git checkout pull/134`
