### PR TITLE
8237977: Further update javax/net/ssl/compatibility/Compatibility.java

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/CipherSuite.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/CipherSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,7 +147,7 @@ public enum CipherSuite {
     TLS_DHE_RSA_WITH_AES_128_CBC_SHA256(
             0x0067, KeyExAlgorithm.DHE_RSA, Protocol.TLSV1_2, Protocol.TLSV1_2),
     TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA(
-            0x004C, KeyExAlgorithm.ECDH_ECDSA, Protocol.TLSV1, Protocol.TLSV1_2),
+            0x004C, KeyExAlgorithm.ECDH_ECDSA, Protocol.SSLV3, Protocol.TLSV1_2),
     TLS_DHE_DSS_WITH_AES_128_CBC_SHA256(
             0x0040, KeyExAlgorithm.DHE_DSS, Protocol.TLSV1_2, Protocol.TLSV1_2),
     TLS_RSA_WITH_AES_256_CBC_SHA256(
@@ -159,7 +159,7 @@ public enum CipherSuite {
     TLS_DH_anon_WITH_AES_256_CBC_SHA(
             0x003A, KeyExAlgorithm.DH_ANON, Protocol.SSLV3, Protocol.TLSV1_2),
     TLS_DHE_RSA_WITH_AES_256_CBC_SHA(
-            0x0039, KeyExAlgorithm.DHE_RSA, Protocol.TLSV1, Protocol.TLSV1_2),
+            0x0039, KeyExAlgorithm.DHE_RSA, Protocol.SSLV3, Protocol.TLSV1_2),
     TLS_DHE_DSS_WITH_AES_256_CBC_SHA(
             0x0038, KeyExAlgorithm.DHE_DSS, Protocol.TLSV1_2, Protocol.TLSV1_2),
     TLS_RSA_WITH_AES_256_CBC_SHA(

--- a/test/jdk/javax/net/ssl/compatibility/Cert.java
+++ b/test/jdk/javax/net/ssl/compatibility/Cert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -387,6 +387,14 @@ public enum Cert {
         this.keyAlgorithm = keyAlgorithm;
         this.certMaterials = certMaterials;
         this.privKeyMaterials = privKeyMaterials;
+    }
+
+    public static Cert[] getCerts(String... certNames) {
+        Cert[] certs = new Cert[certNames.length];
+        for(int i = 0; i < certNames.length; i++) {
+            certs[i] = Cert.valueOf(certNames[i]);
+        }
+        return certs;
     }
 
     // Two certificates (mainCert and exampleCert) are selected to respect the

--- a/test/jdk/javax/net/ssl/compatibility/JdkInfo.java
+++ b/test/jdk/javax/net/ssl/compatibility/JdkInfo.java
@@ -1,5 +1,6 @@
+
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +22,9 @@
  * questions.
  */
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /*
  * It represents a JDK with some specific attributes.
  * If two JdkInfo instances have the same version value, the instances are
@@ -32,7 +36,9 @@ public class JdkInfo {
 
     public final String version;
     public final String supportedProtocols;
+    public final String enabledProtocols;
     public final String supportedCipherSuites;
+    public final String enabledCipherSuites;
     public final boolean supportsSNI;
     public final boolean supportsALPN;
 
@@ -48,14 +54,18 @@ public class JdkInfo {
         String[] attributes = Utils.split(output, Utils.PARAM_DELIMITER);
         version = attributes[0].replaceAll(".*=", "");
         supportedProtocols = attributes[1].replaceAll(".*=", "");
-        supportedCipherSuites = attributes[2].replaceAll(".*=", "");
-        supportsSNI = Boolean.valueOf(attributes[3].replaceAll(".*=", ""));
-        supportsALPN = Boolean.valueOf(attributes[4].replaceAll(".*=", ""));
+        enabledProtocols = attributes[2].replaceAll(".*=", "");
+        supportedCipherSuites = attributes[3].replaceAll(".*=", "");
+        enabledCipherSuites = attributes[4].replaceAll(".*=", "");
+        supportsSNI = Boolean.valueOf(attributes[5].replaceAll(".*=", ""));
+        supportsALPN = Boolean.valueOf(attributes[6].replaceAll(".*=", ""));
     }
 
     // Determines the specific attributes for the specified JDK.
     private static String jdkAttributes(String jdkPath) {
-        return ProcessUtils.java(jdkPath, null, JdkUtils.class).getOutput();
+        Map<String, String> props = new LinkedHashMap<>();
+        props.put("java.security.properties", Utils.SECURITY_PROPERTIES_FILE);
+        return ProcessUtils.java(jdkPath, props, JdkUtils.class).getOutput();
     }
 
     @Override
@@ -89,7 +99,15 @@ public class JdkInfo {
         return supportedProtocols.contains(protocol.name);
     }
 
+    public boolean enablesProtocol(Protocol protocol) {
+        return enabledProtocols.contains(protocol.name);
+    }
+
     public boolean supportsCipherSuite(CipherSuite cipherSuite) {
         return supportedCipherSuites.contains(cipherSuite.name());
+    }
+
+    public boolean enablesCipherSuite(CipherSuite cipherSuite) {
+        return enabledCipherSuites.contains(cipherSuite.name());
     }
 }

--- a/test/jdk/javax/net/ssl/compatibility/JdkUtils.java
+++ b/test/jdk/javax/net/ssl/compatibility/JdkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLSocketFactory;
 
 /*
  * This class is used for returning some specific JDK information.
@@ -34,7 +33,9 @@ public class JdkUtils {
 
     public static final String JAVA_RUNTIME_VERSION = "javaRuntimeVersion";
     public static final String SUPPORTED_PROTOCOLS = "supportedProtocols";
+    public static final String ENABLED_PROTOCOLS = "enabledProtocols";
     public static final String SUPPORTED_CIPHER_SUITES = "supportedCipherSuites";
+    public static final String ENABLED_CIPHER_SUITES = "enabledCipherSuites";
     public static final String SUPPORTS_SNI = "supportsSNI";
     public static final String SUPPORTS_ALPN = "supportsALPN";
 
@@ -43,39 +44,34 @@ public class JdkUtils {
         return System.getProperty("java.runtime.version");
     }
 
-    private static String supportedProtocols() {
-        StringBuilder protocols = new StringBuilder();
-        for (String protocol : new String[] {
-                "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" }) {
-            if (supportsProtocol(protocol)) {
-                protocols.append(protocol).append(Utils.VALUE_DELIMITER);
-            }
-        }
-        return protocols.toString().substring(
-                0, protocols.toString().length() - 1);
+    private static String supportedProtocols()
+            throws NoSuchAlgorithmException {
+        String[] protocols = SSLContext.getDefault()
+                .createSSLEngine().getSupportedProtocols();
+        return Utils.join(Utils.VALUE_DELIMITER, protocols).toString();
     }
 
-    private static boolean supportsProtocol(String protocol) {
-        boolean supported = true;
-        try {
-            SSLContext.getInstance(protocol);
-        } catch (NoSuchAlgorithmException e) {
-            supported = false;
-        }
-        return supported;
+    private static String enabledProtocols()
+            throws NoSuchAlgorithmException {
+        String[] protocols = SSLContext.getDefault()
+                .createSSLEngine().getEnabledProtocols();
+        return Utils.join(Utils.VALUE_DELIMITER, protocols).toString();
     }
 
-    private static String supportedCipherSuites() {
-        StringBuilder cipherSuites = new StringBuilder();
-        String[] supportedCipherSuites = ((SSLSocketFactory) SSLSocketFactory
-                .getDefault()).getSupportedCipherSuites();
-        for (int i = 0; i < supportedCipherSuites.length - 1; i++) {
-            cipherSuites.append(supportedCipherSuites[i])
-                    .append(Utils.VALUE_DELIMITER);
-        }
-        cipherSuites.append(
-                supportedCipherSuites[supportedCipherSuites.length - 1]);
-        return cipherSuites.toString();
+    private static String supportedCipherSuites()
+            throws NoSuchAlgorithmException {
+        String[] supportedCipherSuites = SSLContext.getDefault()
+                .createSSLEngine().getSupportedCipherSuites();
+        return Utils.join(Utils.VALUE_DELIMITER, supportedCipherSuites)
+                .toString();
+    }
+
+    private static String enabledCipherSuites()
+            throws NoSuchAlgorithmException {
+        String[] enabledCipherSuites = SSLContext.getDefault()
+                .createSSLEngine().getEnabledCipherSuites();
+        return Utils.join(Utils.VALUE_DELIMITER, enabledCipherSuites)
+                .toString();
     }
 
     // Checks if SNI is supported by the JDK build.
@@ -104,7 +100,9 @@ public class JdkUtils {
         System.out.print(Utils.join(Utils.PARAM_DELIMITER,
                 attr(JAVA_RUNTIME_VERSION, javaRuntimeVersion()),
                 attr(SUPPORTED_PROTOCOLS, supportedProtocols()),
+                attr(ENABLED_PROTOCOLS, enabledProtocols()),
                 attr(SUPPORTED_CIPHER_SUITES, supportedCipherSuites()),
+                attr(ENABLED_CIPHER_SUITES, enabledCipherSuites()),
                 attr(SUPPORTS_SNI, supportsSNI()),
                 attr(SUPPORTS_ALPN, supportsALPN())));
     }

--- a/test/jdk/javax/net/ssl/compatibility/Server.java
+++ b/test/jdk/javax/net/ssl/compatibility/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,14 +54,6 @@ public class Server {
         this(certs, 0);
     }
 
-    private void setEnabledCipherSuites(String... cipherSuites) {
-        serverSocket.setEnabledCipherSuites(cipherSuites);
-    }
-
-    private void setEnabledProtocols(String... protocols) {
-        serverSocket.setEnabledProtocols(protocols);
-    }
-
     private void setNeedClientAuth(boolean needClientAuth) {
         serverSocket.setNeedClientAuth(needClientAuth);
     }
@@ -100,8 +92,7 @@ public class Server {
 
     public static void main(String[] args) throws IOException {
         System.out.println("----- Server start -----");
-        String protocol = System.getProperty(Utils.PROP_PROTOCOL);
-        String cipherSuite = System.getProperty(Utils.PROP_CIPHER_SUITE);
+        String certs = System.getProperty(Utils.PROP_CERTS);
         boolean clientAuth
                 = Boolean.getBoolean(Utils.PROP_CLIENT_AUTH);
         String appProtocols = System.getProperty(Utils.PROP_APP_PROTOCOLS);
@@ -112,19 +103,16 @@ public class Server {
 
         System.out.println(Utils.join(Utils.PARAM_DELIMITER,
                 "ServerJDK=" + System.getProperty(Utils.PROP_SERVER_JDK),
-                "Protocol=" + protocol,
-                "CipherSuite=" + cipherSuite,
                 "ClientAuth=" + clientAuth,
                 "AppProtocols=" + appProtocols));
 
         Status status = Status.SUCCESS;
         Server server = null;
         try {
-            server = new Server(Cert.getCerts(CipherSuite.cipherSuite(cipherSuite)));
+            server = new Server(
+                    Cert.getCerts(Utils.split(certs, Utils.VALUE_DELIMITER)));
             System.out.println("port=" + server.getPort());
             server.setNeedClientAuth(clientAuth);
-            server.setEnabledProtocols(protocol);
-            server.setEnabledCipherSuites(cipherSuite);
             if (appProtocols != null) {
                 if (supportsALPN) {
                     server.setApplicationProtocols(

--- a/test/jdk/javax/net/ssl/compatibility/TestCase.java
+++ b/test/jdk/javax/net/ssl/compatibility/TestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,14 @@ public class TestCase {
     public final JdkInfo clientJdk;
     public final UseCase useCase;
 
+    public final boolean protocolSupportsCipherSuite;
+
+    public final boolean serverEnablesProtocol;
+    public final boolean serverEnablesCipherSuite;
+
+    public final boolean clientSupportsProtocol;
+    public final boolean clientSupportsCipherSuite;
+
     public final boolean negativeCaseOnServer;
     public final boolean negativeCaseOnClient;
 
@@ -40,10 +48,20 @@ public class TestCase {
         this.clientJdk = clientJdk;
         this.useCase = useCase;
 
-        negativeCaseOnServer = useCase.negativeCase
-                || !serverJdk.supportsCipherSuite(useCase.cipherSuite);
-        negativeCaseOnClient = useCase.negativeCase
-                || !clientJdk.supportsCipherSuite(useCase.cipherSuite);
+        serverEnablesProtocol = serverJdk.enablesProtocol(useCase.protocol);
+        serverEnablesCipherSuite = serverJdk.enablesCipherSuite(useCase.cipherSuite);
+
+        clientSupportsProtocol = clientJdk.supportsProtocol(useCase.protocol);
+        clientSupportsCipherSuite = clientJdk.supportsCipherSuite(useCase.cipherSuite);
+
+        protocolSupportsCipherSuite = useCase.protocolSupportsCipherSuite;
+
+        negativeCaseOnServer = !protocolSupportsCipherSuite
+                || !serverEnablesProtocol
+                || !serverEnablesCipherSuite;
+        negativeCaseOnClient = !protocolSupportsCipherSuite
+                || !clientSupportsProtocol
+                || !clientSupportsCipherSuite;
     }
 
     public Status getStatus() {
@@ -52,6 +70,45 @@ public class TestCase {
 
     public void setStatus(Status status) {
         this.status = status;
+    }
+
+    public boolean isNegative() {
+        return negativeCaseOnServer || negativeCaseOnClient;
+    }
+
+    public boolean isFailed() {
+        return status == Status.FAIL || status == Status.UNEXPECTED_SUCCESS;
+    }
+
+    public String negativeCaseReason() {
+        return Utils.join(". ",
+                !protocolSupportsCipherSuite
+                        ? "Protocol doesn't support cipher suite"
+                        : "",
+                !serverEnablesProtocol
+                        ? "Server doesn't enable protocol"
+                        : "",
+                !serverEnablesCipherSuite
+                        ? "Server doesn't enable cipher suite"
+                        : "",
+                !clientSupportsProtocol
+                        ? "Client doesn't support protocol"
+                        : "",
+                !clientSupportsCipherSuite
+                        ? "Client doesn't support cipher suite"
+                        : "");
+    }
+
+    public String reason() {
+        if (status == Status.SUCCESS) {
+            return "";
+        }
+
+        if (status == Status.EXPECTED_FAIL && isNegative()) {
+            return negativeCaseReason();
+        }
+
+        return "Refer to log at case hyperlink for details...";
     }
 
     @Override

--- a/test/jdk/javax/net/ssl/compatibility/UseCase.java
+++ b/test/jdk/javax/net/ssl/compatibility/UseCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ public class UseCase {
             = Boolean.getBoolean("fullCipherSuites");
 
     public static final Protocol[] PROTOCOLS = new Protocol[] {
+            Protocol.SSLV3,
             Protocol.TLSV1,
             Protocol.TLSV1_1,
             Protocol.TLSV1_2,
@@ -148,7 +149,7 @@ public class UseCase {
     public final ServerName serverName;
     public final AppProtocol appProtocol;
 
-    public final boolean negativeCase;
+    public final boolean protocolSupportsCipherSuite;
 
     public UseCase(
             Protocol protocol,
@@ -162,7 +163,7 @@ public class UseCase {
         this.serverName = serverName;
         this.appProtocol = appProtocol;
 
-        negativeCase = !cipherSuite.supportedByProtocol(protocol);
+        protocolSupportsCipherSuite = cipherSuite.supportedByProtocol(protocol);
     }
 
     @Override

--- a/test/jdk/javax/net/ssl/compatibility/Utils.java
+++ b/test/jdk/javax/net/ssl/compatibility/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ public class Utils {
 
     /* ***** Properties ***** */
     public static final String PROP_PORT = "test.port";
+    public static final String PROP_CERTS = "test.certs";
     public static final String PROP_PROTOCOL = "test.protocol";
     public static final String PROP_CIPHER_SUITE = "test.cipher.suite";
     public static final String PROP_CLIENT_AUTH = "test.client.auth";
@@ -67,6 +68,11 @@ public class Utils {
             = "test.negative.case.on.server";
     public static final String PROP_NEGATIVE_CASE_ON_CLIENT
             = "test.negative.case.on.client";
+
+    public static final boolean DEBUG = Boolean.getBoolean("debug");
+    public static final String SECURITY_PROPERTIES_FILE = System.getProperty(
+            "test.security.properties",
+            System.getProperty("test.src") + "/java.security");
 
     public static final int TIMEOUT = 10000;
     public static final char[] PASSWORD = "testpass".toCharArray();
@@ -147,13 +153,20 @@ public class Utils {
         return bytes;
     }
 
-    public static String join(String delimiter, String... values) {
+    @SuppressWarnings("unchecked")
+    public static <T> String join(String delimiter, T... values) {
         StringBuilder result = new StringBuilder();
         if (values != null && values.length > 0) {
             for (int i = 0; i < values.length - 1; i++) {
-                result.append(values[i]).append(delimiter);
+                if (values[i] != null && !values[i].toString().isEmpty()) {
+                    result.append(values[i]).append(delimiter);
+                }
             }
-            result.append(values[values.length - 1]);
+
+            if (values[values.length - 1] != null
+                    && !values[values.length - 1].toString().isEmpty()) {
+                result.append(values[values.length - 1]);
+            }
         }
         return result.toString();
     }


### PR DESCRIPTION
I'd like to backport JDK-8237977 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8237977](https://bugs.openjdk.java.net/browse/JDK-8237977): Further update javax/net/ssl/compatibility/Compatibility.java


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/153/head:pull/153`
`$ git checkout pull/153`

To update a local copy of the PR:
`$ git checkout pull/153`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/153/head`
