### PR TITLE
8231118: ARM32: Math tests failures

### DIFF
--- a/src/hotspot/cpu/arm/assembler_arm_32.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm_32.hpp
@@ -963,8 +963,8 @@ class Assembler : public AbstractAssembler  {
 
   F(fldmia, 1, 1)    F(fldmfd, 1, 1)
   F(fldmdb, 1, 2)    F(fldmea, 1, 2)
-  F(fstmia, 0, 1)    F(fstmfd, 0, 1)
-  F(fstmdb, 0, 2)    F(fstmea, 0, 2)
+  F(fstmia, 0, 1)    F(fstmea, 0, 1)
+  F(fstmdb, 0, 2)    F(fstmfd, 0, 2)
 #undef F
 
   // fconst{s,d} encoding:

--- a/src/hotspot/cpu/arm/c1_Runtime1_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_Runtime1_arm.cpp
@@ -189,7 +189,7 @@ static OopMap* save_live_registers(StubAssembler* sasm, bool save_fpu_registers 
   __ push(RegisterSet(FP) | RegisterSet(LR));
   __ push(RegisterSet(R0, R6) | RegisterSet(R8, R10) | R12 | altFP_7_11);
   if (save_fpu_registers) {
-    __ fstmdbd(SP, FloatRegisterSet(D0, fpu_save_size / 2), writeback);
+    __ fpush(FloatRegisterSet(D0, fpu_save_size / 2));
   } else {
     __ sub(SP, SP, fpu_save_size * wordSize);
   }
@@ -206,7 +206,7 @@ static void restore_live_registers(StubAssembler* sasm,
   __ block_comment("restore_live_registers");
 
   if (restore_fpu_registers) {
-    __ fldmiad(SP, FloatRegisterSet(D0, fpu_save_size / 2), writeback);
+    __ fpop(FloatRegisterSet(D0, fpu_save_size / 2));
     if (!restore_R0) {
       __ add(SP, SP, (R1_offset - fpu_save_size) * wordSize);
     }

--- a/src/hotspot/cpu/arm/macroAssembler_arm.hpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.hpp
@@ -435,6 +435,26 @@ public:
     fldmias(SP, FloatRegisterSet(fd), writeback, cond);
   }
 
+  void fpush(FloatRegisterSet reg_set) {
+    fstmdbd(SP, reg_set, writeback);
+  }
+
+  void fpop(FloatRegisterSet reg_set) {
+    fldmiad(SP, reg_set, writeback);
+  }
+
+  void fpush_hardfp(FloatRegisterSet reg_set) {
+#ifndef __SOFTFP__
+    fpush(reg_set);
+#endif
+  }
+
+  void fpop_hardfp(FloatRegisterSet reg_set) {
+#ifndef __SOFTFP__
+    fpop(reg_set);
+#endif
+  }
+
   // Order access primitives
   enum Membar_mask_bits {
     StoreStore = 1 << 3,

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -132,14 +132,14 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm,
   __ push(SAVED_BASE_REGS);
   if (HaveVFP) {
     if (VM_Version::has_vfp3_32()) {
-      __ fstmdbd(SP, FloatRegisterSet(D16, 16), writeback);
+      __ fpush(FloatRegisterSet(D16, 16));
     } else {
       if (FloatRegisterImpl::number_of_registers > 32) {
         assert(FloatRegisterImpl::number_of_registers == 64, "nb fp registers should be 64");
         __ sub(SP, SP, 32 * wordSize);
       }
     }
-    __ fstmdbd(SP, FloatRegisterSet(D0, 16), writeback);
+    __ fpush(FloatRegisterSet(D0, 16));
   } else {
     __ sub(SP, SP, fpu_save_size * wordSize);
   }
@@ -173,9 +173,9 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm,
 
 void RegisterSaver::restore_live_registers(MacroAssembler* masm, bool restore_lr) {
   if (HaveVFP) {
-    __ fldmiad(SP, FloatRegisterSet(D0, 16), writeback);
+    __ fpop(FloatRegisterSet(D0, 16));
     if (VM_Version::has_vfp3_32()) {
-      __ fldmiad(SP, FloatRegisterSet(D16, 16), writeback);
+      __ fpop(FloatRegisterSet(D16, 16));
     } else {
       if (FloatRegisterImpl::number_of_registers > 32) {
         assert(FloatRegisterImpl::number_of_registers == 64, "nb fp registers should be 64");
@@ -220,26 +220,21 @@ static void push_param_registers(MacroAssembler* masm, int fp_regs_in_arguments)
   // R1-R3 arguments need to be saved, but we push 4 registers for 8-byte alignment
   __ push(RegisterSet(R0, R3));
 
-#ifdef __ABI_HARD__
   // preserve arguments
   // Likely not needed as the locking code won't probably modify volatile FP registers,
   // but there is no way to guarantee that
   if (fp_regs_in_arguments) {
     // convert fp_regs_in_arguments to a number of double registers
     int double_regs_num = (fp_regs_in_arguments + 1) >> 1;
-    __ fstmdbd(SP, FloatRegisterSet(D0, double_regs_num), writeback);
+    __ fpush_hardfp(FloatRegisterSet(D0, double_regs_num));
   }
-#endif // __ ABI_HARD__
 }
 
 static void pop_param_registers(MacroAssembler* masm, int fp_regs_in_arguments) {
-#ifdef __ABI_HARD__
   if (fp_regs_in_arguments) {
     int double_regs_num = (fp_regs_in_arguments + 1) >> 1;
-    __ fldmiad(SP, FloatRegisterSet(D0, double_regs_num), writeback);
+    __ fpop_hardfp(FloatRegisterSet(D0, double_regs_num));
   }
-#endif // __ABI_HARD__
-
   __ pop(RegisterSet(R0, R3));
 }
 
@@ -461,11 +456,13 @@ static void patch_callers_callsite(MacroAssembler *masm) {
   // Pushing an even number of registers for stack alignment.
   // Selecting R9, which had to be saved anyway for some platforms.
   __ push(RegisterSet(R0, R3) | R9 | LR);
+  __ fpush_hardfp(FloatRegisterSet(D0, 8));
 
   __ mov(R0, Rmethod);
   __ mov(R1, LR);
   __ call(CAST_FROM_FN_PTR(address, SharedRuntime::fixup_callers_callsite));
 
+  __ fpop_hardfp(FloatRegisterSet(D0, 8));
   __ pop(RegisterSet(R0, R3) | R9 | LR);
 
   __ bind(skip);

--- a/src/hotspot/cpu/arm/stubGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/stubGenerator_arm.cpp
@@ -179,9 +179,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ mov(Rtemp, SP);
     __ push(RegisterSet(FP) | RegisterSet(LR));
-#ifndef __SOFTFP__
-    __ fstmdbd(SP, FloatRegisterSet(D8, 8), writeback);
-#endif
+    __ fpush_hardfp(FloatRegisterSet(D8, 8));
     __ stmdb(SP, RegisterSet(R0, R2) | RegisterSet(R4, R6) | RegisterSet(R8, R10) | altFP_7_11, writeback);
     __ mov(Rmethod, R3);
     __ ldmia(Rtemp, RegisterSet(R1, R3) | Rthread); // stacked arguments
@@ -243,9 +241,7 @@ class StubGenerator: public StubCodeGenerator {
 #endif
 
     __ pop(RegisterSet(R4, R6) | RegisterSet(R8, R10) | altFP_7_11);
-#ifndef __SOFTFP__
-    __ fldmiad(SP, FloatRegisterSet(D8, 8), writeback);
-#endif
+    __ fpop_hardfp(FloatRegisterSet(D8, 8));
     __ pop(RegisterSet(FP) | RegisterSet(PC));
 
     return start;

--- a/src/hotspot/cpu/arm/stubRoutinesCrypto_arm.cpp
+++ b/src/hotspot/cpu/arm/stubRoutinesCrypto_arm.cpp
@@ -129,7 +129,7 @@ address generate_aescrypt_encryptBlock() {
   //    Register tbox = R3; // transposition box reference
 
   __ push (RegisterSet(R4, R12) | LR);
-  __ fstmdbd(SP, FloatRegisterSet(D0, 4), writeback);
+  __ fpush(FloatRegisterSet(D0, 4));
   __ sub(SP, SP, 32);
 
   // preserve TBox references
@@ -308,7 +308,7 @@ address generate_aescrypt_encryptBlock() {
   __ str(R0, Address(R9));
 
   __ add(SP, SP, 32);
-  __ fldmiad(SP, FloatRegisterSet(D0, 4), writeback);;
+  __ fpop(FloatRegisterSet(D0, 4));
 
   __ pop(RegisterSet(R4, R12) | PC);
   return start;
@@ -326,7 +326,7 @@ address generate_aescrypt_decryptBlock() {
   //    Register tbox = R3; // transposition box reference
 
   __ push (RegisterSet(R4, R12) | LR);
-  __ fstmdbd(SP, FloatRegisterSet(D0, 4), writeback);
+  __ fpush(FloatRegisterSet(D0, 4));
   __ sub(SP, SP, 32);
 
   // retrieve key length
@@ -521,7 +521,7 @@ address generate_aescrypt_decryptBlock() {
   __ str(R0, Address(R9));
 
   __ add(SP, SP, 32);
-  __ fldmiad(SP, FloatRegisterSet(D0, 4), writeback);;
+  __ fpop(FloatRegisterSet(D0, 4));
   __ pop(RegisterSet(R4, R12) | PC);
 
   return start;
@@ -680,7 +680,7 @@ address generate_cipherBlockChaining_decryptAESCrypt() {
   Label decrypt_8_blocks;
   int quad = 1;
   // Process 8 blocks in parallel
-  __ fstmdbd(SP, FloatRegisterSet(D8, 8), writeback);
+  __ fpush(FloatRegisterSet(D8, 8));
   __ sub(SP, SP, 40);
 
   // record output buffer end address (used as a block counter)
@@ -1020,7 +1020,7 @@ address generate_cipherBlockChaining_decryptAESCrypt() {
   __ b(decrypt_8_blocks, ne);
 
   __ add(SP, SP, 40);
-  __ fldmiad(SP, FloatRegisterSet(D8, 8), writeback);;
+  __ fpop(FloatRegisterSet(D8, 8));
   }
 
   __ bind(cbc_done);


### PR DESCRIPTION
Hi!

I'd like to backport fixes for Math test failures happens on Raspberry Pi 4 running Raspbian OS 10 ("buster").  The patch applies cleanly.  Tests show failure without the patch and success after the patch.  
Tested: tier1 Rpi4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8231118](https://bugs.openjdk.java.net/browse/JDK-8231118): ARM32: Math tests failures


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/199.diff">https://git.openjdk.java.net/jdk13u-dev/pull/199.diff</a>

</details>
