### PR TITLE
8263996: Fix build on 13u after JDK-8234779 backport

### DIFF
--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -286,9 +286,6 @@ class PlatformMonitor : public CHeapObj<mtSynchronizer> {
 
 #endif // PLATFORM_MONITOR_IMPL_INDIRECT
 
- private:
-  NONCOPYABLE(PlatformMonitor);
-
  public:
   void lock();
   void unlock();

--- a/src/hotspot/os/solaris/os_solaris.hpp
+++ b/src/hotspot/os/solaris/os_solaris.hpp
@@ -341,8 +341,6 @@ class PlatformMonitor : public CHeapObj<mtSynchronizer> {
   mutex_t _mutex; // Native mutex for locking
   cond_t  _cond;  // Native condition variable for blocking
 
-  NONCOPYABLE(PlatformMonitor);
-
  public:
   PlatformMonitor();
   ~PlatformMonitor();

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -194,8 +194,6 @@ class PlatformMonitor : public CHeapObj<mtSynchronizer> {
   CRITICAL_SECTION   _mutex; // Native mutex for locking
   CONDITION_VARIABLE _cond;  // Native condition variable for blocking
 
-  NONCOPYABLE(PlatformMonitor);
-
  public:
   PlatformMonitor();
   ~PlatformMonitor();


### PR DESCRIPTION
I would like to partialy revert changes made by backport of JDK-8234779 to jdk13u: to remove restriction for copying objects from PlatformMonitor class due to the builds failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263996](https://bugs.openjdk.java.net/browse/JDK-8263996): Fix build on 13u after JDK-8234779 backport


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/160/head:pull/160`
`$ git checkout pull/160`

To update a local copy of the PR:
`$ git checkout pull/160`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/160/head`
