### PR TITLE
8260308: Update LogCompilation junit to 4.13.1

### DIFF
--- a/src/utils/LogCompilation/pom.xml
+++ b/src/utils/LogCompilation/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
I'd like to backport JDK-8260308 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1 and compiler/compilercontrol/logcompilation tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8260308](https://bugs.openjdk.java.net/browse/JDK-8260308): Update LogCompilation junit to 4.13.1


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/135/head:pull/135`
`$ git checkout pull/135`
