### PR TITLE
8256633: Fix product build on Windows+Arm64

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -476,8 +476,7 @@ class Address {
         if (size == 0) // It's a byte
           i->f(_ext.shift() >= 0, 12);
         else {
-          if (_ext.shift() > 0)
-            assert(_ext.shift() == (int)size, "bad shift");
+          assert(_ext.shift() <= 0 || _ext.shift() == (int)size, "bad shift");
           i->f(_ext.shift() > 0, 12);
         }
         i->f(0b10, 11, 10);


### PR DESCRIPTION
Clean backport to jdk13u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8256633](https://bugs.openjdk.java.net/browse/JDK-8256633): Fix product build on Windows+Arm64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/190/head:pull/190` \
`$ git checkout pull/190`

Update a local copy of the PR: \
`$ git checkout pull/190` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 190`

View PR using the GUI difftool: \
`$ git pr show -t 190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/190.diff">https://git.openjdk.java.net/jdk13u-dev/pull/190.diff</a>

</details>
