### PR TITLE
8264108: Update version .jcheck/conf in jdk13u-dev to be 13.0.8

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,7 +1,7 @@
 [general]
 project=jdk-updates
 jbs=JDK
-version=13.0.7
+version=13.0.8
 
 [checks]
 error=author,committer,reviewers,issues,executable,symlink,message,hg-tag,whitespace


### PR DESCRIPTION
I hope that with this change all subsequent fixes (until July 2021) will have fixVersion 13.0.8

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264108](https://bugs.openjdk.java.net/browse/JDK-8264108): Update version .jcheck/conf in jdk13u-dev to be 13.0.8


### Reviewers
 * [Andrew Brygin](https://openjdk.java.net/census#bae) (@bae - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/161/head:pull/161`
`$ git checkout pull/161`

To update a local copy of the PR:
`$ git checkout pull/161`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/161/head`
