### PR TITLE
8261585: Restore HandleArea used in Deoptimization::uncommon_trap

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2173,6 +2173,7 @@ Deoptimization::UnrollBlock* Deoptimization::uncommon_trap(JavaThread* thread, j
     // This enters VM and may safepoint
     uncommon_trap_inner(thread, trap_request);
   }
+  HandleMark hm(thread);
   return fetch_unroll_info_helper(thread, exec_mode);
 }
 

--- a/test/hotspot/jtreg/compiler/uncommontrap/UncommonTrapLeak.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/UncommonTrapLeak.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.ref.WeakReference;
+
+/*
+ * @test
+ * @bug 8260473
+ * @summary Handle leak might cause object not collected as expected
+ *
+ * @run main/othervm -XX:-Inline -XX:-TieredCompilation -XX:CompileCommand=compileonly,UncommonTrapLeak.foo
+ *                   -XX:CompileThreshold=100 -XX:-BackgroundCompilation UncommonTrapLeak
+ *
+ * @author Hui Shi
+ */
+public class UncommonTrapLeak {
+    static WeakReference<Object> ref = null;
+    static int val = 0;
+    public static void main(String args[]) {
+        for (int i = 0; i < 300; i++) {
+            val++;
+            foo(i);
+            System.gc();
+            if (ref.get() != null) {
+                throw new RuntimeException("Failed: referent not collected after trap " + ref.get());
+            }
+            if (i % 100 == 0) {
+                System.out.println(i);
+            }
+        }
+    }
+
+    static void foo(int i) {
+        Object o = new Object();
+        ref = new WeakReference<Object>(o);
+        if (val == 200) {
+            // trigger Deoptimization::uncommon_trap
+            if (o instanceof UncommonTrapLeak) {
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Low risk minor patch required for parity with odjk11. Applies cleanly.  Get RuntimeException from newly added UncommonTrapLeak.java:45 without the patch, pass the test with the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261585](https://bugs.openjdk.java.net/browse/JDK-8261585): Restore HandleArea used in Deoptimization::uncommon_trap


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/171.diff">https://git.openjdk.java.net/jdk13u-dev/pull/171.diff</a>

</details>
