### PR TITLE
8263425: AArch64: two potential bugs in C1 LIRGenerator::generate_address()

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -173,7 +173,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
     if (large_disp != 0) {
       LIR_Opr tmp = new_pointer_register();
       if (Assembler::operand_valid_for_add_sub_immediate(large_disp)) {
-        __ add(tmp, tmp, LIR_OprFact::intptrConst(large_disp));
+        __ add(index, LIR_OprFact::intptrConst(large_disp), tmp);
         index = tmp;
       } else {
         __ move(tmp, LIR_OprFact::intptrConst(large_disp));
@@ -190,7 +190,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
   }
 
   // at this point we either have base + index or base + displacement
-  if (large_disp == 0) {
+  if (large_disp == 0 && index->is_register()) {
     return new LIR_Address(base, index, type);
   } else {
     assert(Address::offset_ok_for_immed(large_disp, 0), "must be");


### PR DESCRIPTION
Hi!
I'd like to backport JDK-8263425 to 13u to fix obvious bugs.  The patch applies cleanly.  Pass basic tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263425](https://bugs.openjdk.java.net/browse/JDK-8263425): AArch64: two potential bugs in C1 LIRGenerator::generate_address()


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/150/head:pull/150`
`$ git checkout pull/150`

To update a local copy of the PR:
`$ git checkout pull/150`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/150/head`
