### PR TITLE
8257853: Remove dependencies on JNF's JNI utility functions in AWT and 2D code

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -33,6 +33,7 @@
 #import "GeomUtilities.h"
 #import "OSVersion.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 #import <Carbon/Carbon.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
@@ -397,9 +398,9 @@ static BOOL shouldUsePressAndHold() {
         deltaY = [event scrollingDeltaY] * 0.1;
     }
 
-    static JNF_CLASS_CACHE(jc_NSEvent, "sun/lwawt/macosx/NSEvent");
-    static JNF_CTOR_CACHE(jctor_NSEvent, jc_NSEvent, "(IIIIIIIIDDI)V");
-    jobject jEvent = JNFNewObject(env, jctor_NSEvent,
+    DECLARE_CLASS(jc_NSEvent, "sun/lwawt/macosx/NSEvent");
+    DECLARE_METHOD(jctor_NSEvent, jc_NSEvent, "<init>", "(IIIIIIIIDDI)V");
+    jobject jEvent = (*env)->NewObject(env, jc_NSEvent, jctor_NSEvent,
                                   [event type],
                                   [event modifierFlags],
                                   clickCount,
@@ -411,11 +412,12 @@ static BOOL shouldUsePressAndHold() {
                                   [AWTToolkit scrollStateWithEvent: event]);
     CHECK_NULL(jEvent);
 
-    static JNF_CLASS_CACHE(jc_PlatformView, "sun/lwawt/macosx/CPlatformView");
-    static JNF_MEMBER_CACHE(jm_deliverMouseEvent, jc_PlatformView, "deliverMouseEvent", "(Lsun/lwawt/macosx/NSEvent;)V");
+    DECLARE_CLASS(jc_PlatformView, "sun/lwawt/macosx/CPlatformView");
+    DECLARE_METHOD(jm_deliverMouseEvent, jc_PlatformView, "deliverMouseEvent", "(Lsun/lwawt/macosx/NSEvent;)V");
     jobject jlocal = (*env)->NewLocalRef(env, m_cPlatformView);
     if (!(*env)->IsSameObject(env, jlocal, NULL)) {
-        JNFCallVoidMethod(env, jlocal, jm_deliverMouseEvent, jEvent);
+        (*env)->CallVoidMethod(env, jlocal, jm_deliverMouseEvent, jEvent);
+        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, jlocal);
     }
     (*env)->DeleteLocalRef(env, jEvent);
@@ -467,9 +469,9 @@ static BOOL shouldUsePressAndHold() {
         charactersIgnoringModifiers = JNFNSToJavaString(env, [event charactersIgnoringModifiers]);
     }
 
-    static JNF_CLASS_CACHE(jc_NSEvent, "sun/lwawt/macosx/NSEvent");
-    static JNF_CTOR_CACHE(jctor_NSEvent, jc_NSEvent, "(IISLjava/lang/String;Ljava/lang/String;)V");
-    jobject jEvent = JNFNewObject(env, jctor_NSEvent,
+    DECLARE_CLASS(jc_NSEvent, "sun/lwawt/macosx/NSEvent");
+    DECLARE_METHOD(jctor_NSEvent, jc_NSEvent, "<init>", "(IISLjava/lang/String;Ljava/lang/String;)V");
+    jobject jEvent = (*env)->NewObject(env, jc_NSEvent, jctor_NSEvent,
                                   [event type],
                                   [event modifierFlags],
                                   [event keyCode],
@@ -477,12 +479,13 @@ static BOOL shouldUsePressAndHold() {
                                   charactersIgnoringModifiers);
     CHECK_NULL(jEvent);
 
-    static JNF_CLASS_CACHE(jc_PlatformView, "sun/lwawt/macosx/CPlatformView");
-    static JNF_MEMBER_CACHE(jm_deliverKeyEvent, jc_PlatformView,
+    DECLARE_CLASS(jc_PlatformView, "sun/lwawt/macosx/CPlatformView");
+    DECLARE_METHOD(jm_deliverKeyEvent, jc_PlatformView,
                             "deliverKeyEvent", "(Lsun/lwawt/macosx/NSEvent;)V");
     jobject jlocal = (*env)->NewLocalRef(env, m_cPlatformView);
     if (!(*env)->IsSameObject(env, jlocal, NULL)) {
-        JNFCallVoidMethod(env, jlocal, jm_deliverKeyEvent, jEvent);
+        (*env)->CallVoidMethod(env, jlocal, jm_deliverKeyEvent, jEvent);
+        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, jlocal);
     }
     if (characters != NULL) {
@@ -497,12 +500,13 @@ static BOOL shouldUsePressAndHold() {
     jint w = (jint) rect.size.width;
     jint h = (jint) rect.size.height;
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    static JNF_CLASS_CACHE(jc_PlatformView, "sun/lwawt/macosx/CPlatformView");
-    static JNF_MEMBER_CACHE(jm_deliverResize, jc_PlatformView, "deliverResize", "(IIII)V");
+    DECLARE_CLASS(jc_PlatformView, "sun/lwawt/macosx/CPlatformView");
+    DECLARE_METHOD(jm_deliverResize, jc_PlatformView, "deliverResize", "(IIII)V");
 
     jobject jlocal = (*env)->NewLocalRef(env, m_cPlatformView);
     if (!(*env)->IsSameObject(env, jlocal, NULL)) {
-        JNFCallVoidMethod(env, jlocal, jm_deliverResize, x,y,w,h);
+        (*env)->CallVoidMethod(env, jlocal, jm_deliverResize, x,y,w,h);
+        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, jlocal);
     }
 }
@@ -531,11 +535,12 @@ static BOOL shouldUsePressAndHold() {
          }
          } else {
          */
-        static JNF_CLASS_CACHE(jc_CPlatformView, "sun/lwawt/macosx/CPlatformView");
-        static JNF_MEMBER_CACHE(jm_deliverWindowDidExposeEvent, jc_CPlatformView, "deliverWindowDidExposeEvent", "()V");
+        DECLARE_CLASS(jc_CPlatformView, "sun/lwawt/macosx/CPlatformView");
+        DECLARE_METHOD(jm_deliverWindowDidExposeEvent, jc_CPlatformView, "deliverWindowDidExposeEvent", "()V");
         jobject jlocal = (*env)->NewLocalRef(env, m_cPlatformView);
         if (!(*env)->IsSameObject(env, jlocal, NULL)) {
-            JNFCallVoidMethod(env, jlocal, jm_deliverWindowDidExposeEvent);
+            (*env)->CallVoidMethod(env, jlocal, jm_deliverWindowDidExposeEvent);
+            CHECK_EXCEPTION();
             (*env)->DeleteLocalRef(env, jlocal);
         }
         /*
@@ -570,8 +575,8 @@ static BOOL shouldUsePressAndHold() {
 // NSAccessibility support
 - (jobject)awtComponent:(JNIEnv*)env
 {
-    static JNF_CLASS_CACHE(jc_CPlatformView, "sun/lwawt/macosx/CPlatformView");
-    static JNF_MEMBER_CACHE(jf_Peer, jc_CPlatformView, "peer", "Lsun/lwawt/LWWindowPeer;");
+    DECLARE_CLASS_RETURN(jc_CPlatformView, "sun/lwawt/macosx/CPlatformView", NULL);
+    DECLARE_FIELD_RETURN(jf_Peer, jc_CPlatformView, "peer", "Lsun/lwawt/LWWindowPeer;", NULL);
     if ((env == NULL) || (m_cPlatformView == NULL)) {
         NSLog(@"Apple AWT : Error AWTView:awtComponent given bad parameters.");
         if (env != NULL)
@@ -584,26 +589,28 @@ static BOOL shouldUsePressAndHold() {
     jobject peer = NULL;
     jobject jlocal = (*env)->NewLocalRef(env, m_cPlatformView);
     if (!(*env)->IsSameObject(env, jlocal, NULL)) {
-        peer = JNFGetObjectField(env, jlocal, jf_Peer);
+        peer = (*env)->GetObjectField(env, jlocal, jf_Peer);
         (*env)->DeleteLocalRef(env, jlocal);
     }
-    static JNF_CLASS_CACHE(jc_LWWindowPeer, "sun/lwawt/LWWindowPeer");
-    static JNF_MEMBER_CACHE(jf_Target, jc_LWWindowPeer, "target", "Ljava/awt/Component;");
+    DECLARE_CLASS_RETURN(jc_LWWindowPeer, "sun/lwawt/LWWindowPeer", NULL);
+    DECLARE_FIELD_RETURN(jf_Target, jc_LWWindowPeer, "target", "Ljava/awt/Component;", NULL);
     if (peer == NULL) {
         NSLog(@"Apple AWT : Error AWTView:awtComponent got null peer from CPlatformView");
         JNFDumpJavaStack(env);
         return NULL;
     }
-    jobject comp = JNFGetObjectField(env, peer, jf_Target);
+    jobject comp = (*env)->GetObjectField(env, peer, jf_Target);
     (*env)->DeleteLocalRef(env, peer);
     return comp;
 }
 
 + (AWTView *) awtView:(JNIEnv*)env ofAccessible:(jobject)jaccessible
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getAWTView, sjc_CAccessibility, "getAWTView", "(Ljavax/accessibility/Accessible;)J");
+    DECLARE_CLASS_RETURN(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility", NULL);
+    DECLARE_STATIC_METHOD_RETURN(jm_getAWTView, sjc_CAccessibility, "getAWTView", "(Ljavax/accessibility/Accessible;)J", NULL);
 
-    jlong jptr = JNFCallStaticLongMethod(env, jm_getAWTView, jaccessible);
+    jlong jptr = (*env)->CallStaticLongMethod(env, sjc_CAccessibility, jm_getAWTView, jaccessible);
+    CHECK_EXCEPTION();
     if (jptr == 0) return nil;
 
     return (AWTView *)jlong_to_ptr(jptr);
@@ -929,7 +936,13 @@ static BOOL shouldUsePressAndHold() {
 /********************************  BEGIN NSTextInputClient Protocol  ********************************/
 
 
-JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
+static jclass jc_CInputMethod = NULL;
+
+#define GET_CIM_CLASS() \
+    GET_CLASS(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
+
+#define GET_CIM_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod", ret);
 
 - (void) insertText:(id)aString replacementRange:(NSRange)replacementRange
 {
@@ -970,16 +983,19 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     if ([self hasMarkedText] || !fProcessingKeystroke || aStringIsComplex) {
         JNIEnv *env = [ThreadUtilities getJNIEnv];
 
-        static JNF_MEMBER_CACHE(jm_selectPreviousGlyph, jc_CInputMethod, "selectPreviousGlyph", "()V");
+        GET_CIM_CLASS();
+        DECLARE_METHOD(jm_selectPreviousGlyph, jc_CInputMethod, "selectPreviousGlyph", "()V");
         // We need to select the previous glyph so that it is overwritten.
         if (fPAHNeedsToSelect) {
-            JNFCallVoidMethod(env, fInputMethodLOCKABLE, jm_selectPreviousGlyph);
+            (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_selectPreviousGlyph);
+            CHECK_EXCEPTION();
             fPAHNeedsToSelect = NO;
         }
 
-        static JNF_MEMBER_CACHE(jm_insertText, jc_CInputMethod, "insertText", "(Ljava/lang/String;)V");
+        DECLARE_METHOD(jm_insertText, jc_CInputMethod, "insertText", "(Ljava/lang/String;)V");
         jstring insertedText =  JNFNSToJavaString(env, useString);
-        JNFCallVoidMethod(env, fInputMethodLOCKABLE, jm_insertText, insertedText); // AWT_THREADING Safe (AWTRunLoopMode)
+        (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_insertText, insertedText); // AWT_THREADING Safe (AWTRunLoopMode)
+        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, insertedText);
 
         // The input method event will create psuedo-key events for each character in the committed string.
@@ -1034,16 +1050,18 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
 #ifdef IM_DEBUG
     fprintf(stderr, "AWTView InputMethod Selector Called : [setMarkedText] \"%s\", loc=%lu, length=%lu\n", [incomingString UTF8String], (unsigned long)selectionRange.location, (unsigned long)selectionRange.length);
 #endif // IM_DEBUG
-    static JNF_MEMBER_CACHE(jm_startIMUpdate, jc_CInputMethod, "startIMUpdate", "(Ljava/lang/String;)V");
-    static JNF_MEMBER_CACHE(jm_addAttribute, jc_CInputMethod, "addAttribute", "(ZZII)V");
-    static JNF_MEMBER_CACHE(jm_dispatchText, jc_CInputMethod, "dispatchText", "(IIZ)V");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CIM_CLASS();
+    DECLARE_METHOD(jm_startIMUpdate, jc_CInputMethod, "startIMUpdate", "(Ljava/lang/String;)V");
+    DECLARE_METHOD(jm_addAttribute, jc_CInputMethod, "addAttribute", "(ZZII)V");
+    DECLARE_METHOD(jm_dispatchText, jc_CInputMethod, "dispatchText", "(IIZ)V");
 
     // NSInputContext already did the analysis of the TSM event and created attributes indicating
     // the underlining and color that should be done to the string.  We need to look at the underline
     // style and color to determine what kind of Java hilighting needs to be done.
     jstring inProcessText = JNFNSToJavaString(env, incomingString);
-    JNFCallVoidMethod(env, fInputMethodLOCKABLE, jm_startIMUpdate, inProcessText); // AWT_THREADING Safe (AWTRunLoopMode)
+    (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_startIMUpdate, inProcessText); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
     (*env)->DeleteLocalRef(env, inProcessText);
 
     if (isAttributedString) {
@@ -1066,20 +1084,24 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
                 (NSColor *)[attributes objectForKey:NSUnderlineColorAttributeName];
                 isGray = !([underlineColorObj isEqual:[NSColor blackColor]]);
 
-                JNFCallVoidMethod(env, fInputMethodLOCKABLE, jm_addAttribute, isThickUnderline, isGray, effectiveRange.location, effectiveRange.length); // AWT_THREADING Safe (AWTRunLoopMode)
+                (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_addAttribute, isThickUnderline,
+                       isGray, effectiveRange.location, effectiveRange.length); // AWT_THREADING Safe (AWTRunLoopMode)
+                CHECK_EXCEPTION();
             }
         }
     }
 
-    static JNF_MEMBER_CACHE(jm_selectPreviousGlyph, jc_CInputMethod, "selectPreviousGlyph", "()V");
+    DECLARE_METHOD(jm_selectPreviousGlyph, jc_CInputMethod, "selectPreviousGlyph", "()V");
     // We need to select the previous glyph so that it is overwritten.
     if (fPAHNeedsToSelect) {
-        JNFCallVoidMethod(env, fInputMethodLOCKABLE, jm_selectPreviousGlyph);
+        (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_selectPreviousGlyph);
+         CHECK_EXCEPTION();
         fPAHNeedsToSelect = NO;
     }
 
-    JNFCallVoidMethod(env, fInputMethodLOCKABLE, jm_dispatchText, selectionRange.location, selectionRange.length, JNI_FALSE); // AWT_THREADING Safe (AWTRunLoopMode)
-
+    (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_dispatchText,
+            selectionRange.location, selectionRange.length, JNI_FALSE); // AWT_THREADING Safe (AWTRunLoopMode)
+         CHECK_EXCEPTION();
     // If the marked text is being cleared (zero-length string) don't handle the key event.
     if ([incomingString length] == 0) {
         fKeyEventsNeeded = NO;
@@ -1097,10 +1119,11 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     }
 
     // unmarkText cancels any input in progress and commits it to the text field.
-    static JNF_MEMBER_CACHE(jm_unmarkText, jc_CInputMethod, "unmarkText", "()V");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    JNFCallVoidMethod(env, fInputMethodLOCKABLE, jm_unmarkText); // AWT_THREADING Safe (AWTRunLoopMode)
-
+    GET_CIM_CLASS();
+    DECLARE_METHOD(jm_unmarkText, jc_CInputMethod, "unmarkText", "()V");
+    (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_unmarkText); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 }
 
 - (BOOL) hasMarkedText
@@ -1113,12 +1136,15 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
         return NO;
     }
 
-    static JNF_MEMBER_CACHE(jf_fCurrentText, jc_CInputMethod, "fCurrentText", "Ljava/text/AttributedString;");
-    static JNF_MEMBER_CACHE(jf_fCurrentTextLength, jc_CInputMethod, "fCurrentTextLength", "I");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject currentText = JNFGetObjectField(env, fInputMethodLOCKABLE, jf_fCurrentText);
+    GET_CIM_CLASS_RETURN(NO);
+    DECLARE_FIELD_RETURN(jf_fCurrentText, jc_CInputMethod, "fCurrentText", "Ljava/text/AttributedString;", NO);
+    DECLARE_FIELD_RETURN(jf_fCurrentTextLength, jc_CInputMethod, "fCurrentTextLength", "I", NO);
+    jobject currentText = (*env)->GetObjectField(env, fInputMethodLOCKABLE, jf_fCurrentText);
+    CHECK_EXCEPTION();
 
-    jint currentTextLength = JNFGetIntField(env, fInputMethodLOCKABLE, jf_fCurrentTextLength);
+    jint currentTextLength = (*env)->GetIntField(env, fInputMethodLOCKABLE, jf_fCurrentTextLength);
+    CHECK_EXCEPTION();
 
     BOOL hasMarkedText = (currentText != NULL && currentTextLength > 0);
 
@@ -1147,9 +1173,10 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     fprintf(stderr, "AWTView InputMethod Selector Called : [attributedSubstringFromRange] location=%lu, length=%lu\n", (unsigned long)theRange.location, (unsigned long)theRange.length);
 #endif // IM_DEBUG
 
-    static JNF_MEMBER_CACHE(jm_substringFromRange, jc_CInputMethod, "attributedSubstringFromRange", "(II)Ljava/lang/String;");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject theString = JNFCallObjectMethod(env, fInputMethodLOCKABLE, jm_substringFromRange, theRange.location, theRange.length); // AWT_THREADING Safe (AWTRunLoopMode)
+    DECLARE_METHOD_RETURN(jm_substringFromRange, jc_CInputMethod, "attributedSubstringFromRange", "(II)Ljava/lang/String;", nil);
+    jobject theString = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_substringFromRange, theRange.location, theRange.length); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION_NULL_RETURN(theString, nil);
 
     id result = [[[NSAttributedString alloc] initWithString:JNFJavaToNSString(env, theString)] autorelease];
 #ifdef IM_DEBUG
@@ -1174,14 +1201,16 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
         return NSMakeRange(NSNotFound, 0);
     }
 
-    static JNF_MEMBER_CACHE(jm_markedRange, jc_CInputMethod, "markedRange", "()[I");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     jarray array;
     jboolean isCopy;
     jint *_array;
     NSRange range = NSMakeRange(NSNotFound, 0);
+    GET_CIM_CLASS_RETURN(range);
+    DECLARE_METHOD_RETURN(jm_markedRange, jc_CInputMethod, "markedRange", "()[I", range);
 
-    array = JNFCallObjectMethod(env, fInputMethodLOCKABLE, jm_markedRange); // AWT_THREADING Safe (AWTRunLoopMode)
+    array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_markedRange); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 
     if (array) {
         _array = (*env)->GetIntArrayElements(env, array, &isCopy);
@@ -1209,18 +1238,20 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
         return NSMakeRange(NSNotFound, 0);
     }
 
-    static JNF_MEMBER_CACHE(jm_selectedRange, jc_CInputMethod, "selectedRange", "()[I");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     jarray array;
     jboolean isCopy;
     jint *_array;
     NSRange range = NSMakeRange(NSNotFound, 0);
+    GET_CIM_CLASS_RETURN(range);
+    DECLARE_METHOD_RETURN(jm_selectedRange, jc_CInputMethod, "selectedRange", "()[I", range);
 
 #ifdef IM_DEBUG
     fprintf(stderr, "AWTView InputMethod Selector Called : [selectedRange]\n");
 #endif // IM_DEBUG
 
-    array = JNFCallObjectMethod(env, fInputMethodLOCKABLE, jm_selectedRange); // AWT_THREADING Safe (AWTRunLoopMode)
+    array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_selectedRange); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
     if (array) {
         _array = (*env)->GetIntArrayElements(env, array, &isCopy);
         if (_array != NULL) {
@@ -1242,9 +1273,10 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
         return NSZeroRect;
     }
 
-    static JNF_MEMBER_CACHE(jm_firstRectForCharacterRange, jc_CInputMethod,
-                            "firstRectForCharacterRange", "(I)[I");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CIM_CLASS_RETURN(NSZeroRect);
+    DECLARE_METHOD_RETURN(jm_firstRectForCharacterRange, jc_CInputMethod,
+                            "firstRectForCharacterRange", "(I)[I", NSZeroRect);
     jarray array;
     jboolean isCopy;
     jint *_array;
@@ -1256,7 +1288,7 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
             (unsigned long)theRange.location, (unsigned long)theRange.length);
 #endif // IM_DEBUG
 
-    array = JNFCallObjectMethod(env, fInputMethodLOCKABLE, jm_firstRectForCharacterRange,
+    array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_firstRectForCharacterRange,
                                 theRange.location); // AWT_THREADING Safe (AWTRunLoopMode)
 
     _array = (*env)->GetIntArrayElements(env, array, &isCopy);
@@ -1285,9 +1317,10 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
         return NSNotFound;
     }
 
-    static JNF_MEMBER_CACHE(jm_characterIndexForPoint, jc_CInputMethod,
-                            "characterIndexForPoint", "(II)I");
     JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CIM_CLASS_RETURN(NSNotFound);
+    DECLARE_METHOD_RETURN(jm_characterIndexForPoint, jc_CInputMethod,
+                            "characterIndexForPoint", "(II)I", NSNotFound);
 
     NSPoint flippedLocation = ConvertNSScreenPoint(env, thePoint);
 
@@ -1295,7 +1328,9 @@ JNF_CLASS_CACHE(jc_CInputMethod, "sun/lwawt/macosx/CInputMethod");
     fprintf(stderr, "AWTView InputMethod Selector Called : [characterIndexForPoint:(NSPoint)thePoint] x=%f, y=%f\n", flippedLocation.x, flippedLocation.y);
 #endif // IM_DEBUG
 
-    jint index = JNFCallIntMethod(env, fInputMethodLOCKABLE, jm_characterIndexForPoint, (jint)flippedLocation.x, (jint)flippedLocation.y); // AWT_THREADING Safe (AWTRunLoopMode)
+    jint index = (*env)->CallIntMethod(env, fInputMethodLOCKABLE, jm_characterIndexForPoint,
+                      (jint)flippedLocation.x, (jint)flippedLocation.y); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 
 #ifdef IM_DEBUG
     fprintf(stderr, "characterIndexForPoint returning %d\n", index);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
@@ -38,6 +38,7 @@
 #import "DnDUtilities.h"
 #import "ThreadUtilities.h"
 #import "LWCToolkit.h"
+#import "JNIUtilities.h"
 
 
 // When sIsJavaDragging is true Java drag gesture has been recognized and a drag is/has been initialized.
@@ -69,9 +70,17 @@ static BOOL sIsJavaDragging;
 }
 @end
 
-JNF_CLASS_CACHE(DataTransfererClass, "sun/awt/datatransfer/DataTransferer");
-JNF_CLASS_CACHE(CDragSourceContextPeerClass, "sun/lwawt/macosx/CDragSourceContextPeer");
-JNF_CLASS_CACHE(CImageClass, "sun/lwawt/macosx/CImage");
+static jclass DataTransfererClass = NULL;
+static jclass CDragSourceContextPeerClass =  NULL;
+
+#define GET_DT_CLASS() \
+    GET_CLASS(DataTransfererClass, "sun/awt/datatransfer/DataTransferer");
+
+#define GET_DT_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(DataTransfererClass, "sun/awt/datatransfer/DataTransferer", ret);
+
+#define GET_DSCP_CLASS() \
+    GET_CLASS(CDragSourceContextPeerClass, "sun/lwawt/macosx/CDragSourceContextPeer");
 
 static NSDragOperation    sDragOperation;
 static NSPoint            sDraggingLocation;
@@ -212,8 +221,11 @@ static BOOL                sNeedsEnter;
 //
 - (jobject)dataTransferer:(JNIEnv*)env
 {
-    JNF_STATIC_MEMBER_CACHE(getInstanceMethod, DataTransfererClass, "getInstance", "()Lsun/awt/datatransfer/DataTransferer;");
-    return JNFCallStaticObjectMethod(env, getInstanceMethod);
+    GET_DT_CLASS_RETURN(NULL);
+    DECLARE_STATIC_METHOD_RETURN(getInstanceMethod, DataTransfererClass, "getInstance", "()Lsun/awt/datatransfer/DataTransferer;", NULL);
+    jobject o = (*env)->CallStaticObjectMethod(env, DataTransfererClass, getInstanceMethod);
+    CHECK_EXCEPTION();
+    return o;
 }
 
 // Appropriated from Windows' awt_DataTransferer.cpp:
@@ -227,9 +239,11 @@ static BOOL                sNeedsEnter;
     jbyteArray data = nil;
 
     if (transferer != NULL) {
-        JNF_MEMBER_CACHE(convertDataMethod, DataTransfererClass, "convertData", "(Ljava/lang/Object;Ljava/awt/datatransfer/Transferable;JLjava/util/Map;Z)[B");
-        data = JNFCallObjectMethod(env, transferer, convertDataMethod, fComponent, fTransferable, format, fFormatMap, (jboolean) TRUE);
+        GET_DT_CLASS_RETURN(NULL);
+        DECLARE_METHOD_RETURN(convertDataMethod, DataTransfererClass, "convertData", "(Ljava/lang/Object;Ljava/awt/datatransfer/Transferable;JLjava/util/Map;Z)[B", NULL);
+        data = (*env)->CallObjectMethod(env, transferer, convertDataMethod, fComponent, fTransferable, format, fFormatMap, (jboolean) TRUE);
     }
+    CHECK_EXCEPTION();
 
     return data;
 }
@@ -555,11 +569,14 @@ static BOOL                sNeedsEnter;
         }
 
         // DragSourceContextPeer.dragDropFinished() should be called even if there was an error:
-        JNF_MEMBER_CACHE(dragDropFinishedMethod, CDragSourceContextPeerClass, "dragDropFinished", "(ZIII)V");
+        GET_DSCP_CLASS();
+        DECLARE_METHOD(dragDropFinishedMethod, CDragSourceContextPeerClass, "dragDropFinished", "(ZIII)V");
         DLog3(@"  -> posting dragDropFinished, point %f, %f", point.x, point.y);
-        JNFCallVoidMethod(env, fDragSourceContextPeer, dragDropFinishedMethod, success, dragOp, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
-                JNF_MEMBER_CACHE(resetHoveringMethod, CDragSourceContextPeerClass, "resetHovering", "()V");
-        JNFCallVoidMethod(env, fDragSourceContextPeer, resetHoveringMethod); // Hust reset static variable
+        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragDropFinishedMethod, success, dragOp, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+        CHECK_EXCEPTION();
+        DECLARE_METHOD(resetHoveringMethod, CDragSourceContextPeerClass, "resetHovering", "()V");
+        (*env)->CallVoidMethod(env, fDragSourceContextPeer, resetHoveringMethod); // Hust reset static variable
+        CHECK_EXCEPTION();
     } @finally {
         sNeedsEnter = NO;
         AWTToolkit.inDoDragDropLoop = NO;
@@ -594,8 +611,10 @@ static BOOL                sNeedsEnter;
     DLog3(@"  -> posting operationChanged, point %f, %f", point.x, point.y);
     jint modifiedModifiers = fDragKeyModifiers | fDragMouseModifiers | [DnDUtilities javaKeyModifiersForNSDragOperation:dragOp];
 
-    JNF_MEMBER_CACHE(operationChangedMethod, CDragSourceContextPeerClass, "operationChanged", "(IIII)V");
-    JNFCallVoidMethod(env, fDragSourceContextPeer, operationChangedMethod, targetActions, modifiedModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    GET_DSCP_CLASS();
+    DECLARE_METHOD(operationChangedMethod, CDragSourceContextPeerClass, "operationChanged", "(IIII)V");
+    (*env)->CallVoidMethod(env, fDragSourceContextPeer, operationChangedMethod, targetActions, modifiedModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    CHECK_EXCEPTION();
 }
 
 - (NSDragOperation)draggingSourceOperationMaskForLocal:(BOOL)localDrag {
@@ -667,12 +686,14 @@ JNF_COCOA_ENTER(env);
         DLog4(@"[CDragSource draggedImage moved]: (%f, %f) %@\n", screenPoint.x, screenPoint.y, self);
 
         DLog3(@"  -> posting dragMotion, point %f, %f", point.x, point.y);
-        JNF_MEMBER_CACHE(dragMotionMethod, CDragSourceContextPeerClass, "dragMotion", "(IIII)V");
-        JNFCallVoidMethod(env, fDragSourceContextPeer, dragMotionMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
-
+        GET_DSCP_CLASS();
+        DECLARE_METHOD(dragMotionMethod, CDragSourceContextPeerClass, "dragMotion", "(IIII)V");
+        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragMotionMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+        CHECK_EXCEPTION();
         DLog3(@"  -> posting dragMouseMoved, point %f, %f", point.x, point.y);
-        JNF_MEMBER_CACHE(dragMouseMovedMethod, CDragSourceContextPeerClass, "dragMouseMoved", "(IIII)V");
-        JNFCallVoidMethod(env, fDragSourceContextPeer, dragMouseMovedMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+        DECLARE_METHOD(dragMouseMovedMethod, CDragSourceContextPeerClass, "dragMouseMoved", "(IIII)V");
+        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragMouseMovedMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+        CHECK_EXCEPTION();
     }
 JNF_COCOA_EXIT(env);
 }
@@ -696,8 +717,10 @@ JNF_COCOA_EXIT(env);
 
     NSPoint point = [self mapNSScreenPointToJavaWithOffset:sDraggingLocation];
     DLog3(@"  -> posting dragEnter, point %f, %f", point.x, point.y);
-    JNF_MEMBER_CACHE(dragEnterMethod, CDragSourceContextPeerClass, "dragEnter", "(IIII)V");
-    JNFCallVoidMethod(env, fDragSourceContextPeer, dragEnterMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    GET_DSCP_CLASS();
+    DECLARE_METHOD(dragEnterMethod, CDragSourceContextPeerClass, "dragEnter", "(IIII)V");
+    (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragEnterMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+     CHECK_EXCEPTION();
 }
 
 - (void) postDragExit {
@@ -706,8 +729,11 @@ JNF_COCOA_EXIT(env);
 
     NSPoint point = [self mapNSScreenPointToJavaWithOffset:sDraggingLocation];
     DLog3(@"  -> posting dragExit, point %f, %f", point.x, point.y);
-    JNF_MEMBER_CACHE(dragExitMethod, CDragSourceContextPeerClass, "dragExit", "(II)V");
-    JNFCallVoidMethod(env, fDragSourceContextPeer, dragExitMethod, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    GET_DSCP_CLASS();
+    DECLARE_METHOD(dragExitMethod, CDragSourceContextPeerClass, "dragExit", "(II)V");
+    (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragExitMethod, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    CHECK_EXCEPTION();
+
 }
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
@@ -40,6 +40,7 @@
 #import "CDataTransferer.h"
 #import "DnDUtilities.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 
 static NSInteger        sDraggingSequenceNumber = -1;
@@ -57,7 +58,12 @@ static jlongArray        sDraggingFormats = nil;
 
 static CDropTarget*        sCurrentDropTarget;
 
-extern JNFClassInfo jc_CDropTargetContextPeer;
+extern jclass jc_CDropTargetContextPeer;
+#define GET_DTCP_CLASS() \
+    GET_CLASS(jc_CDropTargetContextPeer, "sun/lwawt/macosx/CDropTargetContextPeer");
+
+#define GET_DTCP_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(jc_CDropTargetContextPeer, "sun/lwawt/macosx/CDropTargetContextPeer", ret);
 
 @implementation CDropTarget
 
@@ -458,10 +464,13 @@ extern JNFClassInfo jc_CDropTargetContextPeer;
         }
 
         // Look up the CDropTargetContextPeer class:
-        JNF_STATIC_MEMBER_CACHE(getDropTargetContextPeerMethod, jc_CDropTargetContextPeer, "getDropTargetContextPeer", "()Lsun/lwawt/macosx/CDropTargetContextPeer;");
+        GET_DTCP_CLASS_RETURN(dragOp);
+        DECLARE_STATIC_METHOD_RETURN(getDropTargetContextPeerMethod, jc_CDropTargetContextPeer,
+                                     "getDropTargetContextPeer", "()Lsun/lwawt/macosx/CDropTargetContextPeer;", dragOp)
         if (sDraggingError == FALSE) {
             // Create a new drop target context peer:
-            jobject dropTargetContextPeer = JNFCallStaticObjectMethod(env, getDropTargetContextPeerMethod);
+            jobject dropTargetContextPeer = (*env)->CallStaticObjectMethod(env, jc_CDropTargetContextPeer, getDropTargetContextPeerMethod);
+            CHECK_EXCEPTION();
 
             if (dropTargetContextPeer != nil) {
                 fDropTargetContextPeer = JNFNewGlobalRef(env, dropTargetContextPeer);
@@ -493,13 +502,16 @@ extern JNFClassInfo jc_CDropTargetContextPeer;
 
         jlongArray formats = sDraggingFormats;
 
-        JNF_MEMBER_CACHE(handleEnterMessageMethod, jc_CDropTargetContextPeer, "handleEnterMessage", "(Ljava/awt/Component;IIII[JJ)I");
+        GET_DTCP_CLASS_RETURN(dragOp);
+        DECLARE_METHOD_RETURN(handleEnterMessageMethod, jc_CDropTargetContextPeer,
+                              "handleEnterMessage", "(Ljava/awt/Component;IIII[JJ)I", dragOp);
         if (sDraggingError == FALSE) {
             // Double-casting self gets rid of 'different size' compiler warning:
             // AWT_THREADING Safe (CToolkitThreadBlockedHandler)
-            actions = JNFCallIntMethod(env, fDropTargetContextPeer, handleEnterMessageMethod,
+            actions = (*env)->CallIntMethod(env, fDropTargetContextPeer, handleEnterMessageMethod,
                                        fComponent, (jint) javaLocation.x, (jint) javaLocation.y,
                                        dropAction, actions, formats, ptr_to_jlong(self));
+            CHECK_EXCEPTION();
         }
 
         if (sDraggingError == FALSE) {
@@ -578,10 +590,13 @@ extern JNFClassInfo jc_CDropTargetContextPeer;
 
         jlongArray formats = sDraggingFormats;
 
-        JNF_MEMBER_CACHE(handleMotionMessageMethod, jc_CDropTargetContextPeer, "handleMotionMessage", "(Ljava/awt/Component;IIII[JJ)I");
+        GET_DTCP_CLASS_RETURN(dragOp);
+        DECLARE_METHOD_RETURN(handleMotionMessageMethod, jc_CDropTargetContextPeer, "handleMotionMessage", "(Ljava/awt/Component;IIII[JJ)I", dragOp);
         if (sDraggingError == FALSE) {
             DLog3(@"  >> posting handleMotionMessage, point %f, %f", javaLocation.x, javaLocation.y);
-            userAction = JNFCallIntMethod(env, fDropTargetContextPeer, handleMotionMessageMethod, fComponent, (jint) javaLocation.x, (jint) javaLocation.y, dropAction, actions, formats, ptr_to_jlong(self)); // AWT_THREADING Safe (CToolkitThreadBlockedHandler)
+            userAction = (*env)->CallIntMethod(env, fDropTargetContextPeer, handleMotionMessageMethod, fComponent,
+                         (jint) javaLocation.x, (jint) javaLocation.y, dropAction, actions, formats, ptr_to_jlong(self)); // AWT_THREADING Safe (CToolkitThreadBlockedHandler)
+        CHECK_EXCEPTION();
         }
 
         if (sDraggingError == FALSE) {
@@ -608,12 +623,14 @@ extern JNFClassInfo jc_CDropTargetContextPeer;
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
     if (sDraggingExited == FALSE && sDraggingError == FALSE) {
-        JNF_MEMBER_CACHE(handleExitMessageMethod, jc_CDropTargetContextPeer, "handleExitMessage", "(Ljava/awt/Component;J)V");
+        GET_DTCP_CLASS();
+        DECLARE_METHOD(handleExitMessageMethod, jc_CDropTargetContextPeer, "handleExitMessage", "(Ljava/awt/Component;J)V");
         if (sDraggingError == FALSE) {
             DLog3(@"  - dragExit: loc native %f, %f\n", sDraggingLocation.x, sDraggingLocation.y);
              // AWT_THREADING Safe (CToolkitThreadBlockedHandler)
-            JNFCallVoidMethod(env, fDropTargetContextPeer,
+            (*env)->CallVoidMethod(env, fDropTargetContextPeer,
                               handleExitMessageMethod, fComponent, ptr_to_jlong(self));
+            CHECK_EXCEPTION();
         }
 
         // 5-27-03 Note: [Radar 3270455]
@@ -658,10 +675,13 @@ extern JNFClassInfo jc_CDropTargetContextPeer;
 
         jlongArray formats = sDraggingFormats;
 
-        JNF_MEMBER_CACHE(handleDropMessageMethod, jc_CDropTargetContextPeer, "handleDropMessage", "(Ljava/awt/Component;IIII[JJ)V");
+        GET_DTCP_CLASS_RETURN(NO);
+        DECLARE_METHOD_RETURN(handleDropMessageMethod, jc_CDropTargetContextPeer, "handleDropMessage", "(Ljava/awt/Component;IIII[JJ)V", NO);
 
         if (sDraggingError == FALSE) {
-            JNFCallVoidMethod(env, fDropTargetContextPeer, handleDropMessageMethod, fComponent, (jint) javaLocation.x, (jint) javaLocation.y, dropAction, actions, formats, ptr_to_jlong(self)); // AWT_THREADING Safe (event)
+            (*env)->CallVoidMethod(env, fDropTargetContextPeer, handleDropMessageMethod, fComponent,
+                     (jint) javaLocation.x, (jint) javaLocation.y, dropAction, actions, formats, ptr_to_jlong(self)); // AWT_THREADING Safe (event)
+            CHECK_EXCEPTION();
         }
     } else {
         // 8-19-03 Note: [Radar 3368754]

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -26,6 +26,7 @@
 #import "LWCToolkit.h"
 #import "ThreadUtilities.h"
 #include "GeomUtilities.h"
+#include "JNIUtilities.h"
 
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
@@ -159,9 +160,10 @@ static jobject createJavaDisplayMode(CGDisplayModeRef mode, JNIEnv *env) {
         w = CGDisplayModeGetWidth(mode);
         CFRelease(currentBPP);
     }
-    static JNF_CLASS_CACHE(jc_DisplayMode, "java/awt/DisplayMode");
-    static JNF_CTOR_CACHE(jc_DisplayMode_ctor, jc_DisplayMode, "(IIII)V");
-    ret = JNFNewObject(env, jc_DisplayMode_ctor, w, h, bpp, refrate);
+    DECLARE_CLASS_RETURN(jc_DisplayMode, "java/awt/DisplayMode", ret);
+    DECLARE_METHOD_RETURN(jc_DisplayMode_ctor, jc_DisplayMode, "<init>", "(IIII)V", ret);
+    ret = (*env)->NewObject(env, jc_DisplayMode, jc_DisplayMode_ctor, w, h, bpp, refrate);
+    CHECK_EXCEPTION();
     JNF_COCOA_EXIT(env);
     return ret;
 }
@@ -252,9 +254,9 @@ JNF_COCOA_ENTER(env);
     jint left = visibleFrame.origin.x - frame.origin.x;
     jint right = frame.size.width - visibleFrame.size.width - left;
 
-    static JNF_CLASS_CACHE(jc_Insets, "java/awt/Insets");
-    static JNF_CTOR_CACHE(jc_Insets_ctor, jc_Insets, "(IIII)V");
-    ret = JNFNewObject(env, jc_Insets_ctor, top, left, bottom, right);
+    DECLARE_CLASS_RETURN(jc_Insets, "java/awt/Insets", ret);
+    DECLARE_METHOD_RETURN(jc_Insets_ctor, jc_Insets, "<init>", "(IIII)V", ret);
+    ret = (*env)->NewObject(env, jc_Insets, jc_Insets_ctor, top, left, bottom, right);
 
 JNF_COCOA_EXIT(env);
 
@@ -327,9 +329,9 @@ Java_sun_awt_CGraphicsDevice_nativeGetDisplayModes
     CFArrayRef allModes = getAllValidDisplayModes(displayID);
 
     CFIndex numModes = allModes ? CFArrayGetCount(allModes): 0;
-    static JNF_CLASS_CACHE(jc_DisplayMode, "java/awt/DisplayMode");
+    DECLARE_CLASS_RETURN(jc_DisplayMode, "java/awt/DisplayMode", NULL);
 
-    jreturnArray = JNFNewObjectArray(env, &jc_DisplayMode, (jsize) numModes);
+    jreturnArray = (*env)->NewObjectArray(env, (jsize)numModes, jc_DisplayMode, NULL);
     if (!jreturnArray) {
         NSLog(@"CGraphicsDevice can't create java array of DisplayMode objects");
         return nil;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
@@ -25,7 +25,7 @@
 
 #import "AWT_debug.h"
 
-#import "jni_util.h"
+#import "JNIUtilities.h"
 #import "ThreadUtilities.h"
 
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
@@ -74,7 +74,8 @@ JNF_COCOA_ENTER(env);
     }
 
     /* Allocate a java array for display identifiers */
-    ret = JNFNewIntArray(env, displayActiveCount);
+    ret = (*env)->NewIntArray(env, displayActiveCount);
+    CHECK_NULL_RETURN(ret, NULL);
 
     /* Initialize and return the backing int array */
     assert(sizeof(jint) >= sizeof(CGDirectDisplayID));
@@ -122,12 +123,13 @@ static void displaycb_handle
 
             jobject graphicsEnv = [wrapper jObjectWithEnv:env];
             if (graphicsEnv == NULL) return; // ref already GC'd
-            static JNF_CLASS_CACHE(jc_CGraphicsEnvironment, "sun/awt/CGraphicsEnvironment");
-            static JNF_MEMBER_CACHE(jm_displayReconfiguration,
+            DECLARE_CLASS(jc_CGraphicsEnvironment, "sun/awt/CGraphicsEnvironment");
+            DECLARE_METHOD(jm_displayReconfiguration,
                     jc_CGraphicsEnvironment, "_displayReconfiguration","(IZ)V");
-            JNFCallVoidMethod(env, graphicsEnv, jm_displayReconfiguration,
+            (*env)->CallVoidMethod(env, graphicsEnv, jm_displayReconfiguration,
                     (jint) display, (jboolean) flags & kCGDisplayRemoveFlag);
             (*env)->DeleteLocalRef(env, graphicsEnv);
+            CHECK_EXCEPTION();
         });
     }];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
@@ -405,8 +405,8 @@ JNF_COCOA_ENTER(env);
     }
 
     count = [sortedPixelSizes count];
-    static JNF_CLASS_CACHE(jc_Dimension, "java/awt/Dimension");
-    jreturnArray = JNFNewObjectArray(env, &jc_Dimension, count);
+    DECLARE_CLASS_RETURN(jc_Dimension, "java/awt/Dimension", jreturnArray);
+    jreturnArray = (*env)->NewObjectArray(env, count, jc_Dimension, NULL);
     CHECK_NULL_RETURN(jreturnArray, NULL);
 
     for(i = 0; i < count; i++){

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
@@ -30,6 +30,7 @@
 #import "AWTEvent.h"
 #import "AWTWindow.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 #import "java_awt_Event.h"
 #import "java_awt_event_KeyEvent.h"
@@ -92,23 +93,24 @@
     }
 
     if (fIsCheckbox) {
-        static JNF_CLASS_CACHE(jc_CCheckboxMenuItem, "sun/lwawt/macosx/CCheckboxMenuItem");
-        static JNF_MEMBER_CACHE(jm_ckHandleAction, jc_CCheckboxMenuItem, "handleAction", "(Z)V");
+        DECLARE_CLASS(jc_CCheckboxMenuItem, "sun/lwawt/macosx/CCheckboxMenuItem");
+        DECLARE_METHOD(jm_ckHandleAction, jc_CCheckboxMenuItem, "handleAction", "(Z)V");
 
         // Send the opposite of what's currently checked -- the action
         // indicates what state we're going to.
         NSInteger state = [sender state];
         jboolean newState = (state == NSOnState ? JNI_FALSE : JNI_TRUE);
-        JNFCallVoidMethod(env, fPeer, jm_ckHandleAction, newState);
+        (*env)->CallVoidMethod(env, fPeer, jm_ckHandleAction, newState);
     } else {
-        static JNF_CLASS_CACHE(jc_CMenuItem, "sun/lwawt/macosx/CMenuItem");
-        static JNF_MEMBER_CACHE(jm_handleAction, jc_CMenuItem, "handleAction", "(JI)V"); // AWT_THREADING Safe (event)
+        DECLARE_CLASS(jc_CMenuItem, "sun/lwawt/macosx/CMenuItem");
+        DECLARE_METHOD(jm_handleAction, jc_CMenuItem, "handleAction", "(JI)V"); // AWT_THREADING Safe (event)
 
         NSUInteger modifiers = [currEvent modifierFlags];
         jint javaModifiers = NsKeyModifiersToJavaModifiers(modifiers, NO);
 
-        JNFCallVoidMethod(env, fPeer, jm_handleAction, UTC(currEvent), javaModifiers); // AWT_THREADING Safe (event)
+        (*env)->CallVoidMethod(env, fPeer, jm_handleAction, UTC(currEvent), javaModifiers); // AWT_THREADING Safe (event)
     }
+    CHECK_EXCEPTION();
     JNF_COCOA_EXIT(env);
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -36,13 +36,29 @@
 #import "PrintModel.h"
 #import "ThreadUtilities.h"
 #import "GeomUtilities.h"
+#import "JNIUtilities.h"
 
-static JNF_CLASS_CACHE(sjc_Paper, "java/awt/print/Paper");
-static JNF_CLASS_CACHE(sjc_PageFormat, "java/awt/print/PageFormat");
-static JNF_CLASS_CACHE(sjc_CPrinterJob, "sun/lwawt/macosx/CPrinterJob");
-static JNF_CLASS_CACHE(sjc_CPrinterDialog, "sun/lwawt/macosx/CPrinterDialog");
-static JNF_MEMBER_CACHE(sjm_getNSPrintInfo, sjc_CPrinterJob, "getNSPrintInfo", "()J");
-static JNF_MEMBER_CACHE(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;");
+static jclass sjc_Paper = NULL;
+static jclass sjc_PageFormat = NULL;
+static jclass sjc_CPrinterJob = NULL;
+static jclass sjc_CPrinterDialog = NULL;
+static jmethodID sjm_getNSPrintInfo = NULL;
+static jmethodID sjm_printerJob = NULL;
+
+#define GET_PAPER_CLASS() GET_CLASS(sjc_Paper, "java/awt/print/Paper");
+#define GET_PAGEFORMAT_CLASS() GET_CLASS(sjc_PageFormat, "java/awt/print/PageFormat");
+#define GET_CPRINTERDIALOG_CLASS() GET_CLASS(sjc_CPrinterDialog, "sun/lwawt/macosx/CPrinterDialog");
+#define GET_CPRINTERDIALOG_CLASS_RETURN(ret) GET_CLASS_RETURN(sjc_CPrinterDialog, "sun/lwawt/macosx/CPrinterDialog", ret);
+#define GET_CPRINTERJOB_CLASS() GET_CLASS(sjc_CPrinterJob, "sun/lwawt/macosx/CPrinterJob");
+#define GET_CPRINTERJOB_CLASS_RETURN(ret) GET_CLASS_RETURN(sjc_CPrinterJob, "sun/lwawt/macosx/CPrinterJob", ret);
+
+#define GET_NSPRINTINFO_METHOD_RETURN(ret) \
+    GET_CPRINTERJOB_CLASS_RETURN(ret); \
+    GET_METHOD_RETURN(sjm_getNSPrintInfo, sjc_CPrinterJob, "getNSPrintInfo", "()J", ret);
+
+#define GET_CPRINTERDIALOG_METHOD_RETURN(ret) \
+   GET_CPRINTERDIALOG_CLASS_RETURN(ret); \
+   GET_METHOD_RETURN(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;", ret);
 
 static NSPrintInfo* createDefaultNSPrintInfo();
 
@@ -140,8 +156,10 @@ static void makeBestFit(NSPrintInfo* src)
 
 static void nsPrintInfoToJavaPaper(JNIEnv* env, NSPrintInfo* src, jobject dst)
 {
-    static JNF_MEMBER_CACHE(jm_setSize, sjc_Paper, "setSize", "(DD)V");
-    static JNF_MEMBER_CACHE(jm_setImageableArea, sjc_Paper, "setImageableArea", "(DDDD)V");
+    GET_PAGEFORMAT_CLASS();
+    GET_PAPER_CLASS();
+    DECLARE_METHOD(jm_setSize, sjc_Paper, "setSize", "(DD)V");
+    DECLARE_METHOD(jm_setImageableArea, sjc_Paper, "setImageableArea", "(DDDD)V");
 
     jdouble jPaperW, jPaperH;
 
@@ -167,7 +185,8 @@ static void nsPrintInfoToJavaPaper(JNIEnv* env, NSPrintInfo* src, jobject dst)
             break;
     }
 
-    JNFCallVoidMethod(env, dst, jm_setSize, jPaperW, jPaperH); // AWT_THREADING Safe (known object - always actual Paper)
+    (*env)->CallVoidMethod(env, dst, jm_setSize, jPaperW, jPaperH); // AWT_THREADING Safe (known object - always actual Paper)
+    CHECK_EXCEPTION();
 
     // Set the imageable area from the margins
     CGFloat leftM = [src leftMargin];
@@ -180,35 +199,44 @@ static void nsPrintInfoToJavaPaper(JNIEnv* env, NSPrintInfo* src, jobject dst)
     jdouble jImageW = jPaperW - (leftM + rightM);
     jdouble jImageH = jPaperH - (topM + bottomM);
 
-    JNFCallVoidMethod(env, dst, jm_setImageableArea, jImageX, jImageY, jImageW, jImageH); // AWT_THREADING Safe (known object - always actual Paper)
+    (*env)->CallVoidMethod(env, dst, jm_setImageableArea, jImageX, jImageY, jImageW, jImageH); // AWT_THREADING Safe (known object - always actual Paper)
+    CHECK_EXCEPTION();
 }
 
 static void javaPaperToNSPrintInfo(JNIEnv* env, jobject src, NSPrintInfo* dst)
 {
     AWT_ASSERT_NOT_APPKIT_THREAD;
 
-    static JNF_MEMBER_CACHE(jm_getWidth, sjc_Paper, "getWidth", "()D");
-    static JNF_MEMBER_CACHE(jm_getHeight, sjc_Paper, "getHeight", "()D");
-    static JNF_MEMBER_CACHE(jm_getImageableX, sjc_Paper, "getImageableX", "()D");
-    static JNF_MEMBER_CACHE(jm_getImageableY, sjc_Paper, "getImageableY", "()D");
-    static JNF_MEMBER_CACHE(jm_getImageableW, sjc_Paper, "getImageableWidth", "()D");
-    static JNF_MEMBER_CACHE(jm_getImageableH, sjc_Paper, "getImageableHeight", "()D");
+    GET_PAGEFORMAT_CLASS();
+    GET_PAPER_CLASS();
+    DECLARE_METHOD(jm_getWidth, sjc_Paper, "getWidth", "()D");
+    DECLARE_METHOD(jm_getHeight, sjc_Paper, "getHeight", "()D");
+    DECLARE_METHOD(jm_getImageableX, sjc_Paper, "getImageableX", "()D");
+    DECLARE_METHOD(jm_getImageableY, sjc_Paper, "getImageableY", "()D");
+    DECLARE_METHOD(jm_getImageableW, sjc_Paper, "getImageableWidth", "()D");
+    DECLARE_METHOD(jm_getImageableH, sjc_Paper, "getImageableHeight", "()D");
 
     // java Paper is always Portrait oriented. Set NSPrintInfo with this
     //  rectangle, and it's orientation may change. If necessary, be sure to call
     //  -[NSPrintInfo setOrientation] after this call, which will then
     //  adjust the -[NSPrintInfo paperSize] as well.
 
-    jdouble jPhysicalWidth = JNFCallDoubleMethod(env, src, jm_getWidth); // AWT_THREADING Safe (!appKit)
-    jdouble jPhysicalHeight = JNFCallDoubleMethod(env, src, jm_getHeight); // AWT_THREADING Safe (!appKit)
+    jdouble jPhysicalWidth = (*env)->CallDoubleMethod(env, src, jm_getWidth); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
+    jdouble jPhysicalHeight = (*env)->CallDoubleMethod(env, src, jm_getHeight); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
 
     [dst setPaperSize:NSMakeSize(jPhysicalWidth, jPhysicalHeight)];
 
     // Set the margins from the imageable area
-    jdouble jImageX = JNFCallDoubleMethod(env, src, jm_getImageableX); // AWT_THREADING Safe (!appKit)
-    jdouble jImageY = JNFCallDoubleMethod(env, src, jm_getImageableY); // AWT_THREADING Safe (!appKit)
-    jdouble jImageW = JNFCallDoubleMethod(env, src, jm_getImageableW); // AWT_THREADING Safe (!appKit)
-    jdouble jImageH = JNFCallDoubleMethod(env, src, jm_getImageableH); // AWT_THREADING Safe (!appKit)
+    jdouble jImageX = (*env)->CallDoubleMethod(env, src, jm_getImageableX); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
+    jdouble jImageY = (*env)->CallDoubleMethod(env, src, jm_getImageableY); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
+    jdouble jImageW = (*env)->CallDoubleMethod(env, src, jm_getImageableW); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
+    jdouble jImageH = (*env)->CallDoubleMethod(env, src, jm_getImageableH); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
 
     [dst setLeftMargin:(CGFloat)jImageX];
     [dst setTopMargin:(CGFloat)jImageY];
@@ -220,9 +248,12 @@ static void nsPrintInfoToJavaPageFormat(JNIEnv* env, NSPrintInfo* src, jobject d
 {
     AWT_ASSERT_NOT_APPKIT_THREAD;
 
-    static JNF_MEMBER_CACHE(jm_setOrientation, sjc_PageFormat, "setOrientation", "(I)V");
-    static JNF_MEMBER_CACHE(jm_setPaper, sjc_PageFormat, "setPaper", "(Ljava/awt/print/Paper;)V");
-    static JNF_CTOR_CACHE(jm_Paper_ctor, sjc_Paper, "()V");
+    GET_CPRINTERJOB_CLASS();
+    GET_PAGEFORMAT_CLASS();
+    GET_PAPER_CLASS();
+    DECLARE_METHOD(jm_setOrientation, sjc_PageFormat, "setOrientation", "(I)V");
+    DECLARE_METHOD(jm_setPaper, sjc_PageFormat, "setPaper", "(Ljava/awt/print/Paper;)V");
+    DECLARE_METHOD(jm_Paper_ctor, sjc_Paper, "<init>", "()V");
 
     jint jOrientation;
     switch ([src orientation]) {
@@ -246,15 +277,21 @@ static void nsPrintInfoToJavaPageFormat(JNIEnv* env, NSPrintInfo* src, jobject d
             break;
     }
 
-    JNFCallVoidMethod(env, dst, jm_setOrientation, jOrientation); // AWT_THREADING Safe (!appKit)
+    (*env)->CallVoidMethod(env, dst, jm_setOrientation, jOrientation); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
 
     // Create a new Paper
-    jobject paper = JNFNewObject(env, jm_Paper_ctor); // AWT_THREADING Safe (known object)
+    jobject paper = (*env)->NewObject(env, sjc_Paper, jm_Paper_ctor); // AWT_THREADING Safe (known object)
+    CHECK_EXCEPTION();
+    if (paper == NULL) {
+        return;
+    }
 
     nsPrintInfoToJavaPaper(env, src, paper);
 
     // Set the Paper in the PageFormat
-    JNFCallVoidMethod(env, dst, jm_setPaper, paper); // AWT_THREADING Safe (!appKit)
+    (*env)->CallVoidMethod(env, dst, jm_setPaper, paper); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
 
     (*env)->DeleteLocalRef(env, paper);
 }
@@ -263,9 +300,12 @@ static void javaPageFormatToNSPrintInfo(JNIEnv* env, jobject srcPrintJob, jobjec
 {
     AWT_ASSERT_NOT_APPKIT_THREAD;
 
-    static JNF_MEMBER_CACHE(jm_getOrientation, sjc_PageFormat, "getOrientation", "()I");
-    static JNF_MEMBER_CACHE(jm_getPaper, sjc_PageFormat, "getPaper", "()Ljava/awt/print/Paper;");
-    static JNF_MEMBER_CACHE(jm_getPrinterName, sjc_CPrinterJob, "getPrinterName", "()Ljava/lang/String;");
+    GET_CPRINTERJOB_CLASS();
+    GET_PAGEFORMAT_CLASS();
+    GET_PAPER_CLASS();
+    DECLARE_METHOD(jm_getOrientation, sjc_PageFormat, "getOrientation", "()I");
+    DECLARE_METHOD(jm_getPaper, sjc_PageFormat, "getPaper", "()Ljava/awt/print/Paper;");
+    DECLARE_METHOD(jm_getPrinterName, sjc_CPrinterJob, "getPrinterName", "()Ljava/lang/String;");
 
     // When setting page information (orientation, size) in NSPrintInfo, set the
     //  rectangle first. This is because setting the orientation will change the
@@ -274,11 +314,12 @@ static void javaPageFormatToNSPrintInfo(JNIEnv* env, jobject srcPrintJob, jobjec
     // Set up the paper. This will force Portrait since java Paper is
     //  not oriented. Then setting the NSPrintInfo orientation below
     //  will flip NSPrintInfo's info as necessary.
-    jobject paper = JNFCallObjectMethod(env, srcPageFormat, jm_getPaper); // AWT_THREADING Safe (!appKit)
+    jobject paper = (*env)->CallObjectMethod(env, srcPageFormat, jm_getPaper); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
     javaPaperToNSPrintInfo(env, paper, dstPrintInfo);
     (*env)->DeleteLocalRef(env, paper);
 
-    switch (JNFCallIntMethod(env, srcPageFormat, jm_getOrientation)) { // AWT_THREADING Safe (!appKit)
+    switch ((*env)->CallIntMethod(env, srcPageFormat, jm_getOrientation)) { // AWT_THREADING Safe (!appKit)
         case java_awt_print_PageFormat_PORTRAIT:
             [dstPrintInfo setOrientation:NS_PORTRAIT];
             break;
@@ -296,11 +337,13 @@ static void javaPageFormatToNSPrintInfo(JNIEnv* env, jobject srcPrintJob, jobjec
             [dstPrintInfo setOrientation:NS_PORTRAIT];
             break;
     }
+    CHECK_EXCEPTION();
 
     // <rdar://problem/4022422> NSPrinterInfo is not correctly set to the selected printer
     // from the Java side of CPrinterJob. Has always assumed the default printer was the one we wanted.
     if (srcPrintJob == NULL) return;
-    jobject printerNameObj = JNFCallObjectMethod(env, srcPrintJob, jm_getPrinterName);
+    jobject printerNameObj = (*env)->CallObjectMethod(env, srcPrintJob, jm_getPrinterName);
+    CHECK_EXCEPTION();
     if (printerNameObj == NULL) return;
     NSString *printerName = JNFJavaToNSString(env, printerNameObj);
     if (printerName == nil) return;
@@ -311,36 +354,41 @@ static void javaPageFormatToNSPrintInfo(JNIEnv* env, jobject srcPrintJob, jobjec
 
 static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject dstPrinterJob, jobject dstPageable)
 {
-    static JNF_MEMBER_CACHE(jm_setService, sjc_CPrinterJob, "setPrinterServiceFromNative", "(Ljava/lang/String;)V");
-    static JNF_MEMBER_CACHE(jm_setCopiesAttribute, sjc_CPrinterJob, "setCopiesAttribute", "(I)V");
-    static JNF_MEMBER_CACHE(jm_setCollated, sjc_CPrinterJob, "setCollated", "(Z)V");
-    static JNF_MEMBER_CACHE(jm_setPageRangeAttribute, sjc_CPrinterJob, "setPageRangeAttribute", "(IIZ)V");
-    static JNF_MEMBER_CACHE(jm_setPrintToFile, sjc_CPrinterJob, "setPrintToFile", "(Z)V");
+    GET_CPRINTERJOB_CLASS();
+    DECLARE_METHOD(jm_setService, sjc_CPrinterJob, "setPrinterServiceFromNative", "(Ljava/lang/String;)V");
+    DECLARE_METHOD(jm_setCopiesAttribute, sjc_CPrinterJob, "setCopiesAttribute", "(I)V");
+    DECLARE_METHOD(jm_setCollated, sjc_CPrinterJob, "setCollated", "(Z)V");
+    DECLARE_METHOD(jm_setPageRangeAttribute, sjc_CPrinterJob, "setPageRangeAttribute", "(IIZ)V");
+    DECLARE_METHOD(jm_setPrintToFile, sjc_CPrinterJob, "setPrintToFile", "(Z)V");
 
     if (src.jobDisposition == NSPrintSaveJob) {
-        JNFCallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, true);
+        (*env)->CallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, true);
+        CHECK_EXCEPTION();
     } else {
-        JNFCallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, false);
+        (*env)->CallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, false);
+        CHECK_EXCEPTION();
     }
 
     // get the selected printer's name, and set the appropriate PrintService on the Java side
     NSString *name = [[src printer] name];
     jstring printerName = JNFNSToJavaString(env, name);
-    JNFCallVoidMethod(env, dstPrinterJob, jm_setService, printerName);
-
+    (*env)->CallVoidMethod(env, dstPrinterJob, jm_setService, printerName);
+    CHECK_EXCEPTION();
 
     NSMutableDictionary* printingDictionary = [src dictionary];
 
     NSNumber* nsCopies = [printingDictionary objectForKey:NSPrintCopies];
     if ([nsCopies respondsToSelector:@selector(integerValue)])
     {
-        JNFCallVoidMethod(env, dstPrinterJob, jm_setCopiesAttribute, [nsCopies integerValue]); // AWT_THREADING Safe (known object)
+        (*env)->CallVoidMethod(env, dstPrinterJob, jm_setCopiesAttribute, [nsCopies integerValue]); // AWT_THREADING Safe (known object)
+        CHECK_EXCEPTION();
     }
 
     NSNumber* nsCollated = [printingDictionary objectForKey:NSPrintMustCollate];
     if ([nsCollated respondsToSelector:@selector(boolValue)])
     {
-        JNFCallVoidMethod(env, dstPrinterJob, jm_setCollated, [nsCollated boolValue] ? JNI_TRUE : JNI_FALSE); // AWT_THREADING Safe (known object)
+        (*env)->CallVoidMethod(env, dstPrinterJob, jm_setCollated, [nsCollated boolValue] ? JNI_TRUE : JNI_FALSE); // AWT_THREADING Safe (known object)
+        CHECK_EXCEPTION();
     }
 
     NSNumber* nsPrintAllPages = [printingDictionary objectForKey:NSPrintAllPages];
@@ -363,9 +411,9 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
             }
             isRangeSet = true;
         }
-        JNFCallVoidMethod(env, dstPrinterJob, jm_setPageRangeAttribute,
-                          jFirstPage, jLastPage, isRangeSet);
-            // AWT_THREADING Safe (known object)
+        (*env)->CallVoidMethod(env, dstPrinterJob, jm_setPageRangeAttribute,
+                          jFirstPage, jLastPage, isRangeSet); // AWT_THREADING Safe (known object)
+        CHECK_EXCEPTION();
 
     }
 }
@@ -374,27 +422,32 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
 {
     AWT_ASSERT_NOT_APPKIT_THREAD;
 
-    static JNF_CLASS_CACHE(jc_Pageable, "java/awt/print/Pageable");
-    static JNF_MEMBER_CACHE(jm_getCopies, sjc_CPrinterJob, "getCopiesInt", "()I");
-    static JNF_MEMBER_CACHE(jm_isCollated, sjc_CPrinterJob, "isCollated", "()Z");
-    static JNF_MEMBER_CACHE(jm_getFromPage, sjc_CPrinterJob, "getFromPageAttrib", "()I");
-    static JNF_MEMBER_CACHE(jm_getToPage, sjc_CPrinterJob, "getToPageAttrib", "()I");
-    static JNF_MEMBER_CACHE(jm_getMinPage, sjc_CPrinterJob, "getMinPageAttrib", "()I");
-    static JNF_MEMBER_CACHE(jm_getMaxPage, sjc_CPrinterJob, "getMaxPageAttrib", "()I");
-    static JNF_MEMBER_CACHE(jm_getSelectAttrib, sjc_CPrinterJob, "getSelectAttrib", "()I");
-    static JNF_MEMBER_CACHE(jm_getNumberOfPages, jc_Pageable, "getNumberOfPages", "()I");
-    static JNF_MEMBER_CACHE(jm_getPageFormat, sjc_CPrinterJob, "getPageFormatFromAttributes", "()Ljava/awt/print/PageFormat;");
+    DECLARE_CLASS(jc_Pageable, "java/awt/print/Pageable");
+    DECLARE_METHOD(jm_getCopies, sjc_CPrinterJob, "getCopiesInt", "()I");
+    DECLARE_METHOD(jm_isCollated, sjc_CPrinterJob, "isCollated", "()Z");
+    DECLARE_METHOD(jm_getFromPage, sjc_CPrinterJob, "getFromPageAttrib", "()I");
+    DECLARE_METHOD(jm_getToPage, sjc_CPrinterJob, "getToPageAttrib", "()I");
+    DECLARE_METHOD(jm_getMinPage, sjc_CPrinterJob, "getMinPageAttrib", "()I");
+    DECLARE_METHOD(jm_getMaxPage, sjc_CPrinterJob, "getMaxPageAttrib", "()I");
+    DECLARE_METHOD(jm_getSelectAttrib, sjc_CPrinterJob, "getSelectAttrib", "()I");
+    DECLARE_METHOD(jm_getNumberOfPages, jc_Pageable, "getNumberOfPages", "()I");
+    DECLARE_METHOD(jm_getPageFormat, sjc_CPrinterJob, "getPageFormatFromAttributes", "()Ljava/awt/print/PageFormat;");
 
     NSMutableDictionary* printingDictionary = [dst dictionary];
 
-    jint copies = JNFCallIntMethod(env, srcPrinterJob, jm_getCopies); // AWT_THREADING Safe (known object)
+    jint copies = (*env)->CallIntMethod(env, srcPrinterJob, jm_getCopies); // AWT_THREADING Safe (known object)
+    CHECK_EXCEPTION();
     [printingDictionary setObject:[NSNumber numberWithInteger:copies] forKey:NSPrintCopies];
 
-    jboolean collated = JNFCallBooleanMethod(env, srcPrinterJob, jm_isCollated); // AWT_THREADING Safe (known object)
+    jboolean collated = (*env)->CallBooleanMethod(env, srcPrinterJob, jm_isCollated); // AWT_THREADING Safe (known object)
+    CHECK_EXCEPTION();
     [printingDictionary setObject:[NSNumber numberWithBool:collated ? YES : NO] forKey:NSPrintMustCollate];
-    jint selectID = JNFCallIntMethod(env, srcPrinterJob, jm_getSelectAttrib);
-    jint fromPage = JNFCallIntMethod(env, srcPrinterJob, jm_getFromPage);
-    jint toPage = JNFCallIntMethod(env, srcPrinterJob, jm_getToPage);
+    jint selectID = (*env)->CallIntMethod(env, srcPrinterJob, jm_getSelectAttrib);
+    CHECK_EXCEPTION();
+    jint fromPage = (*env)->CallIntMethod(env, srcPrinterJob, jm_getFromPage);
+    CHECK_EXCEPTION();
+    jint toPage = (*env)->CallIntMethod(env, srcPrinterJob, jm_getToPage);
+    CHECK_EXCEPTION();
     if (selectID ==0) {
         [printingDictionary setObject:[NSNumber numberWithBool:YES] forKey:NSPrintAllPages];
     } else if (selectID == 2) {
@@ -403,8 +456,10 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
         [printingDictionary setObject:[NSNumber numberWithBool:NO] forKey:NSPrintAllPages];
         [printingDictionary setObject:[NSNumber numberWithBool:YES] forKey:NSPrintSelectionOnly];
     } else {
-        jint minPage = JNFCallIntMethod(env, srcPrinterJob, jm_getMinPage);
-        jint maxPage = JNFCallIntMethod(env, srcPrinterJob, jm_getMaxPage);
+        jint minPage = (*env)->CallIntMethod(env, srcPrinterJob, jm_getMinPage);
+        CHECK_EXCEPTION();
+        jint maxPage = (*env)->CallIntMethod(env, srcPrinterJob, jm_getMaxPage);
+        CHECK_EXCEPTION();
 
         // for PD_SELECTION or PD_NOSELECTION, check from/to page
         // to determine which radio button to select
@@ -419,7 +474,8 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
     [printingDictionary setObject:[NSNumber numberWithInteger:fromPage] forKey:NSPrintFirstPage];
     [printingDictionary setObject:[NSNumber numberWithInteger:toPage] forKey:NSPrintLastPage];
 
-    jobject page = JNFCallObjectMethod(env, srcPrinterJob, jm_getPageFormat);
+    jobject page = (*env)->CallObjectMethod(env, srcPrinterJob, jm_getPageFormat);
+    CHECK_EXCEPTION();
     if (page != NULL) {
         javaPageFormatToNSPrintInfo(env, NULL, page, dst);
     }
@@ -467,6 +523,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPrinterJob_validatePaper
   (JNIEnv *env, jobject jthis, jobject origpaper, jobject newpaper)
 {
 JNF_COCOA_ENTER(env);
+
 
     NSPrintInfo* printInfo = createDefaultNSPrintInfo(env, NULL);
     javaPaperToNSPrintInfo(env, origpaper, printInfo);
@@ -526,31 +583,37 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJob_printLoop
 {
     AWT_ASSERT_NOT_APPKIT_THREAD;
 
-    static JNF_MEMBER_CACHE(jm_getPageFormat, sjc_CPrinterJob, "getPageFormat", "(I)Ljava/awt/print/PageFormat;");
-    static JNF_MEMBER_CACHE(jm_getPageFormatArea, sjc_CPrinterJob, "getPageFormatArea", "(Ljava/awt/print/PageFormat;)Ljava/awt/geom/Rectangle2D;");
-    static JNF_MEMBER_CACHE(jm_getPrinterName, sjc_CPrinterJob, "getPrinterName", "()Ljava/lang/String;");
-    static JNF_MEMBER_CACHE(jm_getPageable, sjc_CPrinterJob, "getPageable", "()Ljava/awt/print/Pageable;");
+    GET_CPRINTERJOB_CLASS_RETURN(NO);
+    DECLARE_METHOD_RETURN(jm_getPageFormat, sjc_CPrinterJob, "getPageFormat", "(I)Ljava/awt/print/PageFormat;", NO);
+    DECLARE_METHOD_RETURN(jm_getPageFormatArea, sjc_CPrinterJob, "getPageFormatArea", "(Ljava/awt/print/PageFormat;)Ljava/awt/geom/Rectangle2D;", NO);
+    DECLARE_METHOD_RETURN(jm_getPrinterName, sjc_CPrinterJob, "getPrinterName", "()Ljava/lang/String;", NO);
+    DECLARE_METHOD_RETURN(jm_getPageable, sjc_CPrinterJob, "getPageable", "()Ljava/awt/print/Pageable;", NO);
 
     jboolean retVal = JNI_FALSE;
 
 JNF_COCOA_ENTER(env);
     // Get the first page's PageFormat for setting things up (This introduces
     //  and is a facet of the same problem in Radar 2818593/2708932).
-    jobject page = JNFCallObjectMethod(env, jthis, jm_getPageFormat, 0); // AWT_THREADING Safe (!appKit)
+    jobject page = (*env)->CallObjectMethod(env, jthis, jm_getPageFormat, 0); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
     if (page != NULL) {
-        jobject pageFormatArea = JNFCallObjectMethod(env, jthis, jm_getPageFormatArea, page); // AWT_THREADING Safe (!appKit)
+        jobject pageFormatArea = (*env)->CallObjectMethod(env, jthis, jm_getPageFormatArea, page); // AWT_THREADING Safe (!appKit)
+        CHECK_EXCEPTION();
 
         PrinterView* printerView = [[PrinterView alloc] initWithFrame:JavaToNSRect(env, pageFormatArea) withEnv:env withPrinterJob:jthis];
         [printerView setFirstPage:firstPage lastPage:lastPage];
 
-        NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr(JNFCallLongMethod(env, jthis, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
+        GET_NSPRINTINFO_METHOD_RETURN(NO)
+        NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr((*env)->CallLongMethod(env, jthis, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
+        CHECK_EXCEPTION();
 
         // <rdar://problem/4156975> passing jthis CPrinterJob as well, so we can extract the printer name from the current job
         javaPageFormatToNSPrintInfo(env, jthis, page, printInfo);
 
         // <rdar://problem/4093799> NSPrinterInfo is not correctly set to the selected printer
         // from the Java side of CPrinterJob. Had always assumed the default printer was the one we wanted.
-        jobject printerNameObj = JNFCallObjectMethod(env, jthis, jm_getPrinterName);
+        jobject printerNameObj = (*env)->CallObjectMethod(env, jthis, jm_getPrinterName);
+        CHECK_EXCEPTION();
         if (printerNameObj != NULL) {
             NSString *printerName = JNFJavaToNSString(env, printerNameObj);
             if (printerName != nil) {
@@ -560,7 +623,7 @@ JNF_COCOA_ENTER(env);
         }
 
         // <rdar://problem/4367998> JTable.print attributes are ignored
-        jobject pageable = JNFCallObjectMethod(env, jthis, jm_getPageable); // AWT_THREADING Safe (!appKit)
+        jobject pageable = (*env)->CallObjectMethod(env, jthis, jm_getPageable); // AWT_THREADING Safe (!appKit)
         javaPrinterJobToNSPrintInfo(env, jthis, pageable, printInfo);
 
         PrintModel* printModel = [[PrintModel alloc] initWithPrintInfo:printInfo];
@@ -596,15 +659,20 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterPageDialog_showDialog
   (JNIEnv *env, jobject jthis)
 {
 
-    static JNF_CLASS_CACHE(jc_CPrinterPageDialog, "sun/lwawt/macosx/CPrinterPageDialog");
-    static JNF_MEMBER_CACHE(jm_page, jc_CPrinterPageDialog, "fPage", "Ljava/awt/print/PageFormat;");
+    DECLARE_CLASS_RETURN(jc_CPrinterPageDialog, "sun/lwawt/macosx/CPrinterPageDialog", NO);
+    DECLARE_FIELD_RETURN(jm_page, jc_CPrinterPageDialog, "fPage", "Ljava/awt/print/PageFormat;", NO);
 
     jboolean result = JNI_FALSE;
 JNF_COCOA_ENTER(env);
-    jobject printerJob = JNFGetObjectField(env, jthis, sjm_printerJob);
-    NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr(JNFCallLongMethod(env, printerJob, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
+    GET_CPRINTERDIALOG_METHOD_RETURN(NO);
+    GET_NSPRINTINFO_METHOD_RETURN(NO)
+    jobject printerJob = (*env)->GetObjectField(env, jthis, sjm_printerJob);
+    if (printerJob == NULL) return NO;
+    NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr((*env)->CallLongMethod(env, printerJob, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
+    if (printInfo == NULL) return result;
 
-    jobject page = JNFGetObjectField(env, jthis, jm_page);
+    jobject page = (*env)->GetObjectField(env, jthis, jm_page);
+    if (page == NULL) return NO;
 
     // <rdar://problem/4156975> passing NULL, because only a CPrinterJob has a real printer associated with it
     javaPageFormatToNSPrintInfo(env, NULL, page, printInfo);
@@ -640,15 +708,19 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJobDialog_showDialog
   (JNIEnv *env, jobject jthis)
 {
-    static JNF_CLASS_CACHE(jc_CPrinterJobDialog, "sun/lwawt/macosx/CPrinterJobDialog");
-    static JNF_MEMBER_CACHE(jm_pageable, jc_CPrinterJobDialog, "fPageable", "Ljava/awt/print/Pageable;");
+    DECLARE_CLASS_RETURN(jc_CPrinterJobDialog, "sun/lwawt/macosx/CPrinterJobDialog", NO);
+    DECLARE_FIELD_RETURN(jm_pageable, jc_CPrinterJobDialog, "fPageable", "Ljava/awt/print/Pageable;", NO);
 
     jboolean result = JNI_FALSE;
 JNF_COCOA_ENTER(env);
-    jobject printerJob = JNFGetObjectField(env, jthis, sjm_printerJob);
-    NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr(JNFCallLongMethod(env, printerJob, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
+    GET_CPRINTERDIALOG_METHOD_RETURN(NO);
+    jobject printerJob = (*env)->GetObjectField(env, jthis, sjm_printerJob);
+    if (printerJob == NULL) return NO;
+    GET_NSPRINTINFO_METHOD_RETURN(NO)
+    NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr((*env)->CallLongMethod(env, printerJob, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
 
-    jobject pageable = JNFGetObjectField(env, jthis, jm_pageable);
+    jobject pageable = (*env)->GetObjectField(env, jthis, jm_pageable);
+    if (pageable == NULL) return NO;
 
     javaPrinterJobToNSPrintInfo(env, printerJob, pageable, printInfo);
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -32,6 +32,7 @@
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 NSColor **sColors = nil;
 NSColor **appleColors = nil;
@@ -46,8 +47,6 @@ JNF_COCOA_ENTER(env);
 JNF_COCOA_EXIT(env);
 }
 
-static JNF_CLASS_CACHE(jc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit");
-static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemColorsChanged", "()V");
 
 + (void)systemColorsDidChange:(NSNotification *)notification {
     AWT_ASSERT_APPKIT_THREAD;
@@ -57,7 +56,11 @@ static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemCol
     // Call LWCToolkit with the news. LWCToolkit makes certain to do its duties
     // from a new thread.
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    JNFCallStaticVoidMethod(env, jm_systemColorsChanged); // AWT_THREADING Safe (event)
+    DECLARE_CLASS(jc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit");
+    DECLARE_STATIC_METHOD(jm_systemColorsChanged, jc_LWCToolkit, "systemColorsChanged", "()V");
+    (*env)->CallStaticVoidMethod(env, jc_LWCToolkit, jm_systemColorsChanged); // AWT_THREADING Safe (event)
+    CHECK_EXCEPTION();
+
 }
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
@@ -35,6 +35,7 @@
 #import "CoreTextSupport.h"
 #import "QuartzSurfaceData.h"
 #include "AWTStrike.h"
+#import "JNIUtilities.h"
 
 static const CGAffineTransform sInverseTX = { 1, 0, 0, -1, 0, 0 };
 
@@ -322,7 +323,8 @@ static void DrawTextContext
 
 -----------------------------------*/
 
-static JNF_CLASS_CACHE(jc_StandardGlyphVector, "sun/font/StandardGlyphVector");
+static jclass jc_StandardGlyphVector = NULL;
+#define GET_SGV_CLASS() GET_CLASS(jc_StandardGlyphVector, "sun/font/StandardGlyphVector");
 
 // Checks the GlyphVector Java object for any transforms that were applied to individual characters. If none are present,
 // strike the glyphs immediately in Core Graphics. Otherwise, obtain the arrays, and defer to above.
@@ -330,8 +332,9 @@ static inline void doDrawGlyphsPipe_checkForPerGlyphTransforms
 (JNIEnv *env, QuartzSDOps *qsdo, const AWTStrike *strike, jobject gVector, BOOL useSubstituion, int *uniChars, CGGlyph *glyphs, CGSize *advances, size_t length)
 {
     // if we have no character substitution, and no per-glyph transformations - strike now!
-    static JNF_MEMBER_CACHE(jm_StandardGlyphVector_gti, jc_StandardGlyphVector, "gti", "Lsun/font/StandardGlyphVector$GlyphTransformInfo;");
-    jobject gti = JNFGetObjectField(env, gVector, jm_StandardGlyphVector_gti);
+    GET_SGV_CLASS();
+    DECLARE_FIELD(jm_StandardGlyphVector_gti, jc_StandardGlyphVector, "gti", "Lsun/font/StandardGlyphVector$GlyphTransformInfo;");
+    jobject gti = (*env)->GetObjectField(env, gVector, jm_StandardGlyphVector_gti);
     if (gti == 0)
     {
         if (useSubstituion)
@@ -347,9 +350,9 @@ static inline void doDrawGlyphsPipe_checkForPerGlyphTransforms
         return;
     }
 
-    static JNF_CLASS_CACHE(jc_StandardGlyphVector_GlyphTransformInfo, "sun/font/StandardGlyphVector$GlyphTransformInfo");
-    static JNF_MEMBER_CACHE(jm_StandardGlyphVector_GlyphTransformInfo_transforms, jc_StandardGlyphVector_GlyphTransformInfo, "transforms", "[D");
-    jdoubleArray g_gtiTransformsArray = JNFGetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_transforms); //(*env)->GetObjectField(env, gti, g_gtiTransforms);
+    DECLARE_CLASS(jc_StandardGlyphVector_GlyphTransformInfo, "sun/font/StandardGlyphVector$GlyphTransformInfo");
+    DECLARE_FIELD(jm_StandardGlyphVector_GlyphTransformInfo_transforms, jc_StandardGlyphVector_GlyphTransformInfo, "transforms", "[D");
+    jdoubleArray g_gtiTransformsArray = (*env)->GetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_transforms); //(*env)->GetObjectField(env, gti, g_gtiTransforms);
     if (g_gtiTransformsArray == NULL) {
         return;
     }
@@ -359,8 +362,8 @@ static inline void doDrawGlyphsPipe_checkForPerGlyphTransforms
         return;
     }
 
-    static JNF_MEMBER_CACHE(jm_StandardGlyphVector_GlyphTransformInfo_indices, jc_StandardGlyphVector_GlyphTransformInfo, "indices", "[I");
-    jintArray g_gtiTXIndicesArray = JNFGetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_indices);
+    DECLARE_FIELD(jm_StandardGlyphVector_GlyphTransformInfo_indices, jc_StandardGlyphVector_GlyphTransformInfo, "indices", "[I");
+    jintArray g_gtiTXIndicesArray = (*env)->GetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_indices);
     jint *g_gvTXIndicesAsInts = (*env)->GetPrimitiveArrayCritical(env, g_gtiTXIndicesArray, NULL);
     if (g_gvTXIndicesAsInts == NULL) {
         (*env)->ReleasePrimitiveArrayCritical(env, g_gtiTransformsArray, g_gvTransformsAsDoubles, JNI_ABORT);
@@ -437,8 +440,9 @@ static inline void doDrawGlyphsPipe_fillGlyphAndAdvanceBuffers
     (*env)->ReleasePrimitiveArrayCritical(env, glyphsArray, glyphsAsInts, JNI_ABORT);
 
     // fill the advance buffer
-    static JNF_MEMBER_CACHE(jm_StandardGlyphVector_positions, jc_StandardGlyphVector, "positions", "[F");
-    jfloatArray posArray = JNFGetObjectField(env, gVector, jm_StandardGlyphVector_positions);
+    GET_SGV_CLASS();
+    DECLARE_FIELD(jm_StandardGlyphVector_positions, jc_StandardGlyphVector, "positions", "[F");
+    jfloatArray posArray = (*env)->GetObjectField(env, gVector, jm_StandardGlyphVector_positions);
     jfloat *positions = NULL;
     if (posArray != NULL) {
         // in this case, the positions have already been pre-calculated for us on the Java side
@@ -497,8 +501,9 @@ static inline void doDrawGlyphsPipe_fillGlyphAndAdvanceBuffers
 static inline void doDrawGlyphsPipe_getGlyphVectorLengthAndAlloc
 (JNIEnv *env, QuartzSDOps *qsdo, const AWTStrike *strike, jobject gVector)
 {
-    static JNF_MEMBER_CACHE(jm_StandardGlyphVector_glyphs, jc_StandardGlyphVector, "glyphs", "[I");
-    jintArray glyphsArray = JNFGetObjectField(env, gVector, jm_StandardGlyphVector_glyphs);
+    GET_SGV_CLASS();
+    DECLARE_FIELD(jm_StandardGlyphVector_glyphs, jc_StandardGlyphVector, "glyphs", "[I");
+    jintArray glyphsArray = (*env)->GetObjectField(env, gVector, jm_StandardGlyphVector_glyphs);
     jsize length = (*env)->GetArrayLength(env, glyphsArray);
 
     if (length == 0)

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
@@ -146,9 +146,9 @@ static NSSize ScaledImageSizeForStatusBar(NSSize imageSize, BOOL autosize) {
         deltaY = [event scrollingDeltaY] * 0.1;
     }
 
-    static JNF_CLASS_CACHE(jc_NSEvent, "sun/lwawt/macosx/NSEvent");
-    static JNF_CTOR_CACHE(jctor_NSEvent, jc_NSEvent, "(IIIIIIIIDDI)V");
-    jobject jEvent = JNFNewObject(env, jctor_NSEvent,
+    DECLARE_CLASS(jc_NSEvent, "sun/lwawt/macosx/NSEvent");
+    DECLARE_METHOD(jctor_NSEvent, jc_NSEvent, "<init>", "(IIIIIIIIDDI)V");
+    jobject jEvent = (*env)->NewObject(env, jc_NSEvent, jctor_NSEvent,
                                   [event type],
                                   [event modifierFlags],
                                   clickCount,
@@ -160,9 +160,10 @@ static NSSize ScaledImageSizeForStatusBar(NSSize imageSize, BOOL autosize) {
                                   [AWTToolkit scrollStateWithEvent: event]);
     CHECK_NULL(jEvent);
 
-    static JNF_CLASS_CACHE(jc_TrayIcon, "sun/lwawt/macosx/CTrayIcon");
-    static JNF_MEMBER_CACHE(jm_handleMouseEvent, jc_TrayIcon, "handleMouseEvent", "(Lsun/lwawt/macosx/NSEvent;)V");
-    JNFCallVoidMethod(env, peer, jm_handleMouseEvent, jEvent);
+    DECLARE_CLASS(jc_TrayIcon, "sun/lwawt/macosx/CTrayIcon");
+    DECLARE_METHOD(jm_handleMouseEvent, jc_TrayIcon, "handleMouseEvent", "(Lsun/lwawt/macosx/NSEvent;)V");
+    (*env)->CallVoidMethod(env, peer, jm_handleMouseEvent, jEvent);
+    CHECK_EXCEPTION();
     (*env)->DeleteLocalRef(env, jEvent);
 }
 
@@ -268,9 +269,10 @@ static NSSize ScaledImageSizeForStatusBar(NSSize imageSize, BOOL autosize) {
     if (([event modifierFlags] & NSControlKeyMask) == 0) {
         //find CTrayIcon.getPopupMenuModel method and call it to get popup menu ptr.
         JNIEnv *env = [ThreadUtilities getJNIEnv];
-        static JNF_CLASS_CACHE(jc_CTrayIcon, "sun/lwawt/macosx/CTrayIcon");
-        static JNF_MEMBER_CACHE(jm_getPopupMenuModel, jc_CTrayIcon, "getPopupMenuModel", "()J");
-        jlong res = JNFCallLongMethod(env, trayIcon.peer, jm_getPopupMenuModel);
+        DECLARE_CLASS(jc_CTrayIcon, "sun/lwawt/macosx/CTrayIcon");
+        DECLARE_METHOD(jm_getPopupMenuModel, jc_CTrayIcon, "getPopupMenuModel", "()J");
+        jlong res = (*env)->CallLongMethod(env, trayIcon.peer, jm_getPopupMenuModel);
+        CHECK_EXCEPTION();
 
         if (res != 0) {
             CPopupMenu *cmenu = jlong_to_ptr(res);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.h
@@ -24,10 +24,9 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#include "jni.h"
+#include "JNIUtilities.h"
 
 jobject CGToJavaRect(JNIEnv *env, CGRect rect);
-CGRect JavaToCGRect(JNIEnv *env, jobject rect);
 
 jobject NSToJavaRect(JNIEnv *env, NSRect rect);
 NSRect JavaToNSRect(JNIEnv *env, jobject rect);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.m
@@ -24,27 +24,13 @@
  */
 
 #import "GeomUtilities.h"
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
-static JNF_CLASS_CACHE(sjc_Point2D, "java/awt/geom/Point2D");
-static JNF_MEMBER_CACHE(jm_pt_getX, sjc_Point2D, "getX", "()D");
-static JNF_MEMBER_CACHE(jm_pt_getY, sjc_Point2D, "getY", "()D");
-
-static JNF_CLASS_CACHE(sjc_Dimension2D, "java/awt/geom/Dimension2D");
-static JNF_MEMBER_CACHE(jm_sz_getWidth, sjc_Dimension2D, "getWidth", "()D");
-static JNF_MEMBER_CACHE(jm_sz_getHeight, sjc_Dimension2D, "getHeight", "()D");
-
-static JNF_CLASS_CACHE(sjc_Rectangle2D, "java/awt/geom/Rectangle2D");
-static JNF_MEMBER_CACHE(jm_rect_getX, sjc_Rectangle2D, "getX", "()D");
-static JNF_MEMBER_CACHE(jm_rect_getY, sjc_Rectangle2D, "getY", "()D");
-static JNF_MEMBER_CACHE(jm_rect_getWidth, sjc_Rectangle2D, "getWidth", "()D");
-static JNF_MEMBER_CACHE(jm_rect_getHeight, sjc_Rectangle2D, "getHeight", "()D");
-
 
 static jobject NewJavaRect(JNIEnv *env, jdouble x, jdouble y, jdouble w, jdouble h) {
-    static JNF_CLASS_CACHE(sjc_Rectangle2DDouble, "java/awt/geom/Rectangle2D$Double");
-    static JNF_CTOR_CACHE(ctor_Rectangle2DDouble, sjc_Rectangle2DDouble, "(DDDD)V");
-    return JNFNewObject(env, ctor_Rectangle2DDouble, x, y, w, h);
+    DECLARE_CLASS_RETURN(sjc_Rectangle2DDouble, "java/awt/geom/Rectangle2D$Double", NULL);
+    DECLARE_METHOD_RETURN(ctor_Rectangle2DDouble, sjc_Rectangle2DDouble, "<init>", "(DDDD)V", NULL);
+    jobject o = (*env)->NewObject(env, sjc_Rectangle2DDouble, ctor_Rectangle2DDouble, x, y, w, h);
+    CHECK_EXCEPTION();
+    return o;
 }
 
 jobject CGToJavaRect(JNIEnv *env, CGRect rect) {
@@ -63,46 +49,55 @@ jobject NSToJavaRect(JNIEnv *env, NSRect rect) {
                        rect.size.height);
 }
 
-CGRect JavaToCGRect(JNIEnv *env, jobject rect) {
-    return CGRectMake(JNFCallDoubleMethod(env, rect, jm_rect_getX),
-                      JNFCallDoubleMethod(env, rect, jm_rect_getY),
-                      JNFCallDoubleMethod(env, rect, jm_rect_getWidth),
-                      JNFCallDoubleMethod(env, rect, jm_rect_getHeight));
-}
-
 NSRect JavaToNSRect(JNIEnv *env, jobject rect) {
-    return NSMakeRect(JNFCallDoubleMethod(env, rect, jm_rect_getX),
-                      JNFCallDoubleMethod(env, rect, jm_rect_getY),
-                      JNFCallDoubleMethod(env, rect, jm_rect_getWidth),
-                      JNFCallDoubleMethod(env, rect, jm_rect_getHeight));
+    DECLARE_CLASS_RETURN(sjc_Rectangle2D, "java/awt/geom/Rectangle2D", NSZeroRect);
+    DECLARE_METHOD_RETURN(jm_rect_getX, sjc_Rectangle2D, "getX", "()D", NSZeroRect);
+    DECLARE_METHOD_RETURN(jm_rect_getY, sjc_Rectangle2D, "getY", "()D", NSZeroRect);
+    DECLARE_METHOD_RETURN(jm_rect_getWidth, sjc_Rectangle2D, "getWidth", "()D", NSZeroRect);
+    DECLARE_METHOD_RETURN(jm_rect_getHeight, sjc_Rectangle2D, "getHeight", "()D", NSZeroRect);
+    return NSMakeRect((*env)->CallDoubleMethod(env, rect, jm_rect_getX),
+                      (*env)->CallDoubleMethod(env, rect, jm_rect_getY),
+                      (*env)->CallDoubleMethod(env, rect, jm_rect_getWidth),
+                      (*env)->CallDoubleMethod(env, rect, jm_rect_getHeight));
 }
 
 jobject NSToJavaPoint(JNIEnv *env, NSPoint point) {
-    static JNF_CLASS_CACHE(sjc_Point2DDouble, "java/awt/geom/Point2D$Double");
-    static JNF_CTOR_CACHE(ctor_Point2DDouble, sjc_Point2DDouble, "(DD)V");
-    return JNFNewObject(env, ctor_Point2DDouble, (jdouble)point.x, (jdouble)point.y);
+    DECLARE_CLASS_RETURN(sjc_Point2DDouble, "java/awt/geom/Point2D$Double", NULL);
+    DECLARE_METHOD_RETURN(ctor_Point2DDouble, sjc_Point2DDouble, "<init>", "(DD)V", NULL);
+    jobject o =  (*env)->NewObject(env, sjc_Point2DDouble, ctor_Point2DDouble, (jdouble)point.x, (jdouble)point.y);
+    CHECK_EXCEPTION();
+    return o;
 }
 
 NSPoint JavaToNSPoint(JNIEnv *env, jobject point) {
-    return NSMakePoint(JNFCallDoubleMethod(env, point, jm_pt_getX),
-                       JNFCallDoubleMethod(env, point, jm_pt_getY));
+    DECLARE_CLASS_RETURN(sjc_Point2D, "java/awt/geom/Point2D", NSZeroPoint);
+    DECLARE_METHOD_RETURN(jm_pt_getX, sjc_Point2D, "getX", "()D", NSZeroPoint);
+    DECLARE_METHOD_RETURN(jm_pt_getY, sjc_Point2D, "getY", "()D", NSZeroPoint);
+
+    return NSMakePoint((*env)->CallDoubleMethod(env, point, jm_pt_getX),
+                       (*env)->CallDoubleMethod(env, point, jm_pt_getY));
 }
 
 jobject NSToJavaSize(JNIEnv *env, NSSize size) {
-    static JNF_CLASS_CACHE(sjc_Dimension2DDouble, "java/awt/Dimension"); // No Dimension2D$Double :-(
-    static JNF_CTOR_CACHE(ctor_Dimension2DDouble, sjc_Dimension2DDouble, "(II)V");
-    return JNFNewObject(env, ctor_Dimension2DDouble, (jint)size.width, (jint)size.height);
+    DECLARE_CLASS_RETURN(sjc_Dimension2DDouble, "java/awt/Dimension", NULL); // No Dimension2D$Double :-(
+    DECLARE_METHOD_RETURN(ctor_Dimension2DDouble, sjc_Dimension2DDouble, "<init>", "(II)V", NULL);
+    jobject o = (*env)->NewObject(env, sjc_Dimension2DDouble, ctor_Dimension2DDouble, (jint)size.width, (jint)size.height);
+    CHECK_EXCEPTION();
+    return o;
 }
 
 NSSize JavaToNSSize(JNIEnv *env, jobject dimension) {
-    return NSMakeSize(JNFCallDoubleMethod(env, dimension, jm_sz_getWidth),
-                      JNFCallDoubleMethod(env, dimension, jm_sz_getHeight));
+    DECLARE_CLASS_RETURN(sjc_Dimension2D, "java/awt/geom/Dimension2D", NSZeroSize);
+    DECLARE_METHOD_RETURN(jm_sz_getWidth, sjc_Dimension2D, "getWidth", "()D", NSZeroSize);
+    DECLARE_METHOD_RETURN(jm_sz_getHeight, sjc_Dimension2D, "getHeight", "()D", NSZeroSize);
+
+    return NSMakeSize((*env)->CallDoubleMethod(env, dimension, jm_sz_getWidth),
+                      (*env)->CallDoubleMethod(env, dimension, jm_sz_getHeight));
 }
 
 static NSScreen *primaryScreen(JNIEnv *env) {
     NSScreen *primaryScreen = [[NSScreen screens] objectAtIndex:0];
     if (primaryScreen != nil) return primaryScreen;
-    if (env != NULL) [JNFException raise:env as:kRuntimeException reason:"Failed to convert, no screen."];
     return nil;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
@@ -27,6 +27,7 @@
 #import "JavaAccessibilityUtilities.h"
 
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 
 @implementation JavaAxAction
@@ -57,20 +58,22 @@
 
 - (NSString *)getDescription
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleActionDescription, sjc_CAccessibility, "getAccessibleActionDescription", "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)Ljava/lang/String;");
-
     JNIEnv* env = [ThreadUtilities getJNIEnv];
+    DECLARE_CLASS_RETURN(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility", nil);
+    DECLARE_METHOD_RETURN(jm_getAccessibleActionDescription, sjc_CAccessibility, "getAccessibleActionDescription",
+                          "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)Ljava/lang/String;", nil);
 
     jobject fCompLocal = (*env)->NewLocalRef(env, fComponent);
     if ((*env)->IsSameObject(env, fCompLocal, NULL)) {
         return nil;
     }
     NSString *str = nil;
-    jstring jstr = JNFCallStaticObjectMethod( env,
+    jstring jstr = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
                                               jm_getAccessibleActionDescription,
                                               fAccessibleAction,
                                               fIndex,
                                               fCompLocal );
+    CHECK_EXCEPTION();
     if (jstr != NULL) {
         str = JNFJavaToNSString(env, jstr); // AWT_THREADING Safe (AWTRunLoopMode)
         (*env)->DeleteLocalRef(env, jstr);
@@ -81,11 +84,14 @@
 
 - (void)perform
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_doAccessibleAction, sjc_CAccessibility, "doAccessibleAction", "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)V");
-
     JNIEnv* env = [ThreadUtilities getJNIEnv];
+    DECLARE_CLASS(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility");
+    DECLARE_METHOD(jm_doAccessibleAction, sjc_CAccessibility, "doAccessibleAction",
+                    "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)V");
 
-    JNFCallStaticVoidMethod(env, jm_doAccessibleAction, fAccessibleAction, fIndex, fComponent); // AWT_THREADING Safe (AWTRunLoopMode)
+    (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_doAccessibleAction,
+             fAccessibleAction, fIndex, fComponent); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.h
@@ -30,18 +30,10 @@ extern NSString *const JavaAccessibilityIgnore;
 extern NSMutableDictionary *sRoles;
 extern void initializeRoles();
 
-extern JNFClassInfo sjc_CAccessibility;
-extern JNFClassInfo sjc_AccessibleComponent;
-extern JNFClassInfo sjc_AccessibleContext;
-extern JNFClassInfo sjc_Accessible;
-extern JNFClassInfo sjc_AccessibleRole;
-extern JNFClassInfo sjc_Point;
-extern JNFClassInfo sjc_AccessibleText;
-
-extern JNFMemberInfo *sjm_getAccessibleRole;
-extern JNFMemberInfo *sjf_key;
-extern JNFMemberInfo *sjf_X;
-extern JNFMemberInfo *sjf_Y;
+#define GET_CACCESSIBILITY_CLASS() \
+    GET_CLASS(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility");
+#define GET_CACCESSIBILITY_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility", ret);
 
 NSSize getAxComponentSize(JNIEnv *env, jobject axComponent, jobject component);
 NSString *getJavaRole(JNIEnv *env, jobject axComponent, jobject component);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.m
@@ -24,6 +24,7 @@
  */
 
 #import "JavaAccessibilityUtilities.h"
+#import "JNIUtilities.h"
 
 #import <AppKit/AppKit.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
@@ -43,38 +44,35 @@ NSMutableDictionary *sRoles = nil;
 void initializeRoles();
 
 // Unique
-static JNF_CLASS_CACHE(sjc_AccessibleState, "javax/accessibility/AccessibleState");
+static jclass sjc_AccessibleState = NULL;
+#define GET_ACCESSIBLESTATE_CLASS_RETURN(ret) \
+     GET_CLASS_RETURN(sjc_AccessibleState, "javax/accessibility/AccessibleState", ret);
 
-// Duplicate
-JNF_CLASS_CACHE(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility");
-JNF_CLASS_CACHE(sjc_AccessibleComponent, "javax/accessibility/AccessibleComponent");
-JNF_CLASS_CACHE(sjc_AccessibleContext, "javax/accessibility/AccessibleContext");
-JNF_CLASS_CACHE(sjc_Accessible, "javax/accessibility/Accessible");
-JNF_CLASS_CACHE(sjc_AccessibleRole, "javax/accessibility/AccessibleRole");
-JNF_CLASS_CACHE(sjc_Point, "java/awt/Point");
-JNF_CLASS_CACHE(sjc_AccessibleText, "javax/accessibility/AccessibleText");
-
-JNF_MEMBER_CACHE(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;");
-JNF_MEMBER_CACHE(sjf_X, sjc_Point, "x", "I");
-JNF_MEMBER_CACHE(sjf_Y, sjc_Point, "y", "I");
+static jclass sjc_CAccessibility = NULL;
 
 NSSize getAxComponentSize(JNIEnv *env, jobject axComponent, jobject component)
 {
-    static JNF_CLASS_CACHE(jc_Dimension, "java/awt/Dimension");
-    static JNF_MEMBER_CACHE(jf_width, jc_Dimension, "width", "I");
-    static JNF_MEMBER_CACHE(jf_height, jc_Dimension, "height", "I");
-    static JNF_STATIC_MEMBER_CACHE(jm_getSize, sjc_CAccessibility, "getSize", "(Ljavax/accessibility/AccessibleComponent;Ljava/awt/Component;)Ljava/awt/Dimension;");
+    DECLARE_CLASS_RETURN(jc_Dimension, "java/awt/Dimension", NSZeroSize);
+    DECLARE_FIELD_RETURN(jf_width, jc_Dimension, "width", "I", NSZeroSize);
+    DECLARE_FIELD_RETURN(jf_height, jc_Dimension, "height", "I", NSZeroSize);
+    DECLARE_STATIC_METHOD_RETURN(jm_getSize, sjc_CAccessibility, "getSize",
+           "(Ljavax/accessibility/AccessibleComponent;Ljava/awt/Component;)Ljava/awt/Dimension;", NSZeroSize);
 
-    jobject dimension = JNFCallStaticObjectMethod(env, jm_getSize, axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    jobject dimension = (*env)->CallStaticObjectMethod(env, jc_Dimension, jm_getSize, axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 
     if (dimension == NULL) return NSZeroSize;
-    return NSMakeSize(JNFGetIntField(env, dimension, jf_width), JNFGetIntField(env, dimension, jf_height));
+    return NSMakeSize((*env)->GetIntField(env, dimension, jf_width), (*env)->GetIntField(env, dimension, jf_height));
 }
 
 NSString *getJavaRole(JNIEnv *env, jobject axComponent, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleRole, sjc_CAccessibility, "getAccessibleRole", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;");
-    jobject axRole = JNFCallStaticObjectMethod(env, sjm_getAccessibleRole, axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleRole, sjc_CAccessibility, "getAccessibleRole",
+                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
+    jobject axRole = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleRole,
+                      axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
     if (axRole == NULL) return @"unknown";
 
     NSString* str = JNFJavaToNSString(env, axRole);
@@ -84,50 +82,84 @@ NSString *getJavaRole(JNIEnv *env, jobject axComponent, jobject component)
 
 jobject getAxSelection(JNIEnv *env, jobject axContext, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleSelection, sjc_CAccessibility, "getAccessibleSelection", "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleSelection;");
-    return JNFCallStaticObjectMethod(env, jm_getAccessibleSelection, axContext, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleSelection, sjc_CAccessibility, "getAccessibleSelection",
+            "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleSelection;", nil);
+    jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleSelection,
+                      axContext, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
+    return o;
 }
 
 jobject getAxContextSelection(JNIEnv *env, jobject axContext, jint index, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_ax_getAccessibleSelection, sjc_CAccessibility, "ax_getAccessibleSelection", "(Ljavax/accessibility/AccessibleContext;ILjava/awt/Component;)Ljavax/accessibility/Accessible;");
-    return JNFCallStaticObjectMethod(env, jm_ax_getAccessibleSelection, axContext, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_ax_getAccessibleSelection, sjc_CAccessibility, "ax_getAccessibleSelection",
+                  "(Ljavax/accessibility/AccessibleContext;ILjava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
+    return (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_ax_getAccessibleSelection,
+                    axContext, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 }
 
 void setAxContextSelection(JNIEnv *env, jobject axContext, jint index, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_addAccessibleSelection, sjc_CAccessibility, "addAccessibleSelection", "(Ljavax/accessibility/AccessibleContext;ILjava/awt/Component;)V");
-    JNFCallStaticVoidMethod(env, jm_addAccessibleSelection, axContext, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_addAccessibleSelection, sjc_CAccessibility, "addAccessibleSelection",
+                   "(Ljavax/accessibility/AccessibleContext;ILjava/awt/Component;)V");
+    (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_addAccessibleSelection,
+                    axContext, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 }
 
 jobject getAxContext(JNIEnv *env, jobject accessible, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleContext, sjc_CAccessibility, "getAccessibleContext", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleContext;");
-    return JNFCallStaticObjectMethod(env, jm_getAccessibleContext, accessible, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleContext, sjc_CAccessibility, "getAccessibleContext",
+               "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleContext;", nil);
+    jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleContext,
+                    accessible, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
+    return o;
 }
 
 BOOL isChildSelected(JNIEnv *env, jobject accessible, jint index, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_isAccessibleChildSelected, sjc_CAccessibility, "isAccessibleChildSelected", "(Ljavax/accessibility/Accessible;ILjava/awt/Component;)Z");
-    return JNFCallStaticBooleanMethod(env, jm_isAccessibleChildSelected, accessible, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(NO);
+    DECLARE_STATIC_METHOD_RETURN(jm_isAccessibleChildSelected, sjc_CAccessibility, "isAccessibleChildSelected",
+                "(Ljavax/accessibility/Accessible;ILjava/awt/Component;)Z", NO);
+    jboolean b = (*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_isAccessibleChildSelected,
+                    accessible, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
+    return b;
 }
 
 jobject getAxStateSet(JNIEnv *env, jobject axContext, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleStateSet, sjc_CAccessibility, "getAccessibleStateSet", "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleStateSet;");
-    return JNFCallStaticObjectMethod(env, jm_getAccessibleStateSet, axContext, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleStateSet, sjc_CAccessibility, "getAccessibleStateSet",
+               "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleStateSet;", nil);
+    jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleStateSet,
+                    axContext, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
+    return o;
 }
 
 BOOL containsAxState(JNIEnv *env, jobject axContext, jobject axState, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_contains, sjc_CAccessibility, "contains", "(Ljavax/accessibility/AccessibleContext;Ljavax/accessibility/AccessibleState;Ljava/awt/Component;)Z");
-    return JNFCallStaticBooleanMethod(env, jm_contains, axContext, axState, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(NO);
+    DECLARE_STATIC_METHOD_RETURN(jm_contains, sjc_CAccessibility, "contains",
+               "(Ljavax/accessibility/AccessibleContext;Ljavax/accessibility/AccessibleState;Ljava/awt/Component;)Z", NO);
+    jboolean b = (*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_contains, axContext, axState, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
+    return b;
 }
 
 BOOL isVertical(JNIEnv *env, jobject axContext, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_VERTICAL, sjc_AccessibleState, "VERTICAL", "Ljavax/accessibility/AccessibleState;");
-    jobject axVertState = JNFGetStaticObjectField(env, jm_VERTICAL);
+    GET_ACCESSIBLESTATE_CLASS_RETURN(NO);
+    DECLARE_STATIC_FIELD_RETURN(jm_VERTICAL, sjc_AccessibleState, "VERTICAL", "Ljavax/accessibility/AccessibleState;", NO);
+    jobject axVertState = (*env)->GetStaticObjectField(env, sjc_AccessibleState, jm_VERTICAL);
+    CHECK_EXCEPTION_NULL_RETURN(axVertState, NO);
     BOOL vertical = containsAxState(env, axContext, axVertState, component);
     (*env)->DeleteLocalRef(env, axVertState);
     return vertical;
@@ -135,8 +167,10 @@ BOOL isVertical(JNIEnv *env, jobject axContext, jobject component)
 
 BOOL isHorizontal(JNIEnv *env, jobject axContext, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_HORIZONTAL, sjc_AccessibleState, "HORIZONTAL", "Ljavax/accessibility/AccessibleState;");
-    jobject axHorizState = JNFGetStaticObjectField(env, jm_HORIZONTAL);
+    GET_ACCESSIBLESTATE_CLASS_RETURN(NO);
+    DECLARE_STATIC_FIELD_RETURN(jm_HORIZONTAL, sjc_AccessibleState, "HORIZONTAL", "Ljavax/accessibility/AccessibleState;", NO);
+    jobject axHorizState = (*env)->GetStaticObjectField(env, sjc_AccessibleState, jm_HORIZONTAL);
+    CHECK_EXCEPTION_NULL_RETURN(axHorizState, NO);
     BOOL horizontal = containsAxState(env, axContext, axHorizState, component);
     (*env)->DeleteLocalRef(env, axHorizState);
     return horizontal;
@@ -144,8 +178,10 @@ BOOL isHorizontal(JNIEnv *env, jobject axContext, jobject component)
 
 BOOL isShowing(JNIEnv *env, jobject axContext, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_SHOWING, sjc_AccessibleState, "SHOWING", "Ljavax/accessibility/AccessibleState;");
-    jobject axVisibleState = JNFGetStaticObjectField(env, jm_SHOWING);
+    GET_ACCESSIBLESTATE_CLASS_RETURN(NO);
+    DECLARE_STATIC_FIELD_RETURN(jm_SHOWING, sjc_AccessibleState, "SHOWING", "Ljavax/accessibility/AccessibleState;", NO);
+    jobject axVisibleState = (*env)->GetStaticObjectField(env, sjc_AccessibleState, jm_SHOWING);
+    CHECK_EXCEPTION_NULL_RETURN(axVisibleState, NO);
     BOOL showing = containsAxState(env, axContext, axVisibleState, component);
     (*env)->DeleteLocalRef(env, axVisibleState);
     return showing;
@@ -153,11 +189,13 @@ BOOL isShowing(JNIEnv *env, jobject axContext, jobject component)
 
 BOOL isSelectable(JNIEnv *env, jobject axContext, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE( jm_SELECTABLE,
+    GET_ACCESSIBLESTATE_CLASS_RETURN(NO);
+    DECLARE_STATIC_FIELD_RETURN(jm_SELECTABLE,
                                     sjc_AccessibleState,
                                     "SELECTABLE",
-                                    "Ljavax/accessibility/AccessibleState;" );
-    jobject axSelectableState = JNFGetStaticObjectField(env, jm_SELECTABLE);
+                                    "Ljavax/accessibility/AccessibleState;", NO );
+    jobject axSelectableState = (*env)->GetStaticObjectField(env, sjc_AccessibleState, jm_SELECTABLE);
+    CHECK_EXCEPTION_NULL_RETURN(axSelectableState, NO);
     BOOL selectable = containsAxState(env, axContext, axSelectableState, component);
     (*env)->DeleteLocalRef(env, axSelectableState);
     return selectable;
@@ -165,16 +203,27 @@ BOOL isSelectable(JNIEnv *env, jobject axContext, jobject component)
 
 NSPoint getAxComponentLocationOnScreen(JNIEnv *env, jobject axComponent, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getLocationOnScreen, sjc_CAccessibility, "getLocationOnScreen", "(Ljavax/accessibility/AccessibleComponent;Ljava/awt/Component;)Ljava/awt/Point;");
-    jobject jpoint = JNFCallStaticObjectMethod(env, jm_getLocationOnScreen, axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(NSZeroPoint);
+    DECLARE_STATIC_METHOD_RETURN(jm_getLocationOnScreen, sjc_CAccessibility, "getLocationOnScreen",
+                  "(Ljavax/accessibility/AccessibleComponent;Ljava/awt/Component;)Ljava/awt/Point;", NSZeroPoint);
+    DECLARE_CLASS_RETURN(sjc_Point, "java/awt/Point", NSZeroPoint);
+    DECLARE_FIELD_RETURN(sjf_X, sjc_Point, "x", "I", NSZeroPoint);
+    DECLARE_FIELD_RETURN(sjf_Y, sjc_Point, "y", "I", NSZeroPoint);
+    jobject jpoint = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getLocationOnScreen,
+                      axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
     if (jpoint == NULL) return NSZeroPoint;
-    return NSMakePoint(JNFGetIntField(env, jpoint, sjf_X), JNFGetIntField(env, jpoint, sjf_Y));
+    return NSMakePoint((*env)->GetIntField(env, jpoint, sjf_X), (*env)->GetIntField(env, jpoint, sjf_Y));
 }
 
 jint getAxTextCharCount(JNIEnv *env, jobject axText, jobject component)
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getCharCount, sjc_CAccessibility, "getCharCount", "(Ljavax/accessibility/AccessibleText;Ljava/awt/Component;)I");
-    return JNFCallStaticIntMethod(env, jm_getCharCount, axText, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_CACCESSIBILITY_CLASS_RETURN(0);
+    DECLARE_STATIC_METHOD_RETURN(jm_getCharCount, sjc_CAccessibility, "getCharCount",
+                  "(Ljavax/accessibility/AccessibleText;Ljava/awt/Component;)I", 0);
+    int i = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, jm_getCharCount, axText, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
+    return i;
 }
 
 // The following JavaAccessibility methods are copied from the corresponding
@@ -265,7 +314,9 @@ static BOOL JavaAccessibilityIsSupportedAttribute(id element, NSString *attribut
 JNIEXPORT jstring JNICALL Java_sun_lwawt_macosx_CAccessibility_roleKey
 (JNIEnv *env, jclass clz, jobject axRole)
 {
-    return JNFGetObjectField(env, axRole, sjf_key);
+    DECLARE_CLASS_RETURN(sjc_AccessibleRole, "javax/accessibility/AccessibleRole", NULL);
+    DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", NULL);
+    return (*env)->GetObjectField(env, axRole, sjf_key);
 }
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -44,6 +44,7 @@
 #import "JavaAccessibilityUtilities.h"
 #import "JavaTextAccessibility.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 #import "AWTView.h"
 
 
@@ -53,19 +54,37 @@
 #define JAVA_AX_VISIBLE_CHILDREN (-3)
 // If the value is >=0, it's an index
 
-static JNF_STATIC_MEMBER_CACHE(jm_getChildrenAndRoles, sjc_CAccessibility, "getChildrenAndRoles", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;IZ)[Ljava/lang/Object;");
-static JNF_STATIC_MEMBER_CACHE(jm_getTableInfo, sjc_CAccessibility, "getTableInfo", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)I");
-static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleComponent, sjc_CAccessibility, "getAccessibleComponent", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleComponent;");
-static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleValue, sjc_CAccessibility, "getAccessibleValue", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleValue;");
-static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;");
-static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleDescription, sjc_CAccessibility, "getAccessibleDescription", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;");
-static JNF_STATIC_MEMBER_CACHE(sjm_isFocusTraversable, sjc_CAccessibility, "isFocusTraversable", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z");
-static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleIndexInParent, sjc_CAccessibility, "getAccessibleIndexInParent", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)I");
+// GET* macros defined in JavaAccessibilityUtilities.h, so they can be shared.
+static jclass sjc_CAccessibility = NULL;
 
-static JNF_CLASS_CACHE(sjc_CAccessible, "sun/lwawt/macosx/CAccessible");
+static jmethodID sjm_getAccessibleName = NULL;
+#define GET_ACCESSIBLENAME_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName", \
+                     "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", ret);
 
-static JNF_MEMBER_CACHE(jf_ptr, sjc_CAccessible, "ptr", "J");
-static JNF_STATIC_MEMBER_CACHE(sjm_getCAccessible, sjc_CAccessible, "getCAccessible", "(Ljavax/accessibility/Accessible;)Lsun/lwawt/macosx/CAccessible;");
+static jmethodID jm_getChildrenAndRoles = NULL;
+#define GET_CHILDRENANDROLES_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(jm_getChildrenAndRoles, sjc_CAccessibility, "getChildrenAndRoles",\
+                      "(Ljavax/accessibility/Accessible;Ljava/awt/Component;IZ)[Ljava/lang/Object;", ret);
+
+static jmethodID sjm_getAccessibleComponent = NULL;
+#define GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleComponent, sjc_CAccessibility, "getAccessibleComponent", \
+           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleComponent;", ret);
+
+static jmethodID sjm_getAccessibleIndexInParent = NULL;
+#define GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleIndexInParent, sjc_CAccessibility, "getAccessibleIndexInParent", \
+                             "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)I", ret);
+
+static jclass sjc_CAccessible = NULL;
+#define GET_CACCESSIBLE_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(sjc_CAccessible, "sun/lwawt/macosx/CAccessible", ret);
+
 
 static jobject sAccessibilityClass = NULL;
 
@@ -271,7 +290,10 @@ static NSObject *sAttributeNamesLOCK = nil;
     }
 
     if (sAccessibilityClass == NULL) {
-        JNF_STATIC_MEMBER_CACHE(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
+        JNIEnv *env = [ThreadUtilities getJNIEnv];
+
+        GET_CACCESSIBILITY_CLASS();
+        DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
 
 #ifdef JAVA_AX_NO_IGNORES
         NSArray *ignoredKeys = [NSArray array];
@@ -281,10 +303,9 @@ static NSObject *sAttributeNamesLOCK = nil;
         jobjectArray result = NULL;
         jsize count = [ignoredKeys count];
 
-        JNIEnv *env = [ThreadUtilities getJNIEnv];
-
-        static JNF_CLASS_CACHE(jc_String, "java/lang/String");
-        result = JNFNewObjectArray(env, &jc_String, count);
+        DECLARE_CLASS(jc_String, "java/lang/String");
+        result = (*env)->NewObjectArray(env, count, jc_String, NULL);
+        CHECK_EXCEPTION();
         if (!result) {
             NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
             return;
@@ -297,7 +318,8 @@ static NSObject *sAttributeNamesLOCK = nil;
             (*env)->DeleteLocalRef(env, jString);
         }
 
-        sAccessibilityClass = JNFCallStaticObjectMethod(env, jm_getAccessibility, result); // AWT_THREADING Safe (known object)
+        sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result); // AWT_THREADING Safe (known object)
+        CHECK_EXCEPTION();
     }
 }
 
@@ -308,10 +330,16 @@ static NSObject *sAttributeNamesLOCK = nil;
 }
 
 + (jobject) getCAccessible:(jobject)jaccessible withEnv:(JNIEnv *)env {
-    if (JNFIsInstanceOf(env, jaccessible, &sjc_CAccessible)) {
+    DECLARE_CLASS_RETURN(sjc_Accessible, "javax/accessibility/Accessible", NULL);
+    GET_CACCESSIBLE_CLASS_RETURN(NULL);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getCAccessible, sjc_CAccessible, "getCAccessible",
+                                "(Ljavax/accessibility/Accessible;)Lsun/lwawt/macosx/CAccessible;", NULL);
+    if ((*env)->IsInstanceOf(env, jaccessible, sjc_CAccessible)) {
         return jaccessible;
-    } else if (JNFIsInstanceOf(env, jaccessible, &sjc_Accessible)) {
-        return JNFCallStaticObjectMethod(env, sjm_getCAccessible, jaccessible);
+    } else if ((*env)->IsInstanceOf(env, jaccessible, sjc_Accessible)) {
+        jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessible,  sjm_getCAccessible, jaccessible);
+        CHECK_EXCEPTION();
+        return o;
     }
     return NULL;
 }
@@ -319,7 +347,10 @@ static NSObject *sAttributeNamesLOCK = nil;
 + (NSArray *)childrenOfParent:(JavaComponentAccessibility *)parent withEnv:(JNIEnv *)env withChildrenCode:(NSInteger)whichChildren allowIgnored:(BOOL)allowIgnored
 {
     if (parent->fAccessible == NULL) return nil;
-    jobjectArray jchildrenAndRoles = (jobjectArray)JNFCallStaticObjectMethod(env, jm_getChildrenAndRoles, parent->fAccessible, parent->fComponent, whichChildren, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
+    GET_CHILDRENANDROLES_METHOD_RETURN(nil);
+    jobjectArray jchildrenAndRoles = (jobjectArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getChildrenAndRoles,
+                  parent->fAccessible, parent->fComponent, whichChildren, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (jchildrenAndRoles == NULL) return nil;
 
     jsize arrayLen = (*env)->GetArrayLength(env, jchildrenAndRoles);
@@ -334,7 +365,10 @@ static NSObject *sAttributeNamesLOCK = nil;
 
         NSString *childJavaRole = nil;
         if (jchildJavaRole != NULL) {
-            jobject jkey = JNFGetObjectField(env, jchildJavaRole, sjf_key);
+            DECLARE_CLASS_RETURN(sjc_AccessibleRole, "javax/accessibility/AccessibleRole", nil);
+            DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", nil);
+            jobject jkey = (*env)->GetObjectField(env, jchildJavaRole, sjf_key);
+            CHECK_EXCEPTION();
             childJavaRole = JNFJavaToNSString(env, jkey);
             (*env)->DeleteLocalRef(env, jkey);
         }
@@ -354,9 +388,11 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 + (JavaComponentAccessibility *)createWithAccessible:(jobject)jaccessible withEnv:(JNIEnv *)env withView:(NSView *)view
 {
+    GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(nil);
     JavaComponentAccessibility *ret = nil;
     jobject jcomponent = [(AWTView *)view awtComponent:env];
-    jint index = JNFCallStaticIntMethod(env, sjm_getAccessibleIndexInParent, jaccessible, jcomponent);
+    jint index = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, sjm_getAccessibleIndexInParent, jaccessible, jcomponent);
+    CHECK_EXCEPTION();
     if (index >= 0) {
       NSString *javaRole = getJavaRole(env, jaccessible, jcomponent);
       ret = [self createWithAccessible:jaccessible role:javaRole index:index withEnv:env withView:view];
@@ -372,10 +408,12 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 + (JavaComponentAccessibility *) createWithParent:(JavaComponentAccessibility *)parent accessible:(jobject)jaccessible role:(NSString *)javaRole index:(jint)index withEnv:(JNIEnv *)env withView:(NSView *)view
 {
+    GET_CACCESSIBLE_CLASS_RETURN(NULL);
+    DECLARE_FIELD_RETURN(jf_ptr, sjc_CAccessible, "ptr", "J", NULL);
     // try to fetch the jCAX from Java, and return autoreleased
     jobject jCAX = [JavaComponentAccessibility getCAccessible:jaccessible withEnv:env];
     if (jCAX == NULL) return nil;
-    JavaComponentAccessibility *value = (JavaComponentAccessibility *) jlong_to_ptr(JNFGetLongField(env, jCAX, jf_ptr));
+    JavaComponentAccessibility *value = (JavaComponentAccessibility *) jlong_to_ptr((*env)->GetLongField(env, jCAX, jf_ptr));
     if (value != nil) {
         (*env)->DeleteLocalRef(env, jCAX);
         return [[value retain] autorelease];
@@ -411,7 +449,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // must hard retain pointer poked into Java object
     [newChild retain];
-    JNFSetLongField(env, jCAX, jf_ptr, ptr_to_jlong(newChild));
+    (*env)->SetLongField(env, jCAX, jf_ptr, ptr_to_jlong(newChild));
     (*env)->DeleteLocalRef(env, jCAX);
 
     // return autoreleased instance
@@ -420,7 +458,9 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (NSArray *)initializeAttributeNamesWithEnv:(JNIEnv *)env
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getInitialAttributeStates, sjc_CAccessibility, "getInitialAttributeStates", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[Z");
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getInitialAttributeStates, sjc_CAccessibility, "getInitialAttributeStates",
+                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[Z", nil);
 
     NSMutableArray *attributeNames = [NSMutableArray arrayWithCapacity:20];
     [attributeNames retain];
@@ -445,7 +485,9 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // Get all the other accessibility attributes states we need in one swell foop.
     // javaRole isn't pulled in because we need protected access to AccessibleRole.key
-    jbooleanArray attributeStates = (jbooleanArray)JNFCallStaticObjectMethod(env, jm_getInitialAttributeStates, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jbooleanArray attributeStates = (jbooleanArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                     jm_getInitialAttributeStates, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (attributeStates == NULL) return nil;
     jboolean *attributeStatesArray = (*env)->GetBooleanArrayElements(env, attributeStates, 0);
     if (attributeStatesArray == NULL) {
@@ -537,11 +579,14 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (void)getActionsWithEnv:(JNIEnv *)env
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleAction, sjc_CAccessibility, "getAccessibleAction", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleAction;");
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_getAccessibleAction, sjc_CAccessibility, "getAccessibleAction",
+                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleAction;");
 
     // On MacOSX, text doesn't have actions, in java it does.
     // cmcnote: NOT TRUE - Editable text has AXShowMenu. Textfields have AXConfirm. Static text has no actions.
-    jobject axAction = JNFCallStaticObjectMethod(env, jm_getAccessibleAction, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject axAction = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleAction, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (axAction != NULL) {
         //+++gdb NOTE: In MacOSX, there is just a single Action, not multiple. In java,
         //  the first one seems to be the most basic, so this will be used.
@@ -560,22 +605,26 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (id)parent
 {
-    static JNF_CLASS_CACHE(sjc_Window, "java/awt/Window");
-    static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleParent, sjc_CAccessibility, "getAccessibleParent", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/Accessible;");
-    static JNF_STATIC_MEMBER_CACHE(sjm_getSwingAccessible, sjc_CAccessible, "getSwingAccessible", "(Ljavax/accessibility/Accessible;)Ljavax/accessibility/Accessible;");
-
     if(fParent == nil) {
         JNIEnv* env = [ThreadUtilities getJNIEnv];
+        GET_CACCESSIBILITY_CLASS_RETURN(nil);
+        DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleParent, sjc_CAccessibility, "getAccessibleParent",
+                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
+        GET_CACCESSIBLE_CLASS_RETURN(nil);
+        DECLARE_STATIC_METHOD_RETURN(sjm_getSwingAccessible, sjc_CAccessible, "getSwingAccessible",
+                                 "(Ljavax/accessibility/Accessible;)Ljavax/accessibility/Accessible;", nil);
+        DECLARE_CLASS_RETURN(sjc_Window, "java/awt/Window", nil);
 
-        jobject jparent = JNFCallStaticObjectMethod(env, sjm_getAccessibleParent, fAccessible, fComponent);
+        jobject jparent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,  sjm_getAccessibleParent, fAccessible, fComponent);
+        CHECK_EXCEPTION();
 
         if (jparent == NULL) {
             fParent = fView;
         } else {
             AWTView *view = fView;
-            jobject jax = JNFCallStaticObjectMethod(env, sjm_getSwingAccessible, fAccessible);
+            jobject jax = (*env)->CallStaticObjectMethod(env, sjc_CAccessible, sjm_getSwingAccessible, fAccessible);
 
-            if (JNFIsInstanceOf(env, jax, &sjc_Window)) {
+            if ((*env)->IsInstanceOf(env, jax, sjc_Window)) {
                 // In this case jparent is an owner toplevel and we should retrieve its own view
                 view = [AWTView awtView:env ofAccessible:jparent];
             }
@@ -781,11 +830,15 @@ static NSObject *sAttributeNamesLOCK = nil;
         return [super accessibilityIndexOfChild:child];
     }
 
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(0);
     jint returnValue =
-        JNFCallStaticIntMethod( [ThreadUtilities getJNIEnv],
+        (*env)->CallStaticIntMethod( env,
+                                sjc_CAccessibility,
                                 sjm_getAccessibleIndexInParent,
                                 ((JavaComponentAccessibility *)child)->fAccessible,
                                 ((JavaComponentAccessibility *)child)->fComponent );
+    CHECK_EXCEPTION();
     return (returnValue == -1) ? NSNotFound : returnValue;
 }
 
@@ -804,10 +857,12 @@ static NSObject *sAttributeNamesLOCK = nil;
 // Flag indicating enabled state of element (NSNumber)
 - (NSNumber *)accessibilityEnabledAttribute
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_isEnabled, sjc_CAccessibility, "isEnabled", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z");
-
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    NSNumber *value = [NSNumber numberWithBool:JNFCallStaticBooleanMethod(env, jm_isEnabled, fAccessible, fComponent)]; // AWT_THREADING Safe (AWTRunLoop)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_isEnabled, sjc_CAccessibility, "isEnabled", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", nil);
+
+    NSNumber *value = [NSNumber numberWithBool:(*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_isEnabled, fAccessible, fComponent)]; // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (value == nil) {
         NSLog(@"WARNING: %s called on component that has no accessible component: %@", __FUNCTION__, self);
     }
@@ -831,25 +886,31 @@ static NSObject *sAttributeNamesLOCK = nil;
 - (BOOL)accessibilityIsFocusedAttributeSettable
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(NO);
+    DECLARE_STATIC_METHOD_RETURN(sjm_isFocusTraversable, sjc_CAccessibility, "isFocusTraversable",
+                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", NO);
     // According to javadoc, a component that is focusable will return true from isFocusTraversable,
     // as well as having AccessibleState.FOCUSABLE in its AccessibleStateSet.
     // We use the former heuristic; if the component focus-traversable, add a focused attribute
     // See also initializeAttributeNamesWithEnv:
-    if (JNFCallStaticBooleanMethod(env, sjm_isFocusTraversable, fAccessible, fComponent)) { // AWT_THREADING Safe (AWTRunLoop)
+    if ((*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, sjm_isFocusTraversable, fAccessible, fComponent)) { // AWT_THREADING Safe (AWTRunLoop)
         return YES;
     }
+    CHECK_EXCEPTION();
 
     return NO;
 }
 
 - (void)accessibilitySetFocusedAttribute:(id)value
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_requestFocus, sjc_CAccessibility, "requestFocus", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_requestFocus, sjc_CAccessibility, "requestFocus", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
 
     if ([(NSNumber*)value boolValue])
     {
-        JNIEnv* env = [ThreadUtilities getJNIEnv];
-        JNFCallStaticVoidMethod(env, jm_requestFocus, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestFocus, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     }
 }
 
@@ -858,7 +919,12 @@ static NSObject *sAttributeNamesLOCK = nil;
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
-    jobject val = JNFCallStaticObjectMethod(env, sjm_getAccessibleDescription, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleDescription, sjc_CAccessibility, "getAccessibleDescription",
+                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
+    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                                   sjm_getAccessibleDescription, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (val == NULL) {
         return nil;
     }
@@ -887,11 +953,13 @@ static NSObject *sAttributeNamesLOCK = nil;
 // Element's maximum value (id)
 - (id)accessibilityMaxValueAttribute
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getMaximumAccessibleValue, sjc_CAccessibility, "getMaximumAccessibleValue", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;");
-
     JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getMaximumAccessibleValue, sjc_CAccessibility, "getMaximumAccessibleValue",
+                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
 
-    jobject axValue = JNFCallStaticObjectMethod(env, jm_getMaximumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMaximumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (axValue == NULL) {
         return [NSNumber numberWithInt:0];
     }
@@ -908,11 +976,13 @@ static NSObject *sAttributeNamesLOCK = nil;
 // Element's minimum value (id)
 - (id)accessibilityMinValueAttribute
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getMinimumAccessibleValue, sjc_CAccessibility, "getMinimumAccessibleValue", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;");
-
     JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getMinimumAccessibleValue, sjc_CAccessibility, "getMinimumAccessibleValue",
+                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
 
-    jobject axValue = JNFCallStaticObjectMethod(env, jm_getMinimumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMinimumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (axValue == NULL) {
         return [NSNumber numberWithInt:0];
     }
@@ -966,7 +1036,10 @@ static NSObject *sAttributeNamesLOCK = nil;
 - (NSValue *)accessibilityPositionAttribute
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    jobject axComponent = JNFCallStaticObjectMethod(env, sjm_getAccessibleComponent, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(nil);
+    jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleComponent,
+                           fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
 
     // NSAccessibility wants the bottom left point of the object in
     // bottom left based screen coords
@@ -1027,11 +1100,14 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     if (value == nil) {
         // query java if necessary
-        static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleRoleDisplayString, sjc_CAccessibility, "getAccessibleRoleDisplayString", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;");
-
         JNIEnv* env = [ThreadUtilities getJNIEnv];
+        GET_CACCESSIBILITY_CLASS_RETURN(nil);
+        DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleRoleDisplayString, sjc_CAccessibility, "getAccessibleRoleDisplayString",
+                                     "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
 
-        jobject axRole = JNFCallStaticObjectMethod(env, jm_getAccessibleRoleDisplayString, fAccessible, fComponent);
+
+        jobject axRole = (*env)->CallStaticObjectMethod(env, jm_getAccessibleRoleDisplayString, fAccessible, fComponent);
+        CHECK_EXCEPTION();
         if (axRole != NULL) {
             value = JNFJavaToNSString(env, axRole);
             (*env)->DeleteLocalRef(env, axRole);
@@ -1081,21 +1157,26 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (void)accessibilitySetSelectedAttribute:(id)value
 {
-    static JNF_STATIC_MEMBER_CACHE( jm_requestSelection,
-                                    sjc_CAccessibility,
-                                    "requestSelection",
-                                    "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V" );
+   JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_requestSelection,
+                          sjc_CAccessibility,
+                          "requestSelection",
+                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
 
     if ([(NSNumber*)value boolValue]) {
-        JNIEnv* env = [ThreadUtilities getJNIEnv];
-        JNFCallStaticVoidMethod(env, jm_requestSelection, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestSelection, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+        CHECK_EXCEPTION();
     }
 }
 
 // Element size (NSValue)
 - (NSValue *)accessibilitySizeAttribute {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    jobject axComponent = JNFCallStaticObjectMethod(env, sjm_getAccessibleComponent, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(nil);
+    jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                           sjm_getAccessibleComponent, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     NSValue* size = [NSValue valueWithSize:getAxComponentSize(env, axComponent, fComponent)];
     (*env)->DeleteLocalRef(env, axComponent);
     return size;
@@ -1155,7 +1236,9 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
-    jobject val = JNFCallStaticObjectMethod(env, sjm_getAccessibleName, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    GET_ACCESSIBLENAME_METHOD_RETURN(nil);
+    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleName, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (val == NULL) {
         return nil;
     }
@@ -1185,8 +1268,6 @@ static NSObject *sAttributeNamesLOCK = nil;
 // (https://docs.oracle.com/javase/8/docs/api/javax/accessibility/AccessibleValue.html#setCurrentAccessibleValue-java.lang.Number-)
 - (id)accessibilityValueAttribute
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getCurrentAccessibleValue, sjc_CAccessibility, "getCurrentAccessibleValue", "(Ljavax/accessibility/AccessibleValue;Ljava/awt/Component;)Ljava/lang/Number;");
-
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
     // Need to handle popupmenus differently.
@@ -1211,11 +1292,14 @@ static NSObject *sAttributeNamesLOCK = nil;
             JavaComponentAccessibility *selectedMenuItem =
                 [selectedChildrenOfMenu objectAtIndex:0];
             if (selectedMenuItem != nil) {
+                GET_CACCESSIBILITY_CLASS_RETURN(nil);
+                GET_ACCESSIBLENAME_METHOD_RETURN(nil);
                 jobject itemValue =
-                        JNFCallStaticObjectMethod( env,
+                        (*env)->CallStaticObjectMethod( env,
                                                    sjm_getAccessibleName,
                                                    selectedMenuItem->fAccessible,
                                                    selectedMenuItem->fComponent ); // AWT_THREADING Safe (AWTRunLoop)
+                CHECK_EXCEPTION();
                 if (itemValue == NULL) {
                     return nil;
                 }
@@ -1233,9 +1317,16 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // cmcnote should coalesce these calls into one java call
     NSNumber *num = nil;
-    jobject axValue = JNFCallStaticObjectMethod(env, sjm_getAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleValue, sjc_CAccessibility, "getAccessibleValue",
+                "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleValue;", nil);
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if (axValue != NULL) {
-        jobject str = JNFCallStaticObjectMethod(env, jm_getCurrentAccessibleValue, axValue, fComponent);
+        DECLARE_STATIC_METHOD_RETURN(jm_getCurrentAccessibleValue, sjc_CAccessibility, "getCurrentAccessibleValue",
+                                     "(Ljavax/accessibility/AccessibleValue;Ljava/awt/Component;)Ljava/lang/Number;", nil);
+        jobject str = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getCurrentAccessibleValue, axValue, fComponent);
+        CHECK_EXCEPTION();
         if (str != NULL) {
             num = JNFJavaToNSNumber(env, str); // AWT_THREADING Safe (AWTRunLoop)
             (*env)->DeleteLocalRef(env, str);
@@ -1333,8 +1424,9 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (id)accessibilityHitTest:(NSPoint)point withEnv:(JNIEnv *)env
 {
-    static JNF_CLASS_CACHE(jc_Container, "java/awt/Container");
-    static JNF_STATIC_MEMBER_CACHE(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest", "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;");
+    DECLARE_CLASS_RETURN(jc_Container, "java/awt/Container", nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest",
+                                 "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
 
     // Make it into java screen coords
     point.y = [[[[self view] window] screen] frame].size.height - point.y;
@@ -1343,7 +1435,9 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     id value = nil;
     if (JNFIsInstanceOf(env, jparent, &jc_Container)) {
-        jobject jaccessible = JNFCallStaticObjectMethod(env, jm_accessibilityHitTest, jparent, (jfloat)point.x, (jfloat)point.y); // AWT_THREADING Safe (AWTRunLoop)
+        jobject jaccessible = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_accessibilityHitTest,
+                               jparent, (jfloat)point.x, (jfloat)point.y); // AWT_THREADING Safe (AWTRunLoop)
+        CHECK_EXCEPTION();
         if (jaccessible != NULL) {
             value = [JavaComponentAccessibility createWithAccessible:jaccessible withEnv:env withView:fView];
             (*env)->DeleteLocalRef(env, jaccessible);
@@ -1366,19 +1460,22 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (id)accessibilityFocusedUIElement
 {
-    static JNF_STATIC_MEMBER_CACHE(jm_getFocusOwner, sjc_CAccessibility, "getFocusOwner", "(Ljava/awt/Component;)Ljavax/accessibility/Accessible;");
-
     JNIEnv *env = [ThreadUtilities getJNIEnv];
+    DECLARE_STATIC_METHOD_RETURN(jm_getFocusOwner, sjc_CAccessibility, "getFocusOwner",
+                                  "(Ljava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
     id value = nil;
 
     NSWindow* hostWindow = [[self->fView window] retain];
-    jobject focused = JNFCallStaticObjectMethod(env, jm_getFocusOwner, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject focused = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getFocusOwner, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     [hostWindow release];
+    CHECK_EXCEPTION();
 
     if (focused != NULL) {
-        if (JNFIsInstanceOf(env, focused, &sjc_Accessible)) {
+        DECLARE_CLASS_RETURN(sjc_Accessible, "javax/accessibility/Accessible", nil);
+        if ((*env)->IsInstanceOf(env, focused, sjc_Accessible)) {
             value = [JavaComponentAccessibility createWithAccessible:focused withEnv:env withView:fView];
         }
+        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, focused);
     }
 
@@ -1569,7 +1666,10 @@ JNF_COCOA_EXIT(env);
 
 - (NSArray *)tabControlsWithEnv:(JNIEnv *)env withTabGroupAxContext:(jobject)axContext withTabCode:(NSInteger)whichTabs allowIgnored:(BOOL)allowIgnored
 {
-    jobjectArray jtabsAndRoles = (jobjectArray)JNFCallStaticObjectMethod(env, jm_getChildrenAndRoles, fAccessible, fComponent, whichTabs, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
+    GET_CHILDRENANDROLES_METHOD_RETURN(nil);
+    jobjectArray jtabsAndRoles = (jobjectArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getChildrenAndRoles,
+                                  fAccessible, fComponent, whichTabs, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
     if(jtabsAndRoles == NULL) return nil;
 
     jsize arrayLen = (*env)->GetArrayLength(env, jtabsAndRoles);
@@ -1585,7 +1685,10 @@ JNF_COCOA_EXIT(env);
         (*env)->DeleteLocalRef(env, jtabsAndRoles);
         return nil;
     }
-    jobject jkey = JNFGetObjectField(env, jtabJavaRole, sjf_key);
+    DECLARE_CLASS_RETURN(sjc_AccessibleRole, "javax/accessibility/AccessibleRole", nil);
+    DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", nil);
+    jobject jkey = (*env)->GetObjectField(env, jtabJavaRole, sjf_key);
+    CHECK_EXCEPTION();
     NSString *tabJavaRole = JNFJavaToNSString(env, jkey);
     (*env)->DeleteLocalRef(env, jkey);
 
@@ -1901,8 +2004,12 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     if (fAccessible == NULL) return 0;
 
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    jint count = JNFCallStaticIntMethod(env, jm_getTableInfo, fAccessible,
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getTableInfo, sjc_CAccessibility, "getTableInfo",
+                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)I", nil);
+    jint count = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, jm_getTableInfo, fAccessible,
                                         fComponent, info);
+    CHECK_EXCEPTION();
     NSNumber *index = [NSNumber numberWithInt:count];
     return index;
 }
@@ -1922,20 +2029,24 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
  * This may use LWCToolkit.invokeAndWait(); don't call while holding fLock
  * and try to pass a component so the event happens on the correct thread.
  */
-static JNF_CLASS_CACHE(sjc_Object, "java/lang/Object");
 static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component)
 {
-    static JNF_MEMBER_CACHE(jm_equals, sjc_Object, "equals", "(Ljava/lang/Object;)Z");
+    DECLARE_CLASS_RETURN(sjc_Object, "java/lang/Object", NO);
+    DECLARE_METHOD_RETURN(jm_equals, sjc_Object, "equals", "(Ljava/lang/Object;)Z", NO);
 
     if ((a == NULL) && (b == NULL)) return YES;
     if ((a == NULL) || (b == NULL)) return NO;
 
     if (pthread_main_np() != 0) {
         // If we are on the AppKit thread
-        static JNF_CLASS_CACHE(sjc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit");
-        static JNF_STATIC_MEMBER_CACHE(jm_doEquals, sjc_LWCToolkit, "doEquals", "(Ljava/lang/Object;Ljava/lang/Object;Ljava/awt/Component;)Z");
-        return JNFCallStaticBooleanMethod(env, jm_doEquals, a, b, component); // AWT_THREADING Safe (AWTRunLoopMode)
+        DECLARE_CLASS_RETURN(sjc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit", NO);
+        DECLARE_STATIC_METHOD_RETURN(jm_doEquals, sjc_LWCToolkit, "doEquals",
+                                     "(Ljava/lang/Object;Ljava/lang/Object;Ljava/awt/Component;)Z", NO);
+        return (*env)->CallStaticBooleanMethod(env, sjc_LWCToolkit, jm_doEquals, a, b, component); // AWT_THREADING Safe (AWTRunLoopMode)
+        CHECK_EXCEPTION();
     }
 
-    return JNFCallBooleanMethod(env, a, jm_equals, b); // AWT_THREADING Safe (!appKit)
+    jboolean jb = (*env)->CallBooleanMethod(env, a, jm_equals, b); // AWT_THREADING Safe (!appKit)
+    CHECK_EXCEPTION();
+    return jb;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrintModel.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrintModel.m
@@ -30,6 +30,7 @@
 
 #import "PrinterView.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 @implementation PrintModel
 
@@ -88,9 +89,10 @@ AWT_ASSERT_NOT_APPKIT_THREAD;
         [self retain];
         [printerView retain];
 
-        static JNF_CLASS_CACHE(jc_CPrinterJob, "sun/lwawt/macosx/CPrinterJob");
-        static JNF_STATIC_MEMBER_CACHE(jm_detachPrintLoop, jc_CPrinterJob, "detachPrintLoop", "(JJ)V");
-        JNFCallStaticVoidMethod(env, jm_detachPrintLoop, ptr_to_jlong(self), ptr_to_jlong(printerView)); // AWT_THREADING Safe (known object)
+        DECLARE_CLASS_RETURN(jc_CPrinterJob, "sun/lwawt/macosx/CPrinterJob", NO);
+        DECLARE_STATIC_METHOD_RETURN(jm_detachPrintLoop, jc_CPrinterJob, "detachPrintLoop", "(JJ)V", NO);
+        (*env)->CallStaticVoidMethod(env, jc_CPrinterJob, jm_detachPrintLoop, ptr_to_jlong(self), ptr_to_jlong(printerView)); // AWT_THREADING Safe (known object)
+        CHECK_EXCEPTION();
     }
 
     return fResult;

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
@@ -34,6 +34,7 @@
 #import "AWTFont.h"
 #import "AWTStrike.h"
 #import "CoreTextSupport.h"
+#import "JNIUtilities.h"
 
 @implementation AWTFont
 
@@ -122,11 +123,12 @@ static NSString* uiBoldName = nil;
         return nil;
     }
 
-    static JNF_CLASS_CACHE(jc_Font, "java/awt/Font");
+    DECLARE_CLASS_RETURN(jc_Font, "java/awt/Font", nil);
 
     // obtain the Font2D
-    static JNF_MEMBER_CACHE(jm_Font_getFont2D, jc_Font, "getFont2D", "()Lsun/font/Font2D;");
-    jobject font2d = JNFCallObjectMethod(env, javaFont, jm_Font_getFont2D);
+    DECLARE_METHOD_RETURN(jm_Font_getFont2D, jc_Font, "getFont2D", "()Lsun/font/Font2D;", nil);
+    jobject font2d = (*env)->CallObjectMethod(env, javaFont, jm_Font_getFont2D);
+    CHECK_EXCEPTION();
     if (font2d == NULL) {
 #ifdef DEBUG
         NSLog(@"nil font2d");
@@ -136,27 +138,28 @@ static NSString* uiBoldName = nil;
 
     // if it's not a CFont, it's likely one of TTF or OTF fonts
     // from the Sun rendering loops
-    static JNF_CLASS_CACHE(jc_CFont, "sun/font/CFont");
-    if (!JNFIsInstanceOf(env, font2d, &jc_CFont)) {
+    DECLARE_CLASS_RETURN(jc_CFont, "sun/font/CFont", nil);
+    if (!(*env)->IsInstanceOf(env, font2d, jc_CFont)) {
 #ifdef DEBUG
         NSLog(@"font2d !instanceof CFont");
 #endif
         return nil;
     }
 
-    static JNF_MEMBER_CACHE(jm_CFont_getFontStrike, jc_CFont, "getStrike", "(Ljava/awt/Font;)Lsun/font/FontStrike;");
-    jobject fontStrike = JNFCallObjectMethod(env, font2d, jm_CFont_getFontStrike, javaFont);
-
-    static JNF_CLASS_CACHE(jc_CStrike, "sun/font/CStrike");
-    if (!JNFIsInstanceOf(env, fontStrike, &jc_CStrike)) {
+    DECLARE_METHOD_RETURN(jm_CFont_getFontStrike, jc_CFont, "getStrike", "(Ljava/awt/Font;)Lsun/font/FontStrike;", nil);
+    jobject fontStrike = (*env)->CallObjectMethod(env, font2d, jm_CFont_getFontStrike, javaFont);
+    CHECK_EXCEPTION();
+    DECLARE_CLASS_RETURN(jc_CStrike, "sun/font/CStrike", nil);
+    if (!(*env)->IsInstanceOf(env, fontStrike, jc_CStrike)) {
 #ifdef DEBUG
         NSLog(@"fontStrike !instanceof CStrike");
 #endif
         return nil;
     }
 
-    static JNF_MEMBER_CACHE(jm_CStrike_nativeStrikePtr, jc_CStrike, "getNativeStrikePtr", "()J");
-    jlong awtStrikePtr = JNFCallLongMethod(env, fontStrike, jm_CStrike_nativeStrikePtr);
+    DECLARE_METHOD_RETURN(jm_CStrike_nativeStrikePtr, jc_CStrike, "getNativeStrikePtr", "()J", nil);
+    jlong awtStrikePtr = (*env)->CallLongMethod(env, fontStrike, jm_CStrike_nativeStrikePtr);
+    CHECK_EXCEPTION();
     if (awtStrikePtr == 0L) {
 #ifdef DEBUG
         NSLog(@"nil nativeFontPtr from CFont");
@@ -285,71 +288,6 @@ static OSStatus CreateFSRef(FSRef *myFSRefPtr, NSString *inPath)
                          myFSRefPtr, NULL);
 }
 
-// /*
-//  * Class:     sun_font_CFontManager
-//  * Method:    loadFileFont
-//  * Signature: (Ljava/lang/String;)Lsun/font/Font2D;
-//  */
-// JNIEXPORT /* sun.font.CFont */ jobject JNICALL
-// Java_sun_font_CFontManager_loadFileFont
-//     (JNIEnv *env, jclass obj, jstring fontpath)
-// {
-//     jobject result = NULL;
-//
-// JNF_COCOA_ENTER(env);
-//
-//     NSString *nsFilePath = JNFJavaToNSString(env, fontpath);
-//     jstring javaFontName = NULL;
-//
-//     //
-//     // Note: This API uses ATS and can therefore return Carbon error codes.
-//     // These codes can be found at:
-//     // http://developer.apple.com/techpubs/macosx/Carbon/Files/FileManager/File_Manager/ResultCodes/ResultCodes.html
-//     //
-//
-//     FSRef iFile;
-//     OSStatus status = CreateFSRef(&iFile, nsFilePath);
-//
-//     if (status == noErr) {
-//         ATSFontContainerRef oContainer;
-//         status = ATSFontActivateFromFileReference(&iFile, kATSFontContextLocal,
-//                                                   kATSFontFormatUnspecified,
-//                                                   NULL,
-//                                                   kATSOptionFlagsUseDataFork,
-//                                                   &oContainer);
-//         if (status == noErr) {
-//             ATSFontRef ioArray[1];
-//             ItemCount oCount;
-//             status = ATSFontFindFromContainer(oContainer,
-//                                               kATSOptionFlagsUseDataFork,
-//                                               1, ioArray, &oCount);
-//
-//             if (status == noErr) {
-//                 CFStringRef oName;
-//                 status = ATSFontGetPostScriptName(ioArray[0],
-//                                                   kATSOptionFlagsUseDataFork,
-//                                                   &oName);
-//                 if (status == noErr) {
-//                     javaFontName = JNFNSToJavaString(env, (NSString *)oName);
-//                     CFRelease(oName);
-//                 }
-//             }
-//         }
-//     }
-//
-//     if (javaFontName != NULL) {
-//         // create the CFont!
-//         static JNF_CLASS_CACHE(sjc_CFont, "sun/font/CFont");
-//         static JNF_CTOR_CACHE(sjf_CFont_ctor,
-//                               sjc_CFont, "(Ljava/lang/String;)V");
-//         result = JNFNewObject(env, sjf_CFont_ctor, javaFontName);
-//     }
-//
-// JNF_COCOA_EXIT(env);
-//
-//     return result;
-// }
-
 /*
  * Class:     sun_font_CFontManager
  * Method:    loadNativeFonts
@@ -359,11 +297,8 @@ JNIEXPORT void JNICALL
 Java_sun_font_CFontManager_loadNativeFonts
     (JNIEnv *env, jobject jthis)
 {
-    static JNF_CLASS_CACHE(jc_CFontManager,
-                           "sun/font/CFontManager");
-    static JNF_MEMBER_CACHE(jm_registerFont, jc_CFontManager,
-                            "registerFont",
-                            "(Ljava/lang/String;Ljava/lang/String;)V");
+    DECLARE_CLASS(jc_CFontManager, "sun/font/CFontManager");
+    DECLARE_METHOD(jm_registerFont, jc_CFontManager, "registerFont", "(Ljava/lang/String;Ljava/lang/String;)V");
 
     jint num = 0;
 
@@ -379,8 +314,8 @@ JNF_COCOA_ENTER(env);
         jobject jFontFamilyName =
             JNFNSToJavaString(env, GetFamilyNameForFontName(fontname));
 
-        JNFCallVoidMethod(env, jthis,
-                          jm_registerFont, jFontName, jFontFamilyName);
+        (*env)->CallVoidMethod(env, jthis, jm_registerFont, jFontName, jFontFamilyName);
+        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, jFontName);
         (*env)->DeleteLocalRef(env, jFontFamilyName);
     }
@@ -637,6 +572,9 @@ Java_sun_font_CFont_getCascadeList
 #endif
         jstring jFontName = (jstring)JNFNSToJavaString(env, fontname);
         (*env)->CallBooleanMethod(env, arrayListOfString, addMID, jFontName);
+        if ((*env)->ExceptionOccurred(env)) {
+            return;
+        }
         (*env)->DeleteLocalRef(env, jFontName);
     }
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.m
@@ -28,6 +28,7 @@
 #import "ThreadUtilities.h"
 #import "LWCToolkit.h"
 #import "CGLSurfaceData.h"
+#import "JNIUtilities.h"
 
 
 extern NSOpenGLPixelFormat *sharedPixelFormat;
@@ -129,8 +130,8 @@ AWT_ASSERT_APPKIT_THREAD;
     AWT_ASSERT_APPKIT_THREAD;
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    static JNF_CLASS_CACHE(jc_JavaLayer, "sun/java2d/opengl/CGLLayer");
-    static JNF_MEMBER_CACHE(jm_drawInCGLContext, jc_JavaLayer, "drawInCGLContext", "()V");
+    DECLARE_CLASS(jc_JavaLayer, "sun/java2d/opengl/CGLLayer");
+    DECLARE_METHOD(jm_drawInCGLContext, jc_JavaLayer, "drawInCGLContext", "()V");
 
     jobject javaLayerLocalRef = [self.javaLayer jObjectWithEnv:env];
     if ((*env)->IsSameObject(env, javaLayerLocalRef, NULL)) {
@@ -146,7 +147,8 @@ AWT_ASSERT_APPKIT_THREAD;
 
     glViewport(0, 0, textureWidth, textureHeight);
 
-    JNFCallVoidMethod(env, javaLayerLocalRef, jm_drawInCGLContext);
+    (*env)->CallVoidMethod(env, javaLayerLocalRef, jm_drawInCGLContext);
+    CHECK_EXCEPTION();
     (*env)->DeleteLocalRef(env, javaLayerLocalRef);
 
     // Call super to finalize the drawing. By default all it does is call glFlush().

--- a/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef __JNIUTILITIES_H
+#define __JNIUTILITIES_H
+
+#include "jni.h"
+#include "jni_util.h"
+
+/********        LOGGING SUPPORT    *********/
+
+#define LOG_NULL(dst_var, name) \
+   if (dst_var == NULL) { \
+       NSLog(@"Bad JNI lookup %s\n", name); \
+    }
+
+/********        GET CLASS SUPPORT    *********/
+
+#define GET_CLASS(dst_var, cls) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->FindClass(env, cls); \
+         if (dst_var != NULL) dst_var = (*env)->NewGlobalRef(env, dst_var); \
+     } \
+     LOG_NULL(dst_var, cls); \
+     CHECK_NULL(dst_var);
+
+#define DECLARE_CLASS(dst_var, cls) \
+    static jclass dst_var = NULL; \
+    GET_CLASS(dst_var, cls);
+
+#define GET_CLASS_RETURN(dst_var, cls, ret) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->FindClass(env, cls); \
+         if (dst_var != NULL) dst_var = (*env)->NewGlobalRef(env, dst_var); \
+     } \
+     LOG_NULL(dst_var, cls); \
+     CHECK_NULL_RETURN(dst_var, ret);
+
+#define DECLARE_CLASS_RETURN(dst_var, cls, ret) \
+    static jclass dst_var = NULL; \
+    GET_CLASS_RETURN(dst_var, cls, ret);
+
+
+/********        GET METHOD SUPPORT    *********/
+
+#define GET_METHOD(dst_var, cls, name, signature) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->GetMethodID(env, cls, name, signature); \
+     } \
+     LOG_NULL(dst_var, name); \
+     CHECK_NULL(dst_var);
+
+#define DECLARE_METHOD(dst_var, cls, name, signature) \
+     static jmethodID dst_var = NULL; \
+     GET_METHOD(dst_var, cls, name, signature);
+
+#define GET_METHOD_RETURN(dst_var, cls, name, signature, ret) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->GetMethodID(env, cls, name, signature); \
+     } \
+     LOG_NULL(dst_var, name); \
+     CHECK_NULL_RETURN(dst_var, ret);
+
+#define DECLARE_METHOD_RETURN(dst_var, cls, name, signature, ret) \
+     static jmethodID dst_var = NULL; \
+     GET_METHOD_RETURN(dst_var, cls, name, signature, ret);
+
+#define GET_STATIC_METHOD(dst_var, cls, name, signature) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->GetStaticMethodID(env, cls, name, signature); \
+     } \
+     LOG_NULL(dst_var, name); \
+     CHECK_NULL(dst_var);
+
+#define DECLARE_STATIC_METHOD(dst_var, cls, name, signature) \
+     static jmethodID dst_var = NULL; \
+     GET_STATIC_METHOD(dst_var, cls, name, signature);
+
+#define GET_STATIC_METHOD_RETURN(dst_var, cls, name, signature, ret) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->GetStaticMethodID(env, cls, name, signature); \
+     } \
+     LOG_NULL(dst_var, name); \
+     CHECK_NULL_RETURN(dst_var, ret);
+
+#define DECLARE_STATIC_METHOD_RETURN(dst_var, cls, name, signature, ret) \
+     static jmethodID dst_var = NULL; \
+     GET_STATIC_METHOD_RETURN(dst_var, cls, name, signature, ret);
+
+/********        GET FIELD SUPPORT    *********/
+
+
+#define GET_FIELD(dst_var, cls, name, signature) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->GetFieldID(env, cls, name, signature); \
+     } \
+     LOG_NULL(dst_var, name); \
+     CHECK_NULL(dst_var);
+
+#define DECLARE_FIELD(dst_var, cls, name, signature) \
+     static jfieldID dst_var = NULL; \
+     GET_FIELD(dst_var, cls, name, signature);
+
+#define GET_FIELD_RETURN(dst_var, cls, name, signature, ret) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->GetFieldID(env, cls, name, signature); \
+     } \
+     LOG_NULL(dst_var, name); \
+     CHECK_NULL_RETURN(dst_var, ret);
+
+#define DECLARE_FIELD_RETURN(dst_var, cls, name, signature, ret) \
+     static jfieldID dst_var = NULL; \
+     GET_FIELD_RETURN(dst_var, cls, name, signature, ret);
+
+#define GET_STATIC_FIELD_RETURN(dst_var, cls, name, signature, ret) \
+     if (dst_var == NULL) { \
+         dst_var = (*env)->GetStaticFieldID(env, cls, name, signature); \
+     } \
+     LOG_NULL(dst_var, name); \
+     CHECK_NULL_RETURN(dst_var, ret);
+
+#define DECLARE_STATIC_FIELD_RETURN(dst_var, cls, name, signature, ret) \
+     static jfieldID dst_var = NULL; \
+     GET_STATIC_FIELD_RETURN(dst_var, cls, name, signature, ret);
+
+/*********       EXCEPTION_HANDLING    *********/
+
+#define CHECK_EXCEPTION() \
+    if ((*env)->ExceptionOccurred(env) != NULL) { \
+        (*env)->ExceptionClear(env); \
+    };
+
+#define CHECK_EXCEPTION_NULL_RETURN(x, y) \
+    CHECK_EXCEPTION(); \
+    if ((x) == NULL) { \
+       return y; \
+    };
+
+#endif /* __JNIUTILITIES_H */

--- a/src/java.desktop/macosx/native/libosxapp/PropertiesUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/PropertiesUtilities.m
@@ -24,16 +24,19 @@
  */
 
 #import "PropertiesUtilities.h"
+#import "JNIUtilities.h"
 
 @implementation PropertiesUtilities
 
 + (NSString *) javaSystemPropertyForKey:(NSString *)key withEnv:(JNIEnv *)env {
-    static JNF_CLASS_CACHE(jc_System, "java/lang/System");
-    static JNF_STATIC_MEMBER_CACHE(jm_getProperty, jc_System, "getProperty", "(Ljava/lang/String;)Ljava/lang/String;");
+    DECLARE_CLASS_RETURN(jc_System, "java/lang/System", nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getProperty, jc_System,
+                                 "getProperty", "(Ljava/lang/String;)Ljava/lang/String;", nil);
 
     jstring jKey = JNFNSToJavaString(env, key);
-    jstring jValue = JNFCallStaticObjectMethod(env, jm_getProperty, jKey);
+    jstring jValue = (*env)->CallStaticObjectMethod(env, jc_System, jm_getProperty, jKey);
     (*env)->DeleteLocalRef(env, jKey);
+    CHECK_EXCEPTION_NULL_RETURN(jValue, nil);
 
     NSString *value = JNFJavaToNSString(env, jValue);
     (*env)->DeleteLocalRef(env, jValue);

--- a/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
+++ b/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
@@ -36,8 +36,11 @@
 
 #import "ThreadUtilities.h"
 #import "CMenuBar.h"
+#import "JNIUtilities.h"
 
-static JNF_CLASS_CACHE(sjc_ScreenMenu, "com/apple/laf/ScreenMenu");
+static jclass sjc_ScreenMenu = NULL;
+#define GET_SCREENMENU_CLASS() \
+     GET_CLASS(sjc_ScreenMenu, "com/apple/laf/ScreenMenu");
 
 static jint ns2awtModifiers(NSUInteger keyMods) {
     jint result = 0;
@@ -104,8 +107,10 @@ static jint ns2awtMouseButton(NSInteger mouseButton) {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
 JNF_COCOA_ENTER(env);
     //NSLog(@"menuWillOpen %@", [menu title]);
-    static JNF_MEMBER_CACHE(jm_ScreenMenu_invokeOpenLater, sjc_ScreenMenu, "invokeOpenLater", "()V");
-    JNFCallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeOpenLater); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_SCREENMENU_CLASS();
+    DECLARE_METHOD(jm_ScreenMenu_invokeOpenLater, sjc_ScreenMenu, "invokeOpenLater", "()V");
+    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeOpenLater); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 JNF_COCOA_EXIT(env);
 
 }
@@ -122,8 +127,10 @@ JNF_COCOA_EXIT(env);
     JNIEnv *env = [ThreadUtilities getJNIEnv];
 JNF_COCOA_ENTER(env);
     //NSLog(@"menuDidClose %@", [menu title]);
-    static JNF_MEMBER_CACHE(jm_ScreenMenu_invokeMenuClosing, sjc_ScreenMenu, "invokeMenuClosing", "()V");
-    JNFCallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeMenuClosing); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_SCREENMENU_CLASS();
+    DECLARE_METHOD(jm_ScreenMenu_invokeMenuClosing, sjc_ScreenMenu, "invokeMenuClosing", "()V");
+    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeMenuClosing); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 JNF_COCOA_EXIT(env);
 }
 
@@ -140,9 +147,11 @@ JNF_COCOA_EXIT(env);
     JNIEnv *env = [ThreadUtilities getJNIEnv];
 JNF_COCOA_ENTER(env);
     // Send that to Java so we can test which item was hit.
-    static JNF_MEMBER_CACHE(jm_ScreenMenu_updateSelectedItem, sjc_ScreenMenu, "handleItemTargeted", "(IIIII)V");
-    JNFCallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_updateSelectedItem, menuIndex,
+    GET_SCREENMENU_CLASS();
+    DECLARE_METHOD(jm_ScreenMenu_updateSelectedItem, sjc_ScreenMenu, "handleItemTargeted", "(IIIII)V");
+    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_updateSelectedItem, menuIndex,
                     NSMinY(rect), NSMinX(rect), NSMaxY(rect), NSMaxX(rect)); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 
 JNF_COCOA_EXIT(env);
 }
@@ -183,8 +192,11 @@ JNF_COCOA_EXIT(env);
     // Call the mouse event handler, which will generate Java mouse events.
     JNIEnv *env = [ThreadUtilities getJNIEnv];
 JNF_COCOA_ENTER(env);
-    static JNF_MEMBER_CACHE(jm_ScreenMenu_handleMouseEvent, sjc_ScreenMenu, "handleMouseEvent", "(IIIIJ)V");
-    JNFCallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_handleMouseEvent, javaKind, javaX, javaY, javaModifiers, javaWhen); // AWT_THREADING Safe (AWTRunLoopMode)
+    GET_SCREENMENU_CLASS();
+    DECLARE_METHOD(jm_ScreenMenu_handleMouseEvent, sjc_ScreenMenu, "handleMouseEvent", "(IIIIJ)V");
+    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_handleMouseEvent,
+             javaKind, javaX, javaY, javaModifiers, javaWhen); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 JNF_COCOA_EXIT(env);
 }
 


### PR DESCRIPTION
Clean backport from 15u-dev to 13u-dev. review of backrot from 17 to 15 - https://github.com/openjdk/jdk15u-dev/pull/9

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257853](https://bugs.openjdk.java.net/browse/JDK-8257853): Remove dependencies on JNF's JNI utility functions in AWT and 2D code


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/173.diff">https://git.openjdk.java.net/jdk13u-dev/pull/173.diff</a>

</details>
