### PR TITLE
8242184: Default signature algorithm for an RSASSA-PSS key

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -1099,6 +1099,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
             case "RSA":
                 return ifcFfcStrength(KeyUtil.getKeySize(k))
                     + "withRSA";
+            case "RSASSA-PSS":
+                return "RSASSA-PSS";
             default:
                 return null;
         }

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -35,6 +35,7 @@ import java.security.cert.X509Certificate;
 import java.security.cert.X509CRLEntry;
 import java.security.cert.CRLException;
 import java.security.*;
+import java.security.spec.AlgorithmParameterSpec;
 import java.util.*;
 
 import javax.security.auth.x500.X500Principal;
@@ -495,10 +496,20 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
             else
                 sigEngine = Signature.getInstance(algorithm, provider);
 
-            sigEngine.initSign(key);
+            AlgorithmParameterSpec params = AlgorithmId
+                    .getDefaultAlgorithmParameterSpec(algorithm, key);
+            try {
+                SignatureUtil.initSignWithParam(sigEngine, key, params, null);
+            } catch (InvalidAlgorithmParameterException e) {
+                throw new SignatureException(e);
+            }
 
-            // in case the name is reset
-            sigAlgId = AlgorithmId.get(sigEngine.getAlgorithm());
+            if (params != null) {
+                sigAlgId = AlgorithmId.get(sigEngine.getParameters());
+            } else {
+                // in case the name is reset
+                sigAlgId = AlgorithmId.get(sigEngine.getAlgorithm());
+            }
             infoSigAlgId = sigAlgId;
 
             DerOutputStream out = new DerOutputStream();

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -597,11 +597,11 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
             SignatureUtil.initSignWithParam(sigEngine, key, signingParams,
                     null);
 
-            // in case the name is reset
             if (signingParams != null) {
                 algId = AlgorithmId.get(sigEngine.getParameters());
             } else {
-                algId = AlgorithmId.get(algorithm);
+                // in case the name is reset
+                algId = AlgorithmId.get(sigEngine.getAlgorithm());
             }
             DerOutputStream out = new DerOutputStream();
             DerOutputStream tmp = new DerOutputStream();

--- a/test/jdk/sun/security/tools/keytool/GenerateAll.java
+++ b/test/jdk/sun/security/tools/keytool/GenerateAll.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8242184
+ * @summary CRL generation error with RSASSA-PSS
+ * @library /test/lib
+ */
+
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class GenerateAll {
+
+    public static void main(String[] args) throws Throwable {
+
+        kt("-genkeypair -alias ca -dname CN=CA -keyalg ec");
+
+        String[] aliases = {
+                "rsa", "dsa", "rrr", "rsassa-pss", "ec"};
+
+        for (String alias : aliases) {
+            // "rrr": keyalg is rsa, sigalg is rsassa-pss
+            // otherwise: keyalg is alias, sigalg auto derived
+            String keyAlg = alias.equals("rrr") ? "rsa" : alias;
+            String extra = alias.equals("rrr") ? " -sigalg rsassa-pss" : "";
+
+            // gen
+            kt("-genkeypair -alias " + alias + " -dname CN=" + alias
+                    + " -keyalg " + keyAlg + extra);
+
+            // req
+            kt("-certreq -alias " + alias + " -file " + alias + ".req");
+            kt("-printcertreq -file " + alias + ".req");
+
+            // gencert
+            kt("-gencert -alias ca -infile " + alias
+                    + ".req -outfile " + alias + ".crt");
+            kt("-printcert -file " + alias + ".crt");
+
+            // crl
+            kt("-gencrl -alias " + alias + " -id 0 -file " + alias + ".crl");
+            kt("-printcrl -file " + alias + ".crl")
+                    .shouldContain("Verified by " + alias);
+        }
+    }
+
+    static OutputAnalyzer kt(String arg) throws Exception {
+        return SecurityTools.keytool("-keystore ks -storepass changeit " + arg)
+                .shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
I'd like to backport JDK-8242184 to jdk13u for parity with jdk11u.
The original patch applied cleanly.
Tested via jtreg with "jdk/sun/security".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8242184](https://bugs.openjdk.java.net/browse/JDK-8242184): Default signature algorithm for an RSASSA-PSS key


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/200/head:pull/200` \
`$ git checkout pull/200`

Update a local copy of the PR: \
`$ git checkout pull/200` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 200`

View PR using the GUI difftool: \
`$ git pr show -t 200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/200.diff">https://git.openjdk.java.net/jdk13u-dev/pull/200.diff</a>

</details>
