### PR TITLE
8240711: TestJstatdPort.java failed due to "ExportException: Port already in use:"

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -70,6 +70,8 @@ public final class JstatdTest {
     private Long jstatdPid;
     private boolean withExternalRegistry = false;
 
+    private volatile static boolean portInUse;
+
     public void setServerName(String serverName) {
         this.serverName = serverName;
     }
@@ -84,20 +86,10 @@ public final class JstatdTest {
 
     private Long waitOnTool(ProcessThread thread) throws Throwable {
         long pid = thread.getPid();
-
-        Throwable t = thread.getUncaught();
-        if (t != null) {
-            if (t.getMessage().contains(
-                    "java.rmi.server.ExportException: Port already in use")) {
-                System.out.println("Port already in use. Trying to restart with a new one...");
-                Thread.sleep(100);
-                return null;
-            } else {
-                // Something unexpected has happened
-                throw new Throwable(t);
-            }
+        if (portInUse) {
+            System.out.println("Port already in use. Trying to restart with a new one...");
+            return null;
         }
-
         System.out.println(thread.getName() + " pid: " + pid);
         return pid;
     }
@@ -274,6 +266,7 @@ public final class JstatdTest {
     }
 
     private ProcessThread tryToSetupJstatdProcess() throws Throwable {
+        portInUse = false;
         ProcessThread jstatdThread = new ProcessThread("Jstatd-Thread",
                 JstatdTest::isJstadReady, getJstatdCmd());
         try {
@@ -296,6 +289,10 @@ public final class JstatdTest {
     }
 
     private static boolean isJstadReady(String line) {
+        if (line.contains("Port already in use")) {
+            portInUse = true;
+            return true;
+        }
         return line.startsWith("jstatd started (bound to ");
     }
 


### PR DESCRIPTION
I'd like to backport JDK-8240711 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
sun/tools/jstatd tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8240711](https://bugs.openjdk.java.net/browse/JDK-8240711): TestJstatdPort.java failed due to "ExportException: Port already in use:"


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/141/head:pull/141`
`$ git checkout pull/141`
