### PR TITLE
8254790: SIGSEGV in string_indexof_char and stringL_indexof_char intrinsics

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6432,7 +6432,7 @@ void MacroAssembler::string_indexof_char(Register str1, Register cnt1, Register 
     pmovmskb(tmp, vec3);
   }
   bsfl(ch, tmp);
-  addl(result, ch);
+  addptr(result, ch);
 
   bind(FOUND_SEQ_CHAR);
   subptr(result, str1);


### PR DESCRIPTION
Hi! Please review the backport of JDK-8254790.  The patch fixes SIGSEGV and is required for code sync with jdk11,15. The patch is taken from jdk15 since the original one can't be applied cleanly due to reasons described https://mail.openjdk.java.net/pipermail/hotspot-compiler-dev/2020-October/040943.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254790](https://bugs.openjdk.java.net/browse/JDK-8254790): SIGSEGV in string_indexof_char and stringL_indexof_char intrinsics


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/170.diff">https://git.openjdk.java.net/jdk13u-dev/pull/170.diff</a>

</details>
