### PR TITLE
8244853: The static build of libextnet is missing the JNI_OnLoad_extnet function

### DIFF
--- a/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
+++ b/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
@@ -34,6 +34,11 @@
 #include "jdk_net_LinuxSocketOptions.h"
 
 /*
+ * Declare library specific JNI_Onload entry if static build
+ */
+DEF_STATIC_JNI_OnLoad
+
+/*
  * Class:     jdk_net_LinuxSocketOptions
  * Method:    setQuickAck
  * Signature: (II)V

--- a/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
+++ b/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
@@ -32,6 +32,11 @@
 #include <netinet/in.h>
 #include "jni_util.h"
 
+/*
+ * Declare library specific JNI_Onload entry if static build
+ */
+DEF_STATIC_JNI_OnLoad
+
 static jint socketOptionSupported(jint sockopt) {
     jint one = 1;
     jint rv, s;

--- a/src/jdk.net/solaris/native/libextnet/SolarisSocketOptions.c
+++ b/src/jdk.net/solaris/native/libextnet/SolarisSocketOptions.c
@@ -32,6 +32,11 @@ static jfieldID sf_bandwidth;
 static int initialized = 0;
 
 /*
+ * Declare library specific JNI_Onload entry if static build
+ */
+DEF_STATIC_JNI_OnLoad
+
+/*
  * Class:     jdk_net_SolarisSocketOptions
  * Method:    init
  * Signature: ()V


### PR DESCRIPTION
I'd like to port this fix for general alignment with other release trains. The patch goes clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8244853](https://bugs.openjdk.java.net/browse/JDK-8244853): The static build of libextnet is missing the JNI_OnLoad_extnet function


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/182/head:pull/182` \
`$ git checkout pull/182`

Update a local copy of the PR: \
`$ git checkout pull/182` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 182`

View PR using the GUI difftool: \
`$ git pr show -t 182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/182.diff">https://git.openjdk.java.net/jdk13u-dev/pull/182.diff</a>

</details>
