### PR TITLE
8261397: Try Catch Method Failing to Work When Dividing An Integer By 0

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -944,6 +944,11 @@ public:
     return LP64_ONLY(true) NOT_LP64(false); // not implemented on x86_32
   }
 
+#ifdef __APPLE__
+  // Is the CPU running emulated (for example macOS Rosetta running x86_64 code on M1 ARM (aarch64)
+  static bool is_cpu_emulated();
+#endif
+
   // support functions for virtualization detection
  private:
   static void check_virt_cpuid(uint32_t idx, uint32_t *regs);

--- a/src/hotspot/os_cpu/bsd_x86/vm_version_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/vm_version_bsd_x86.cpp
@@ -25,3 +25,24 @@
 #include "precompiled.hpp"
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
+
+#ifdef __APPLE__
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+bool VM_Version::is_cpu_emulated() {
+  int ret = 0;
+  size_t size = sizeof(ret);
+  // Is this process being ran in Rosetta (i.e. emulation) mode on macOS?
+  if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+    // errno == ENOENT is a valid response, but anything else is a real error
+    if (errno != ENOENT) {
+      warning("unable to lookup sysctl.proc_translated");
+    }
+  }
+  return (ret==1);
+}
+
+#endif
+


### PR DESCRIPTION
Backport-of: 0257caad38b4358bd151e993b708603fce2056f2

Please review this backport of 8261397 to jdk13u-dev

patch applied cleanly, but had to be changed  due to missing MACOS_ONLY macro in jdk13.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261397](https://bugs.openjdk.java.net/browse/JDK-8261397): Try Catch Method Failing to Work When Dividing An Integer By 0 ⚠️ Issue is not open.


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/164/head:pull/164` \
`$ git checkout pull/164`

Update a local copy of the PR: \
`$ git checkout pull/164` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 164`

View PR using the GUI difftool: \
`$ git pr show -t 164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/164.diff">https://git.openjdk.java.net/jdk13u-dev/pull/164.diff</a>

</details>
