### PR TITLE
8256682: JDK-8202343 is incomplete

### DIFF
--- a/test/jdk/sun/security/util/HostnameMatcher/NullHostnameCheck.java
+++ b/test/jdk/sun/security/util/HostnameMatcher/NullHostnameCheck.java
@@ -44,10 +44,11 @@ import jdk.test.lib.security.SecurityUtils;
  * @bug 8211339 8234728
  * @summary Verify hostname returns an exception instead of null pointer when
  * creating a new engine
- * @run main NullHostnameCheck TLSv1
- * @run main NullHostnameCheck TLSv1.1
- * @run main NullHostnameCheck TLSv1.2
- * @run main NullHostnameCheck TLSv1.3
+ * @library /test/lib
+ * @run main/othervm NullHostnameCheck TLSv1
+ * @run main/othervm NullHostnameCheck TLSv1.1
+ * @run main/othervm NullHostnameCheck TLSv1.2
+ * @run main/othervm NullHostnameCheck TLSv1.3
  */
 
 


### PR DESCRIPTION
Need to fix this test after 8202343, a small change

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256682](https://bugs.openjdk.java.net/browse/JDK-8256682): JDK-8202343 is incomplete


### Reviewers
 * [Andrew Brygin](https://openjdk.java.net/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/167.diff">https://git.openjdk.java.net/jdk13u-dev/pull/167.diff</a>

</details>
