### PR TITLE
8244573: java.lang.ArrayIndexOutOfBoundsException thrown for malformed class file

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Code_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Code_attribute.java
@@ -125,7 +125,7 @@ public class Code_attribute extends Attribute {
 
             Instruction current = null;
             int pc = 0;
-            Instruction next = new Instruction(code, pc);
+            Instruction next = (pc < code.length ? new Instruction(code, pc) : null);
 
         };
     }

--- a/test/langtools/tools/javap/8244573/Malformed.jcod
+++ b/test/langtools/tools/javap/8244573/Malformed.jcod
@@ -1,0 +1,51 @@
+class Malformed {
+  0xCAFEBABE;
+  0; // minor version
+  57; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "java/lang/Object"; // #4
+    Utf8 "<init>"; // #5
+    Utf8 "()V"; // #6
+    class #8; // #7
+    Utf8 "Malformed"; // #8
+    Utf8 "Code"; // #9
+  } // Constant Pool
+
+  0x0020; // access
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // fields
+  } // fields
+
+  [] { // methods
+    { // Member
+      0x0000; // access
+      #5; // name_cpx
+      #6; // sig_cpx
+      [] { // Attributes
+        Attr(#9) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [] { // Attributes
+  } // Attributes
+} // end class Malformed
+

--- a/test/langtools/tools/javap/8244573/T8244573.java
+++ b/test/langtools/tools/javap/8244573/T8244573.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8244573
+ * @summary javap, java.lang.ArrayIndexOutOfBoundsException thrown for malformed class file
+ * @build Malformed
+ * @run main T8244573
+ * @modules jdk.jdeps/com.sun.tools.javap
+ */
+import java.io.PrintWriter;
+
+public class T8244573 {
+
+    public static void main(String args[]) throws Exception {
+        if (com.sun.tools.javap.Main.run(new String[]{"-c", System.getProperty("test.classes") + "/Malformed.class"},
+                new PrintWriter(System.out)) != 0) {
+            throw new AssertionError();
+        }
+    }
+}


### PR DESCRIPTION
I'd like to backport JDK-8244573 to 13u for parity with 11u.
The patch applies cleanly.
Tested with tier1; new test fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8244573](https://bugs.openjdk.java.net/browse/JDK-8244573): java.lang.ArrayIndexOutOfBoundsException thrown for malformed class file


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/155/head:pull/155`
`$ git checkout pull/155`

To update a local copy of the PR:
`$ git checkout pull/155`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/155/head`
