### PR TITLE
8259343: [macOS] Update JNI error handling in Cocoa code.

### DIFF
--- a/make/lib/Lib-java.desktop.gmk
+++ b/make/lib/Lib-java.desktop.gmk
@@ -98,6 +98,7 @@ ifeq ($(call isTargetOs, macosx), true)
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS := \
+          -ljava \
           -framework Accelerate \
           -framework ApplicationServices \
           -framework AudioToolbox \
@@ -111,6 +112,8 @@ ifeq ($(call isTargetOs, macosx), true)
           -framework IOSurface \
           -framework QuartzCore, \
   ))
+
+  $(BUILD_LIBOSXAPP): $(call FindLib, java.base, java)
 
   TARGETS += $(BUILD_LIBOSXAPP)
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1290,6 +1290,7 @@ static jclass jc_CInputMethod = NULL;
 
     array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_firstRectForCharacterRange,
                                 theRange.location); // AWT_THREADING Safe (AWTRunLoopMode)
+    CHECK_EXCEPTION();
 
     _array = (*env)->GetIntArrayElements(env, array, &isCopy);
     if (_array) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -56,7 +56,7 @@ static jmethodID sjm_printerJob = NULL;
     GET_CPRINTERJOB_CLASS_RETURN(ret); \
     GET_METHOD_RETURN(sjm_getNSPrintInfo, sjc_CPrinterJob, "getNSPrintInfo", "()J", ret);
 
-#define GET_CPRINTERDIALOG_METHOD_RETURN(ret) \
+#define GET_CPRINTERDIALOG_FIELD_RETURN(ret) \
    GET_CPRINTERDIALOG_CLASS_RETURN(ret); \
    GET_METHOD_RETURN(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;", ret);
 
@@ -624,6 +624,7 @@ JNF_COCOA_ENTER(env);
 
         // <rdar://problem/4367998> JTable.print attributes are ignored
         jobject pageable = (*env)->CallObjectMethod(env, jthis, jm_getPageable); // AWT_THREADING Safe (!appKit)
+        CHECK_EXCEPTION();
         javaPrinterJobToNSPrintInfo(env, jthis, pageable, printInfo);
 
         PrintModel* printModel = [[PrintModel alloc] initWithPrintInfo:printInfo];
@@ -664,11 +665,12 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterPageDialog_showDialog
 
     jboolean result = JNI_FALSE;
 JNF_COCOA_ENTER(env);
-    GET_CPRINTERDIALOG_METHOD_RETURN(NO);
+    GET_CPRINTERDIALOG_FIELD_RETURN(NO);
     GET_NSPRINTINFO_METHOD_RETURN(NO)
     jobject printerJob = (*env)->GetObjectField(env, jthis, sjm_printerJob);
     if (printerJob == NULL) return NO;
     NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr((*env)->CallLongMethod(env, printerJob, sjm_getNSPrintInfo)); // AWT_THREADING Safe (known object)
+    CHECK_EXCEPTION();
     if (printInfo == NULL) return result;
 
     jobject page = (*env)->GetObjectField(env, jthis, jm_page);
@@ -713,7 +715,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJobDialog_showDialog
 
     jboolean result = JNI_FALSE;
 JNF_COCOA_ENTER(env);
-    GET_CPRINTERDIALOG_METHOD_RETURN(NO);
+    GET_CPRINTERDIALOG_FIELD_RETURN(NO);
     jobject printerJob = (*env)->GetObjectField(env, jthis, sjm_printerJob);
     if (printerJob == NULL) return NO;
     GET_NSPRINTINFO_METHOD_RETURN(NO)

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.m
@@ -24,6 +24,7 @@
  */
 
 #import "GeomUtilities.h"
+#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 static jobject NewJavaRect(JNIEnv *env, jdouble x, jdouble y, jdouble w, jdouble h) {
     DECLARE_CLASS_RETURN(sjc_Rectangle2DDouble, "java/awt/geom/Rectangle2D$Double", NULL);
@@ -55,10 +56,11 @@ NSRect JavaToNSRect(JNIEnv *env, jobject rect) {
     DECLARE_METHOD_RETURN(jm_rect_getY, sjc_Rectangle2D, "getY", "()D", NSZeroRect);
     DECLARE_METHOD_RETURN(jm_rect_getWidth, sjc_Rectangle2D, "getWidth", "()D", NSZeroRect);
     DECLARE_METHOD_RETURN(jm_rect_getHeight, sjc_Rectangle2D, "getHeight", "()D", NSZeroRect);
-    return NSMakeRect((*env)->CallDoubleMethod(env, rect, jm_rect_getX),
-                      (*env)->CallDoubleMethod(env, rect, jm_rect_getY),
-                      (*env)->CallDoubleMethod(env, rect, jm_rect_getWidth),
-                      (*env)->CallDoubleMethod(env, rect, jm_rect_getHeight));
+    jdouble x = (*env)->CallDoubleMethod(env, rect, jm_rect_getX); CHECK_EXCEPTION();
+    jdouble y = (*env)->CallDoubleMethod(env, rect, jm_rect_getY); CHECK_EXCEPTION();
+    jdouble w = (*env)->CallDoubleMethod(env, rect, jm_rect_getWidth); CHECK_EXCEPTION();
+    jdouble h = (*env)->CallDoubleMethod(env, rect, jm_rect_getHeight); CHECK_EXCEPTION();
+    return NSMakeRect(x, y, w, h);
 }
 
 jobject NSToJavaPoint(JNIEnv *env, NSPoint point) {
@@ -73,9 +75,9 @@ NSPoint JavaToNSPoint(JNIEnv *env, jobject point) {
     DECLARE_CLASS_RETURN(sjc_Point2D, "java/awt/geom/Point2D", NSZeroPoint);
     DECLARE_METHOD_RETURN(jm_pt_getX, sjc_Point2D, "getX", "()D", NSZeroPoint);
     DECLARE_METHOD_RETURN(jm_pt_getY, sjc_Point2D, "getY", "()D", NSZeroPoint);
-
-    return NSMakePoint((*env)->CallDoubleMethod(env, point, jm_pt_getX),
-                       (*env)->CallDoubleMethod(env, point, jm_pt_getY));
+    jdouble x = (*env)->CallDoubleMethod(env, point, jm_pt_getX); CHECK_EXCEPTION();
+    jdouble y = (*env)->CallDoubleMethod(env, point, jm_pt_getY); CHECK_EXCEPTION();
+    return NSMakePoint(x, y);
 }
 
 jobject NSToJavaSize(JNIEnv *env, NSSize size) {
@@ -90,14 +92,15 @@ NSSize JavaToNSSize(JNIEnv *env, jobject dimension) {
     DECLARE_CLASS_RETURN(sjc_Dimension2D, "java/awt/geom/Dimension2D", NSZeroSize);
     DECLARE_METHOD_RETURN(jm_sz_getWidth, sjc_Dimension2D, "getWidth", "()D", NSZeroSize);
     DECLARE_METHOD_RETURN(jm_sz_getHeight, sjc_Dimension2D, "getHeight", "()D", NSZeroSize);
-
-    return NSMakeSize((*env)->CallDoubleMethod(env, dimension, jm_sz_getWidth),
-                      (*env)->CallDoubleMethod(env, dimension, jm_sz_getHeight));
+    jdouble w = (*env)->CallDoubleMethod(env, dimension, jm_sz_getWidth); CHECK_EXCEPTION();
+    jdouble h = (*env)->CallDoubleMethod(env, dimension, jm_sz_getHeight); CHECK_EXCEPTION();
+    return NSMakeSize(w, h);
 }
 
 static NSScreen *primaryScreen(JNIEnv *env) {
     NSScreen *primaryScreen = [[NSScreen screens] objectAtIndex:0];
     if (primaryScreen != nil) return primaryScreen;
+    if (env != NULL) [JNFException raise:env as:kRuntimeException reason:"Failed to convert, no screen."];
     return nil;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -623,6 +623,7 @@ static NSObject *sAttributeNamesLOCK = nil;
         } else {
             AWTView *view = fView;
             jobject jax = (*env)->CallStaticObjectMethod(env, sjc_CAccessible, sjm_getSwingAccessible, fAccessible);
+            CHECK_EXCEPTION();
 
             if ((*env)->IsInstanceOf(env, jax, sjc_Window)) {
                 // In this case jparent is an owner toplevel and we should retrieve its own view
@@ -911,6 +912,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     if ([(NSNumber*)value boolValue])
     {
         (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestFocus, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+        CHECK_EXCEPTION();
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaTextAccessibility.m
@@ -160,7 +160,6 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
 
     DECLARE_STATIC_METHOD_RETURN(jm_getTextRange, sjc_CAccessibleText, "getTextRange",
                     "(Ljavax/accessibility/AccessibleEditableText;IILjava/awt/Component;)Ljava/lang/String;", nil);
-    CHECK_EXCEPTION();
     jobject jrange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getTextRange,
                        axEditableText, 0, getAxTextCharCount(env, axEditableText, fComponent), fComponent);
     CHECK_EXCEPTION();

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
@@ -123,6 +123,7 @@ static jclass sjc_CPrinterJob = NULL;
     DECLARE_METHOD_RETURN(jm_getJobName, sjc_CPrinterJob, "getJobName", "()Ljava/lang/String;", nil);
 
     jobject o = (*env)->CallObjectMethod(env, fPrinterJob, jm_getJobName); // AWT_THREADING Safe (known object)
+    CHECK_EXCEPTION();
     id result = JNFJavaToNSString(env, o);
     (*env)->DeleteLocalRef(env, o);
     return result;


### PR DESCRIPTION
clean backport from jdk15 to jdk13, only gmk file needed to be renamed.

not a clean backport from 17 to 13.

jdk15u review - https://github.com/openjdk/jdk15u-dev/pull/10

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259343](https://bugs.openjdk.java.net/browse/JDK-8259343): [macOS] Update JNI error handling in Cocoa code.


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/175.diff">https://git.openjdk.java.net/jdk13u-dev/pull/175.diff</a>

</details>
