### PR TITLE
8247753: UIManager.getSytemLookAndFeelClassName() returns wrong value on Fedora 32

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -95,10 +95,19 @@ public abstract class UNIXToolkit extends SunToolkit
 
     @Override
     public String getDesktop() {
+        String gnome = "gnome";
         String gsi = AccessController.doPrivileged(
                         (PrivilegedAction<String>) ()
                                 -> System.getenv("GNOME_DESKTOP_SESSION_ID"));
-        return (gsi != null) ? "gnome" : null;
+        if (gsi != null) {
+            return gnome;
+        }
+
+        String desktop = AccessController.doPrivileged(
+                (PrivilegedAction<String>) ()
+                        -> System.getenv("XDG_CURRENT_DESKTOP"));
+        return (desktop != null && desktop.toLowerCase().contains(gnome))
+                ? gnome : null;
     }
 
     /**

--- a/test/jdk/javax/swing/LookAndFeel/SystemLookAndFeel/SystemLookAndFeelTest.java
+++ b/test/jdk/javax/swing/LookAndFeel/SystemLookAndFeel/SystemLookAndFeelTest.java
@@ -21,9 +21,9 @@
  * questions.
  */
 
- /*
+/*
  * @test
- * @bug 8226783
+ * @bug 8226783 8247753
  * @key headful
  * @summary Verify System L&F
  */
@@ -52,25 +52,26 @@ public class SystemLookAndFeelTest {
         } else if (os.contains("macos")) {
             expLAF = "com.apple.laf.AquaLookAndFeel";
         } else if (os.contains("linux") || os.contains("sunos")) {
-           /*
-            * The implementation keys off the following desktop setting to
-            * decide if GTK is an appropriate system L&F.
-            * In its absence, there probably isn't support for the GTK L&F
-            * anyway. It does not tell us if the GTK libraries are available
-            * but they really should be if this is a gnome session.
-            * If it proves necessary the test can perhaps be updated to see
-            * if the GTK LAF is listed as installed and can be instantiated.
-            */
-           String gnome = System.getenv("GNOME_DESKTOP_SESSION_ID");
-           System.out.println("Gnome desktop session ID is " + gnome);
-           if (gnome != null) {
-               expLAF = "com.sun.java.swing.plaf.gtk.GTKLookAndFeel";
-           } else if (os.contains("linux")) {
-               expLAF = "javax.swing.plaf.metal.MetalLookAndFeel";
-           } else if (os.contains("sunos")) {
-               expLAF = "com.sun.java.swing.plaf.motif.MotifLookAndFeel";
-           }
-       }
+            /*
+             * The implementation keys off the following desktop setting to
+             * decide if GTK is an appropriate system L&F.
+             * In its absence, there probably isn't support for the GTK L&F
+             * anyway. It does not tell us if the GTK libraries are available
+             * but they really should be if this is a gnome session.
+             * If it proves necessary the test can perhaps be updated to see
+             * if the GTK LAF is listed as installed and can be instantiated.
+             */
+            String gnome = System.getenv("GNOME_DESKTOP_SESSION_ID");
+            String desktop = System.getenv("XDG_CURRENT_DESKTOP");
+            System.out.println("Gnome desktop session ID is " + gnome);
+            System.out.println("XDG_CURRENT_DESKTOP is set to " + desktop);
+            if (gnome != null ||
+                    (desktop != null && desktop.toLowerCase().contains("gnome"))) {
+                expLAF = "com.sun.java.swing.plaf.gtk.GTKLookAndFeel";
+            } else {
+                expLAF = "javax.swing.plaf.metal.MetalLookAndFeel";
+            }
+        }
         System.out.println("Expected System LAF is " + expLAF);
         if (expLAF == null) {
             System.out.println("No match for expected LAF, unknown OS ?");
@@ -79,5 +80,5 @@ public class SystemLookAndFeelTest {
         if (!(laf.equals(expLAF))) {
             throw new RuntimeException("LAF not as expected");
         }
-   }
+    }
 }


### PR DESCRIPTION
This patch does change some code inside a condition clause in a test. Now, in jdk17 that condition (so, context for this fix) checks for linux only but in jdk13 it checks also for solaris. Other than that, patch goes clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247753](https://bugs.openjdk.java.net/browse/JDK-8247753): UIManager.getSytemLookAndFeelClassName() returns wrong value on Fedora 32


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/188/head:pull/188` \
`$ git checkout pull/188`

Update a local copy of the PR: \
`$ git checkout pull/188` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 188`

View PR using the GUI difftool: \
`$ git pr show -t 188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/188.diff">https://git.openjdk.java.net/jdk13u-dev/pull/188.diff</a>

</details>
