### PR TITLE
8244088: [Regression] Switch of Gnome theme ends up in deadlocked UI

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -703,7 +703,7 @@ static int gtk3_unload()
  */
 static void flush_gtk_event_loop()
 {
-    while((*fp_g_main_context_iteration)(NULL));
+    while((*fp_g_main_context_iteration)(NULL, FALSE));
 }
 
 /*

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
@@ -396,7 +396,7 @@ static void         (*fp_g_object_set)(gpointer object,
                                        const gchar *first_property_name,
                                        ...);
 
-static gboolean (*fp_g_main_context_iteration)(GMainContext *context);
+static gboolean (*fp_g_main_context_iteration)(GMainContext *context, gboolean may_block);
 static gboolean (*fp_g_str_has_prefix)(const gchar *str, const gchar *prefix);
 static gchar** (*fp_g_strsplit)(const gchar *string, const gchar *delimiter,
            gint max_tokens);

--- a/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
@@ -346,10 +346,8 @@ Java_com_sun_java_swing_plaf_gtk_GTKEngine_nativeFinishPainting(
 JNIEXPORT void JNICALL Java_com_sun_java_swing_plaf_gtk_GTKEngine_native_1switch_1theme(
         JNIEnv *env, jobject this)
 {
-    // Note that flush_gtk_event_loop takes care of locks (7053002)
-    gtk->gdk_threads_enter();
+    // Note that gtk->flush_event_loop takes care of locks (7053002), gdk_threads_enter/gdk_threads_leave should not be used.
     gtk->flush_event_loop();
-    gtk->gdk_threads_leave();
 }
 
 /*


### PR DESCRIPTION
The issue exists and the fix works in GTK-3-based systems (e.g. Xfce).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8244088](https://bugs.openjdk.java.net/browse/JDK-8244088): [Regression] Switch of Gnome theme ends up in deadlocked UI


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/197/head:pull/197` \
`$ git checkout pull/197`

Update a local copy of the PR: \
`$ git checkout pull/197` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 197`

View PR using the GUI difftool: \
`$ git pr show -t 197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/197.diff">https://git.openjdk.java.net/jdk13u-dev/pull/197.diff</a>

</details>
