### PR TITLE
8255845: Memory leak in imageFile.cpp

### DIFF
--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -178,8 +178,8 @@ const char* ImageModuleData::package_to_module(const char* package_name) {
     // retrieve package location
     ImageLocation location;
     bool found = _image_file->find_location(path, location);
+    delete[] path;
     if (!found) {
-        delete[] path;
         return NULL;
     }
 


### PR DESCRIPTION
fix here, too, for consistency. Clean; no regressions found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255845](https://bugs.openjdk.java.net/browse/JDK-8255845): Memory leak in imageFile.cpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/194.diff">https://git.openjdk.java.net/jdk13u-dev/pull/194.diff</a>

</details>
