### PR TITLE
8234691: Potential double-free in ParallelSPCleanupTask constructor

### DIFF
--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -322,6 +322,8 @@ class SubTasksDone: public CHeapObj<mtInternal> {
 
   // Set all tasks to unclaimed.
   void clear();
+
+  NONCOPYABLE(SubTasksDone);
 
 public:
   // Initializes "this" to a state in which there are "n" tasks to be

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -561,7 +561,7 @@ private:
 public:
   ParallelSPCleanupTask(uint num_workers, DeflateMonitorCounters* counters) :
     AbstractGangTask("Parallel Safepoint Cleanup"),
-    _subtasks(SubTasksDone(SafepointSynchronize::SAFEPOINT_CLEANUP_NUM_TASKS)),
+    _subtasks(SafepointSynchronize::SAFEPOINT_CLEANUP_NUM_TASKS),
     _cleanup_threads_cl(ParallelSPCleanupThreadClosure(counters)),
     _num_workers(num_workers),
     _counters(counters) {}


### PR DESCRIPTION
I'd like to backport JDK-8234691 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8234691](https://bugs.openjdk.java.net/browse/JDK-8234691): Potential double-free in ParallelSPCleanupTask constructor


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/163/head:pull/163`
`$ git checkout pull/163`

To update a local copy of the PR:
`$ git checkout pull/163`
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/163/head`
