### PR TITLE
8239365: ProcessBuilder test modifications for AIX execution

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -74,6 +74,10 @@ public class Basic {
     /* used for AIX only */
     static final String libpath = System.getenv("LIBPATH");
 
+    /* Used for regex String matching for long error messages */
+    static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error=13)";
+    static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error=2)";
+
     /**
      * Returns the number of milliseconds since time given by
      * startNanoTime, which must have been previously returned from a
@@ -305,7 +309,7 @@ public class Basic {
         } catch (IOException e) {
             String m = e.getMessage();
             if (EnglishUnix.is() &&
-                ! matches(m, "Permission denied"))
+                ! matches(m, PERMISSION_DENIED_ERROR_MSG))
                 unexpected(e);
         } catch (Throwable t) { unexpected(t); }
     }
@@ -415,7 +419,7 @@ public class Basic {
                         } catch (IOException e) {
                             String m = e.getMessage();
                             if (EnglishUnix.is() &&
-                                ! matches(m, "No such file"))
+                                ! matches(m, NO_SUCH_FILE_ERROR_MSG))
                                 unexpected(e);
                         } catch (Throwable t) { unexpected(t); }
 
@@ -428,7 +432,7 @@ public class Basic {
                         } catch (IOException e) {
                             String m = e.getMessage();
                             if (EnglishUnix.is() &&
-                                ! matches(m, "No such file"))
+                                ! matches(m, NO_SUCH_FILE_ERROR_MSG))
                                 unexpected(e);
                         } catch (Throwable t) { unexpected(t); }
 
@@ -1982,7 +1986,7 @@ public class Basic {
         } catch (IOException e) {
             String m = e.getMessage();
             if (EnglishUnix.is() &&
-                ! matches(m, "No such file or directory"))
+                ! matches(m, NO_SUCH_FILE_ERROR_MSG))
                 unexpected(e);
         } catch (Throwable t) { unexpected(t); }
 
@@ -1998,8 +2002,8 @@ public class Basic {
                 String m = e.getMessage();
                 Pattern p = Pattern.compile(programName);
                 if (! matches(m, programName)
-                    || (EnglishUnix.is()
-                        && ! matches(m, "No such file or directory")))
+                    || (EnglishUnix.is() &&
+                        ! matches(m, NO_SUCH_FILE_ERROR_MSG)))
                     unexpected(e);
             } catch (Throwable t) { unexpected(t); }
 
@@ -2015,7 +2019,7 @@ public class Basic {
             String m = e.getMessage();
             if (! matches(m, "in directory")
                 || (EnglishUnix.is() &&
-                    ! matches(m, "No such file or directory")))
+                    ! matches(m, NO_SUCH_FILE_ERROR_MSG)))
                 unexpected(e);
         } catch (Throwable t) { unexpected(t); }
 
@@ -2282,7 +2286,7 @@ public class Basic {
             new File("./emptyCommand").delete();
             String m = e.getMessage();
             if (EnglishUnix.is() &&
-                ! matches(m, "Permission denied"))
+                ! matches(m, PERMISSION_DENIED_ERROR_MSG))
                 unexpected(e);
         } catch (Throwable t) { unexpected(t); }
 


### PR DESCRIPTION
I'd like to backport JDK-8239365 to jdk13u for parity with jdk11u.
The original patch applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8239365](https://bugs.openjdk.java.net/browse/JDK-8239365): ProcessBuilder test modifications for AIX execution


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/151/head:pull/151`
`$ git checkout pull/151`

To update a local copy of the PR:
`$ git checkout pull/151`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/151/head`
