### PR TITLE
8259232: Bad JNI lookup during printing

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -57,7 +57,7 @@ static jmethodID sjm_printerJob = NULL;
 
 #define GET_CPRINTERDIALOG_FIELD_RETURN(ret) \
    GET_CPRINTERDIALOG_CLASS_RETURN(ret); \
-   GET_METHOD_RETURN(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;", ret);
+   GET_FIELD_RETURN(sjm_printerJob, sjc_CPrinterDialog, "fPrinterJob", "Lsun/lwawt/macosx/CPrinterJob;", ret);
 
 static NSPrintInfo* createDefaultNSPrintInfo();
 

--- a/test/jdk/java/awt/print/bug8023392/bug8023392.java
+++ b/test/jdk/java/awt/print/bug8023392/bug8023392.java
@@ -23,7 +23,7 @@
 
 /*
   test
-  @bug 8023392
+  @bug 8023392 8259232
   @summary Swing text components printed with spaces between chars
   @author Anton Nashatyrev
   @run applet/manual=yesno bug8023392.html


### PR DESCRIPTION
I'd like to backport JDK-8259232 to jdk13u for parity with jdk11u.
The original patch applied cleanly. 
Tested via jtreg with test/jdk/java/awt/print/bug8023392 pointed in the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259232](https://bugs.openjdk.java.net/browse/JDK-8259232): Bad JNI lookup during printing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/181/head:pull/181` \
`$ git checkout pull/181`

Update a local copy of the PR: \
`$ git checkout pull/181` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 181`

View PR using the GUI difftool: \
`$ git pr show -t 181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/181.diff">https://git.openjdk.java.net/jdk13u-dev/pull/181.diff</a>

</details>
