### PR TITLE
8250911: [windows] os::pd_map_memory error detection broken

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4921,7 +4921,7 @@ char* os::pd_map_memory(int fd, const char* file_name, size_t file_offset,
 
   hFile = CreateFile(file_name, GENERIC_READ, FILE_SHARE_READ, NULL,
                      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-  if (hFile == NULL) {
+  if (hFile == INVALID_HANDLE_VALUE) {
     log_info(os)("CreateFile() failed: GetLastError->%ld.", GetLastError());
     return NULL;
   }


### PR DESCRIPTION
I'd like to backport JDK-8250911 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8250911](https://bugs.openjdk.java.net/browse/JDK-8250911): [windows] os::pd_map_memory error detection broken


### Download
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/147/head:pull/147`
`$ git checkout pull/147`
