### PR TITLE
8234779: Provide idiom for declaring classes noncopyable

### DIFF
--- a/src/hotspot/os/aix/os_perf_aix.cpp
+++ b/src/hotspot/os/aix/os_perf_aix.cpp
@@ -28,6 +28,7 @@
 #include "os_aix.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/os_perf.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include CPU_HEADER(vm_version_ext)
 
@@ -893,8 +894,7 @@ class NetworkPerformanceInterface::NetworkPerformance : public CHeapObj<mtIntern
   friend class NetworkPerformanceInterface;
  private:
   NetworkPerformance();
-  NetworkPerformance(const NetworkPerformance& rhs); // no impl
-  NetworkPerformance& operator=(const NetworkPerformance& rhs); // no impl
+  NONCOPYABLE(NetworkPerformance);
   bool initialize();
   ~NetworkPerformance();
   int network_utilization(NetworkInterface** network_interfaces) const;

--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -26,6 +26,7 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/os.hpp"
 #include "runtime/os_perf.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include CPU_HEADER(vm_version_ext)
 
 #ifdef __APPLE__
@@ -72,8 +73,8 @@ class CPUPerformanceInterface::CPUPerformance : public CHeapObj<mtInternal> {
   int cpu_load_total_process(double* cpu_load);
   int cpu_loads_process(double* pjvmUserLoad, double* pjvmKernelLoad, double* psystemTotalLoad);
 
-  CPUPerformance(const CPUPerformance& rhs); // no impl
-  CPUPerformance& operator=(const CPUPerformance& rhs); // no impl
+  NONCOPYABLE(CPUPerformance);
+
  public:
   CPUPerformance();
   bool initialize();
@@ -264,8 +265,7 @@ class SystemProcessInterface::SystemProcesses : public CHeapObj<mtInternal> {
  private:
   SystemProcesses();
   bool initialize();
-  SystemProcesses(const SystemProcesses& rhs); // no impl
-  SystemProcesses& operator=(const SystemProcesses& rhs); // no impl
+  NONCOPYABLE(SystemProcesses);
   ~SystemProcesses();
 
   //information about system processes
@@ -412,8 +412,7 @@ class NetworkPerformanceInterface::NetworkPerformance : public CHeapObj<mtIntern
   friend class NetworkPerformanceInterface;
  private:
   NetworkPerformance();
-  NetworkPerformance(const NetworkPerformance& rhs); // no impl
-  NetworkPerformance& operator=(const NetworkPerformance& rhs); // no impl
+  NONCOPYABLE(NetworkPerformance);
   bool initialize();
   ~NetworkPerformance();
   int network_utilization(NetworkInterface** network_interfaces) const;

--- a/src/hotspot/os/bsd/semaphore_bsd.hpp
+++ b/src/hotspot/os/bsd/semaphore_bsd.hpp
@@ -25,6 +25,8 @@
 #ifndef OS_BSD_SEMAPHORE_BSD_HPP
 #define OS_BSD_SEMAPHORE_BSD_HPP
 
+#include "utilities/globalDefinitions.hpp"
+
 #ifndef __APPLE__
 // Use POSIX semaphores.
 # include "semaphore_posix.hpp"
@@ -37,9 +39,7 @@
 class OSXSemaphore : public CHeapObj<mtInternal>{
   semaphore_t _semaphore;
 
-  // Prevent copying and assignment.
-  OSXSemaphore(const OSXSemaphore&);
-  OSXSemaphore& operator=(const OSXSemaphore&);
+  NONCOPYABLE(OSXSemaphore);
 
  public:
   OSXSemaphore(uint value = 0);

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -28,6 +28,7 @@
 #include "os_linux.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/os_perf.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include CPU_HEADER(vm_version_ext)
 
@@ -957,8 +958,7 @@ class NetworkPerformanceInterface::NetworkPerformance : public CHeapObj<mtIntern
   friend class NetworkPerformanceInterface;
  private:
   NetworkPerformance();
-  NetworkPerformance(const NetworkPerformance& rhs); // no impl
-  NetworkPerformance& operator=(const NetworkPerformance& rhs); // no impl
+  NONCOPYABLE(NetworkPerformance);
   bool initialize();
   ~NetworkPerformance();
   int64_t read_counter(const char* iface, const char* counter) const;

--- a/src/hotspot/os/linux/waitBarrier_linux.hpp
+++ b/src/hotspot/os/linux/waitBarrier_linux.hpp
@@ -26,13 +26,12 @@
 #define OS_LINUX_WAITBARRIER_LINUX_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class LinuxWaitBarrier : public CHeapObj<mtInternal> {
   volatile int _futex_barrier;
 
-  // Prevent copying and assignment of LinuxWaitBarrier instances.
-  LinuxWaitBarrier(const LinuxWaitBarrier&);
-  LinuxWaitBarrier& operator=(const LinuxWaitBarrier&);
+  NONCOPYABLE(LinuxWaitBarrier);
 
  public:
   LinuxWaitBarrier() : _futex_barrier(0) {};

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -286,6 +286,9 @@ class PlatformMonitor : public CHeapObj<mtSynchronizer> {
 
 #endif // PLATFORM_MONITOR_IMPL_INDIRECT
 
+ private:
+  NONCOPYABLE(PlatformMonitor);
+
  public:
   void lock();
   void unlock();

--- a/src/hotspot/os/posix/semaphore_posix.hpp
+++ b/src/hotspot/os/posix/semaphore_posix.hpp
@@ -26,15 +26,14 @@
 #define OS_POSIX_SEMAPHORE_POSIX_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include <semaphore.h>
 
 class PosixSemaphore : public CHeapObj<mtInternal> {
   sem_t _semaphore;
 
-  // Prevent copying and assignment.
-  PosixSemaphore(const PosixSemaphore&);
-  PosixSemaphore& operator=(const PosixSemaphore&);
+  NONCOPYABLE(PosixSemaphore);
 
  public:
   PosixSemaphore(uint value = 0);

--- a/src/hotspot/os/solaris/os_perf_solaris.cpp
+++ b/src/hotspot/os/solaris/os_perf_solaris.cpp
@@ -28,6 +28,7 @@
 #include "runtime/os.hpp"
 #include "runtime/os_perf.hpp"
 #include "os_solaris.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
 #include CPU_HEADER(vm_version_ext)
@@ -745,8 +746,7 @@ class NetworkPerformanceInterface::NetworkPerformance : public CHeapObj<mtIntern
   friend class NetworkPerformanceInterface;
  private:
   NetworkPerformance();
-  NetworkPerformance(const NetworkPerformance& rhs); // no impl
-  NetworkPerformance& operator=(const NetworkPerformance& rhs); // no impl
+  NONCOPYABLE(NetworkPerformance);
   bool initialize();
   ~NetworkPerformance();
   int network_utilization(NetworkInterface** network_interfaces) const;

--- a/src/hotspot/os/solaris/os_solaris.hpp
+++ b/src/hotspot/os/solaris/os_solaris.hpp
@@ -341,6 +341,8 @@ class PlatformMonitor : public CHeapObj<mtSynchronizer> {
   mutex_t _mutex; // Native mutex for locking
   cond_t  _cond;  // Native condition variable for blocking
 
+  NONCOPYABLE(PlatformMonitor);
+
  public:
   PlatformMonitor();
   ~PlatformMonitor();

--- a/src/hotspot/os/windows/os_perf_windows.cpp
+++ b/src/hotspot/os/windows/os_perf_windows.cpp
@@ -30,6 +30,7 @@
 #include "pdh_interface.hpp"
 #include "runtime/os_perf.hpp"
 #include "runtime/os.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include CPU_HEADER(vm_version_ext)
 #include <math.h>
@@ -1369,8 +1370,7 @@ class NetworkPerformanceInterface::NetworkPerformance : public CHeapObj<mtIntern
   bool _iphlp_attached;
 
   NetworkPerformance();
-  NetworkPerformance(const NetworkPerformance& rhs); // no impl
-  NetworkPerformance& operator=(const NetworkPerformance& rhs); // no impl
+  NONCOPYABLE(NetworkPerformance);
   bool initialize();
   ~NetworkPerformance();
   int network_utilization(NetworkInterface** network_interfaces) const;

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -194,6 +194,8 @@ class PlatformMonitor : public CHeapObj<mtSynchronizer> {
   CRITICAL_SECTION   _mutex; // Native mutex for locking
   CONDITION_VARIABLE _cond;  // Native condition variable for blocking
 
+  NONCOPYABLE(PlatformMonitor);
+
  public:
   PlatformMonitor();
   ~PlatformMonitor();

--- a/src/hotspot/os/windows/semaphore_windows.hpp
+++ b/src/hotspot/os/windows/semaphore_windows.hpp
@@ -26,15 +26,14 @@
 #define OS_WINDOWS_SEMAPHORE_WINDOWS_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include <windows.h>
 
 class WindowsSemaphore : public CHeapObj<mtInternal> {
   HANDLE _semaphore;
 
-  // Prevent copying and assignment.
-  WindowsSemaphore(const WindowsSemaphore&);
-  WindowsSemaphore& operator=(const WindowsSemaphore&);
+  NONCOPYABLE(WindowsSemaphore);
 
  public:
   WindowsSemaphore(uint value = 0);

--- a/src/hotspot/share/gc/g1/g1FreeIdSet.hpp
+++ b/src/hotspot/share/gc/g1/g1FreeIdSet.hpp
@@ -45,9 +45,7 @@ class G1FreeIdSet : public CHeapObj<mtGC> {
   uint head_index(uintx head) const;
   uintx make_head(uint index, uintx old_head) const;
 
-  // Noncopyable.
-  G1FreeIdSet(const G1FreeIdSet&);
-  G1FreeIdSet& operator=(const G1FreeIdSet&);
+  NONCOPYABLE(G1FreeIdSet);
 
 public:
   G1FreeIdSet(uint start, uint size);

--- a/src/hotspot/share/gc/g1/g1SharedDirtyCardQueue.hpp
+++ b/src/hotspot/share/gc/g1/g1SharedDirtyCardQueue.hpp
@@ -37,9 +37,7 @@ class G1SharedDirtyCardQueue {
   void** _buffer;
   size_t _index;
 
-  // Noncopyable
-  G1SharedDirtyCardQueue(const G1SharedDirtyCardQueue&);
-  G1SharedDirtyCardQueue& operator=(const G1SharedDirtyCardQueue&);
+  NONCOPYABLE(G1SharedDirtyCardQueue);
 
 public:
   G1SharedDirtyCardQueue(G1DirtyCardQueueSet* qset);

--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -196,9 +196,7 @@ NOT_AIX( private: )
     const Block* _head;
     const Block* _tail;
 
-    // Noncopyable.
-    AllocationList(const AllocationList&);
-    AllocationList& operator=(const AllocationList&);
+    NONCOPYABLE(AllocationList);
 
   public:
     AllocationList();

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -48,9 +48,7 @@ class OopStorage::ActiveArray {
   ActiveArray(size_t size);
   ~ActiveArray();
 
-  // Noncopyable
-  ActiveArray(const ActiveArray&);
-  ActiveArray& operator=(const ActiveArray&);
+  NONCOPYABLE(ActiveArray);
 
   static size_t blocks_offset();
   Block* const* base_ptr() const;
@@ -118,9 +116,7 @@ class OopStorage::AllocationListEntry {
   mutable const Block* _prev;
   mutable const Block* _next;
 
-  // Noncopyable.
-  AllocationListEntry(const AllocationListEntry&);
-  AllocationListEntry& operator=(const AllocationListEntry&);
+  NONCOPYABLE(AllocationListEntry);
 
 public:
   AllocationListEntry();
@@ -153,9 +149,7 @@ class OopStorage::Block /* No base class, to avoid messing up alignment. */ {
   template<typename F, typename BlockPtr>
   static bool iterate_impl(F f, BlockPtr b);
 
-  // Noncopyable.
-  Block(const Block&);
-  Block& operator=(const Block&);
+  NONCOPYABLE(Block);
 
 public:
   const AllocationListEntry& allocation_list_entry() const;

--- a/src/hotspot/share/gc/shared/oopStorageParState.hpp
+++ b/src/hotspot/share/gc/shared/oopStorageParState.hpp
@@ -26,7 +26,7 @@
 #define SHARE_GC_SHARED_OOPSTORAGEPARSTATE_HPP
 
 #include "gc/shared/oopStorage.hpp"
-#include "utilities/macros.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 //////////////////////////////////////////////////////////////////////////////
 // Support for parallel and optionally concurrent state iteration.
@@ -134,9 +134,7 @@ class OopStorage::BasicParState {
   uint _estimated_thread_count;
   bool _concurrent;
 
-  // Noncopyable.
-  BasicParState(const BasicParState&);
-  BasicParState& operator=(const BasicParState&);
+  NONCOPYABLE(BasicParState);
 
   struct IterationData;
 

--- a/src/hotspot/share/gc/shared/ptrQueue.hpp
+++ b/src/hotspot/share/gc/shared/ptrQueue.hpp
@@ -28,6 +28,7 @@
 #include "memory/padded.hpp"
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/lockFreeStack.hpp"
 #include "utilities/sizes.hpp"
 
@@ -44,9 +45,7 @@ class PtrQueueSet;
 class PtrQueue {
   friend class VMStructs;
 
-  // Noncopyable - not defined.
-  PtrQueue(const PtrQueue&);
-  PtrQueue& operator=(const PtrQueue&);
+  NONCOPYABLE(PtrQueue);
 
   // The ptr queue set to which this queue belongs.
   PtrQueueSet* const _qset;
@@ -205,6 +204,8 @@ class BufferNode {
   BufferNode() : _index(0), _next(NULL) { }
   ~BufferNode() { }
 
+  NONCOPYABLE(BufferNode);
+
   static size_t buffer_offset() {
     return offset_of(BufferNode, _buffer);
   }
@@ -274,6 +275,8 @@ class BufferNode::Allocator {
   void delete_list(BufferNode* list);
   bool try_transfer_pending();
 
+  NONCOPYABLE(Allocator);
+
 public:
   Allocator(const char* name, size_t buffer_size);
   ~Allocator();
@@ -308,6 +311,8 @@ class PtrQueueSet {
   bool _notify_when_complete;
 
   void assert_completed_buffers_list_len_correct_locked() NOT_DEBUG_RETURN;
+
+  NONCOPYABLE(PtrQueueSet);
 
 protected:
   bool _all_active;

--- a/src/hotspot/share/gc/shared/taskqueue.hpp
+++ b/src/hotspot/share/gc/shared/taskqueue.hpp
@@ -28,6 +28,7 @@
 #include "memory/allocation.hpp"
 #include "memory/padded.hpp"
 #include "oops/oopsHierarchy.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/stack.hpp"
 
@@ -514,9 +515,8 @@ class TaskTerminator : public StackObj {
 private:
   ParallelTaskTerminator*  _terminator;
 
-  // Noncopyable.
-  TaskTerminator(const TaskTerminator&);
-  TaskTerminator& operator=(const TaskTerminator&);
+  NONCOPYABLE(TaskTerminator);
+
 public:
   TaskTerminator(uint n_threads, TaskQueueSetSuper* queue_set);
   ~TaskTerminator();

--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.hpp
@@ -29,6 +29,7 @@
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "memory/allocation.hpp"
 #include "memory/iterator.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ShenandoahHeap;
 class ShenandoahHeapRegion;
@@ -52,10 +53,8 @@ private:
   ShenandoahParallelCodeHeapIterator* _iters;
   int                       _length;
 
-private:
-  // Noncopyable.
-  ShenandoahParallelCodeCacheIterator(const ShenandoahParallelCodeCacheIterator& o);
-  ShenandoahParallelCodeCacheIterator& operator=(const ShenandoahParallelCodeCacheIterator& o);
+  NONCOPYABLE(ShenandoahParallelCodeCacheIterator);
+
 public:
   ShenandoahParallelCodeCacheIterator(const GrowableArray<CodeHeap*>* heaps);
   ~ShenandoahParallelCodeCacheIterator();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -33,6 +33,7 @@
 #include "gc/shenandoah/shenandoahEvacOOMHandler.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 #include "services/memoryManager.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ConcurrentGCTimer;
 class ReferenceProcessor;
@@ -67,8 +68,7 @@ private:
   DEFINE_PAD_MINUS_SIZE(1, DEFAULT_CACHE_LINE_SIZE, 0);
 
   // No implicit copying: iterators should be passed by reference to capture the state
-  ShenandoahRegionIterator(const ShenandoahRegionIterator& that);
-  ShenandoahRegionIterator& operator=(const ShenandoahRegionIterator& o);
+  NONCOPYABLE(ShenandoahRegionIterator);
 
 public:
   ShenandoahRegionIterator();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2013, 2019, Red Hat, Inc. All rights reserved.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -27,6 +27,7 @@
 #include "memory/allocation.hpp"
 #include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ShenandoahHeapRegionSet;
 
@@ -40,8 +41,7 @@ private:
   DEFINE_PAD_MINUS_SIZE(1, DEFAULT_CACHE_LINE_SIZE, 0);
 
   // No implicit copying: iterators should be passed by reference to capture the state
-  ShenandoahHeapRegionSetIterator(const ShenandoahHeapRegionSetIterator& that);
-  ShenandoahHeapRegionSetIterator& operator=(const ShenandoahHeapRegionSetIterator& o);
+  NONCOPYABLE(ShenandoahHeapRegionSetIterator);
 
 public:
   ShenandoahHeapRegionSetIterator(const ShenandoahHeapRegionSet* const set);

--- a/src/hotspot/share/gc/z/zArray.hpp
+++ b/src/hotspot/share/gc/z/zArray.hpp
@@ -25,6 +25,7 @@
 #define SHARE_GC_Z_ZARRAY_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 template <typename T>
 class ZArray {
@@ -35,9 +36,7 @@ private:
   size_t _size;
   size_t _capacity;
 
-  // Copy and assignment are not allowed
-  ZArray(const ZArray<T>& array);
-  ZArray<T>& operator=(const ZArray<T>& array);
+  NONCOPYABLE(ZArray);
 
   void expand(size_t new_capacity);
 

--- a/src/hotspot/share/gc/z/zList.hpp
+++ b/src/hotspot/share/gc/z/zList.hpp
@@ -26,6 +26,7 @@
 
 #include "memory/allocation.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 template <typename T> class ZList;
 
@@ -68,9 +69,7 @@ private:
   ZListNode<T> _head;
   size_t       _size;
 
-  // Passing by value and assignment is not allowed
-  ZList(const ZList<T>& list);
-  ZList<T>& operator=(const ZList<T>& list);
+  NONCOPYABLE(ZList);
 
   void verify() const {
     assert(_head._next->_prev == &_head, "List corrupt");

--- a/src/hotspot/share/jfr/jni/jfrJavaCall.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaCall.hpp
@@ -28,6 +28,7 @@
 #include "jni.h"
 #include "jfr/utilities/jfrAllocation.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class JavaCallArguments;
 class JavaThread;
@@ -86,8 +87,7 @@ class JfrJavaArguments : public StackObj {
     int _java_stack_slots;
 
     Parameters();
-    Parameters(const Parameters&); // no impl
-    Parameters& operator=(const Parameters&); // no impl
+    NONCOPYABLE(Parameters);
 
     void push(const JavaValue& value);
     void push_large(const JavaValue& value);

--- a/src/hotspot/share/memory/metaspaceClosure.hpp
+++ b/src/hotspot/share/memory/metaspaceClosure.hpp
@@ -28,6 +28,7 @@
 #include "logging/log.hpp"
 #include "memory/allocation.hpp"
 #include "oops/array.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/hashtable.inline.hpp"
 
@@ -104,9 +105,8 @@ public:
   class Ref : public CHeapObj<mtInternal> {
     Writability _writability;
     Ref* _next;
-    // Noncopyable.
-    Ref(const Ref&);
-    Ref& operator=(const Ref&);
+    NONCOPYABLE(Ref);
+
   protected:
     virtual void** mpp() const = 0;
     Ref(Writability w) : _writability(w), _next(NULL) {}

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -29,6 +29,7 @@
 #include "memory/metaspace.hpp"
 #include "runtime/orderAccess.hpp"
 #include "utilities/align.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // Array for metadata allocation
 
@@ -49,9 +50,7 @@ protected:
   }
 
  private:
-  // Turn off copy constructor and assignment operator.
-  Array(const Array<T>&);
-  void operator=(const Array<T>&);
+  NONCOPYABLE(Array);
 
   void* operator new(size_t size, ClassLoaderData* loader_data, int length, TRAPS) throw() {
     size_t word_size = Array::size(length);

--- a/src/hotspot/share/runtime/os_perf.hpp
+++ b/src/hotspot/share/runtime/os_perf.hpp
@@ -26,6 +26,7 @@
 #define SHARE_RUNTIME_OS_PERF_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
 #define FUNCTIONALITY_NOT_IMPLEMENTED -8
@@ -190,9 +191,8 @@ class NetworkInterface : public ResourceObj {
   uint64_t _bytes_out;
   NetworkInterface* _next;
 
-  NetworkInterface(); // no impl
-  NetworkInterface(const NetworkInterface& rhs); // no impl
-  NetworkInterface& operator=(const NetworkInterface& rhs); // no impl
+  NONCOPYABLE(NetworkInterface);
+
  public:
   NetworkInterface(const char* name, uint64_t bytes_in, uint64_t bytes_out, NetworkInterface* next) :
   _name(NULL),
@@ -268,8 +268,8 @@ class NetworkPerformanceInterface : public CHeapObj<mtInternal> {
  private:
   class NetworkPerformance;
   NetworkPerformance* _impl;
-  NetworkPerformanceInterface(const NetworkPerformanceInterface& rhs); // no impl
-  NetworkPerformanceInterface& operator=(const NetworkPerformanceInterface& rhs); // no impl
+  NONCOPYABLE(NetworkPerformanceInterface);
+
  public:
   NetworkPerformanceInterface();
   bool initialize();

--- a/src/hotspot/share/runtime/semaphore.hpp
+++ b/src/hotspot/share/runtime/semaphore.hpp
@@ -26,6 +26,7 @@
 #define SHARE_RUNTIME_SEMAPHORE_HPP
 
 #include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #if defined(LINUX) || defined(SOLARIS) || defined(AIX)
 # include "semaphore_posix.hpp"
@@ -43,9 +44,7 @@ class JavaThread;
 class Semaphore : public CHeapObj<mtSynchronizer> {
   SemaphoreImpl _impl;
 
-  // Prevent copying and assignment of Semaphore instances.
-  Semaphore(const Semaphore&);
-  Semaphore& operator=(const Semaphore&);
+  NONCOPYABLE(Semaphore);
 
  public:
   Semaphore(uint value = 0) : _impl(value) {}

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -48,6 +48,7 @@
 #include "runtime/unhandledOops.hpp"
 #include "utilities/align.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #ifdef ZERO
 # include "stack_zero.hpp"
@@ -870,9 +871,7 @@ class NonJavaThread::Iterator : public StackObj {
   uint _protect_enter;
   NonJavaThread* _current;
 
-  // Noncopyable.
-  Iterator(const Iterator&);
-  Iterator& operator=(const Iterator&);
+  NONCOPYABLE(Iterator);
 
 public:
   Iterator();

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -27,6 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "utilities/align.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // Forward decl;
 class BitMapClosure;
@@ -357,9 +358,7 @@ class ArenaBitMap : public BitMap {
   ArenaBitMap(Arena* arena, idx_t size_in_bits);
 
  private:
-  // Don't allow copy or assignment.
-  ArenaBitMap(const ArenaBitMap&);
-  ArenaBitMap& operator=(const ArenaBitMap&);
+  NONCOPYABLE(ArenaBitMap);
 };
 
 // A BitMap with storage in the CHeap.
@@ -368,8 +367,7 @@ class CHeapBitMap : public BitMap {
  private:
   // Don't allow copy or assignment, to prevent the
   // allocated memory from leaking out to other instances.
-  CHeapBitMap(const CHeapBitMap&);
-  CHeapBitMap& operator=(const CHeapBitMap&);
+  NONCOPYABLE(CHeapBitMap);
 
   // NMT memory type
   MEMFLAGS _flags;

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -66,6 +66,19 @@
 // This file holds all globally used constants & types, class (forward)
 // declarations and a few frequently used utility functions.
 
+// Declare the named class to be noncopyable.  This macro must be used in
+// a private part of the class's definition, followed by a semi-colon.
+// Doing so provides private declarations for the class's copy constructor
+// and assignment operator.  Because these operations are private, most
+// potential callers will fail to compile because they are inaccessible.
+// The operations intentionally lack a definition, to provoke link-time
+// failures for calls from contexts where they are accessible, e.g. from
+// within the class or from a friend of the class.
+// Note: The lack of definitions is still not completely bullet-proof, as
+// an apparent call might be optimized away by copy elision.
+// For C++11 the declarations should be changed to deleted definitions.
+#define NONCOPYABLE(C) C(C const&); C& operator=(C const&) /* next token must be ; */
+
 //----------------------------------------------------------------------------------------------------
 // Printf-style formatters for fixed- and variable-width types as pointers and
 // integers.  These are derived from the definitions in inttypes.h.  If the platform

--- a/src/hotspot/share/utilities/lockFreeStack.hpp
+++ b/src/hotspot/share/utilities/lockFreeStack.hpp
@@ -27,7 +27,7 @@
 
 #include "runtime/atomic.hpp"
 #include "utilities/debug.hpp"
-#include "utilities/macros.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // The LockFreeStack class template provides a lock-free LIFO. The objects
 // in the sequence are intrusively linked via a member in the objects.  As
@@ -69,9 +69,7 @@ class LockFreeStack {
     } while (old != cur);
   }
 
-  // Noncopyable.
-  LockFreeStack(const LockFreeStack&);
-  LockFreeStack& operator=(const LockFreeStack&);
+  NONCOPYABLE(LockFreeStack);
 
 public:
   LockFreeStack() : _top(NULL) {}

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -43,8 +43,7 @@ DEBUG_ONLY(class ResourceMark;)
 // -XX:+DisplayVMOutputToStderr
 class outputStream : public ResourceObj {
  private:
-   outputStream(const outputStream&);
-   outputStream& operator=(const outputStream&);
+   NONCOPYABLE(outputStream);
 
  protected:
    int _indentation; // current indentation

--- a/src/hotspot/share/utilities/singleWriterSynchronizer.hpp
+++ b/src/hotspot/share/utilities/singleWriterSynchronizer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,9 +55,7 @@ class SingleWriterSynchronizer {
 
   DEBUG_ONLY(volatile uint _writers;)
 
-  // Noncopyable.
-  SingleWriterSynchronizer(const SingleWriterSynchronizer&);
-  SingleWriterSynchronizer& operator=(const SingleWriterSynchronizer&);
+  NONCOPYABLE(SingleWriterSynchronizer);
 
 public:
   SingleWriterSynchronizer();

--- a/src/hotspot/share/utilities/waitBarrier.hpp
+++ b/src/hotspot/share/utilities/waitBarrier.hpp
@@ -28,6 +28,7 @@
 #include "memory/allocation.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/waitBarrier_generic.hpp"
 
 #if defined(LINUX)
@@ -81,9 +82,7 @@ template <typename WaitBarrierImpl>
 class WaitBarrierType : public CHeapObj<mtInternal> {
   WaitBarrierImpl _impl;
 
-  // Prevent copying and assignment of WaitBarrier instances.
-  WaitBarrierType(const WaitBarrierDefault&);
-  WaitBarrierType& operator=(const WaitBarrierDefault&);
+  NONCOPYABLE(WaitBarrierType);
 
 #ifdef ASSERT
   int _last_arm_tag;

--- a/src/hotspot/share/utilities/waitBarrier_generic.hpp
+++ b/src/hotspot/share/utilities/waitBarrier_generic.hpp
@@ -27,6 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "runtime/semaphore.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 // In addition to the barrier tag, it uses two counters to keep the semaphore
 // count correct and not leave any late thread waiting.
@@ -39,9 +40,7 @@ class GenericWaitBarrier : public CHeapObj<mtInternal> {
   volatile int _barrier_threads;
   Semaphore _sem_barrier;
 
-  // Prevent copying and assignment of GenericWaitBarrier instances.
-  GenericWaitBarrier(const GenericWaitBarrier&);
-  GenericWaitBarrier& operator=(const GenericWaitBarrier&);
+  NONCOPYABLE(GenericWaitBarrier);
 
   int wake_if_needed();
 


### PR DESCRIPTION
I'd like to backport JDK-8234779 to jdk13u for parity with jdk11u.
The original patch applied not cleanly. 

The merge was required for the following 6 files:
1) due to the context changes in the includes of headers part:
src/hotspot/share/utilities/bitMap.hpp
src/hotspot/share/gc/z/zList.hpp
2) due to no definition of such a class (PlatformMutex):  
src/hotspot/os/windows/os_windows.hpp
src/hotspot/os/solaris/os_solaris.hpp
src/hotspot/os/posix/os_posix.hpp
3) due to the context changes:
src/hotspot/share/gc/shared/ptrQueue.hpp

All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8234779](https://bugs.openjdk.java.net/browse/JDK-8234779): Provide idiom for declaring classes noncopyable


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/158/head:pull/158`
`$ git checkout pull/158`

To update a local copy of the PR:
`$ git checkout pull/158`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/158/head`
