### PR TITLE
8264640: CMS ParScanClosure misses a barrier

### DIFF
--- a/src/hotspot/share/gc/cms/parOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/cms/parOopClosures.inline.hpp
@@ -44,6 +44,7 @@ template <class T> inline void ParScanWeakRefClosure::do_oop_work(T* p) {
     // we need to ensure that it is copied (see comment in
     // ParScanClosure::do_oop_work).
     Klass* objK = obj->klass();
+    OrderAccess::loadload();
     markOop m = obj->mark_raw();
     oop new_obj;
     if (m->is_marked()) { // Contains forwarding pointer.
@@ -108,6 +109,7 @@ inline void ParScanClosure::do_oop_work(T* p,
       // overwritten with an overflow next pointer after the object is
       // forwarded.
       Klass* objK = obj->klass();
+      OrderAccess::loadload();
       markOop m = obj->mark_raw();
       oop new_obj;
       if (m->is_marked()) { // Contains forwarding pointer.


### PR DESCRIPTION
Hi, please review an original fix for a GC crash. The jdk13u is the latest supported version that still has buggy code, it was deleted in jdk14 as a part of   JEP 363: Remove the Concurrent Mark Sweep (CMS) Garbage Collector. So I'm proposing it here.

The fix is low-risk, on x86-64 it just introduces a compiler barrier to prevent two reads to be reordered as intended by surrounding comments. On CPUs with weaker memory models it introduces CPU barriers as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264640](https://bugs.openjdk.java.net/browse/JDK-8264640): CMS ParScanClosure misses a barrier


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)
 * johnc - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/165/head:pull/165` \
`$ git checkout pull/165`

Update a local copy of the PR: \
`$ git checkout pull/165` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 165`

View PR using the GUI difftool: \
`$ git pr show -t 165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/165.diff">https://git.openjdk.java.net/jdk13u-dev/pull/165.diff</a>

</details>
