### PR TITLE
8261198: [macOS] Incorrect JNI parameters in number conversion in A11Y code

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -964,14 +964,14 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
     }
     DECLARE_CLASS_RETURN(jnumber_Class, "java/lang/Number", nil);
     DECLARE_CLASS_RETURN(jinteger_Class, "java/lang/Integer", nil);
-    DECLARE_METHOD_RETURN(jm_intValue, jnumber_Class, "intValue", "()D", nil);
+    DECLARE_METHOD_RETURN(jm_intValue, jnumber_Class, "intValue", "()I", nil);
     DECLARE_METHOD_RETURN(jm_doubleValue, jnumber_Class, "doubleValue", "()D", nil);
     if ((*env)->IsInstanceOf(env, jnumber, jinteger_Class)) {
-        jint i = (*env)->CallIntMethod(env, jnumber_Class, jm_intValue);
+        jint i = (*env)->CallIntMethod(env, jnumber, jm_intValue);
         CHECK_EXCEPTION();
         return [NSNumber numberWithInteger:i];
     } else {
-        jdouble d = (*env)->CallDoubleMethod(env, jnumber_Class, jm_doubleValue);
+        jdouble d = (*env)->CallDoubleMethod(env, jnumber, jm_doubleValue);
         CHECK_EXCEPTION();
         return [NSNumber numberWithDouble:d];
     }


### PR DESCRIPTION
I'd like to backport JDK-8261198 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
Tested with SwingSet2 demo using voiceover.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261198](https://bugs.openjdk.java.net/browse/JDK-8261198): [macOS] Incorrect JNI parameters in number conversion in A11Y code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/185.diff">https://git.openjdk.java.net/jdk13u-dev/pull/185.diff</a>

</details>
