### PR TITLE
8241248: NullPointerException in sun.security.ssl.HKDF.extract(HKDF.java:93)

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/PreSharedKeyExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/PreSharedKeyExtension.java
@@ -381,9 +381,11 @@ final class PreSharedKeyExtension {
                 SSLSessionImpl s = null;
 
                 for (PskIdentity requestedId : pskSpec.identities) {
-                    // If we are keeping state, see if the identity is in the cache
+                    // If we are keeping state, see if the identity is in the
+                    // cache. Note that for TLS 1.3, we would also clean
+                    // up the cached session if it is not rejoinable.
                     if (requestedId.identity.length == SessionId.MAX_LENGTH) {
-                        s = sessionCache.get(requestedId.identity);
+                        s = sessionCache.pull(requestedId.identity);
                     }
                     // See if the identity is a stateless ticket
                     if (s == null &&

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
@@ -175,6 +175,15 @@ final class SSLSessionContextImpl implements SSLSessionContext {
         return (SSLSessionImpl)getSession(id);
     }
 
+    // package-private method, find and remove session from cache
+    // return found session
+    SSLSessionImpl pull(byte[] id) {
+        if (id != null) {
+            return sessionCache.pull(new SessionId(id));
+        }
+        return null;
+    }
+
     // package-private method, used ONLY by ClientHandshaker
     SSLSessionImpl get(String hostname, int port) {
         /*

--- a/src/java.base/share/classes/sun/security/ssl/ServerHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerHello.java
@@ -560,9 +560,6 @@ final class ServerHello {
 
                 setUpPskKD(shc,
                         shc.resumingSession.consumePreSharedKey());
-
-                // The session can't be resumed again---remove it from cache
-                sessionCache.remove(shc.resumingSession.getSessionId());
             }
 
             // update the responders

--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -101,6 +101,11 @@ public abstract class Cache<K,V> {
     public abstract void remove(Object key);
 
     /**
+     * Pull an entry from the cache.
+     */
+    public abstract V pull(Object key);
+
+    /**
      * Set the maximum size.
      */
     public abstract void setCapacity(int size);
@@ -222,6 +227,10 @@ class NullCache<K,V> extends Cache<K,V> {
 
     public void remove(Object key) {
         // empty
+    }
+
+    public V pull(Object key) {
+        return null;
     }
 
     public void setCapacity(int size) {
@@ -399,6 +408,26 @@ class MemoryCache<K,V> extends Cache<K,V> {
         CacheEntry<K,V> entry = cacheMap.remove(key);
         if (entry != null) {
             entry.invalidate();
+        }
+    }
+
+    public synchronized V pull(Object key) {
+        emptyQueue();
+        CacheEntry<K,V> entry = cacheMap.remove(key);
+        if (entry == null) {
+            return null;
+        }
+
+        long time = (lifetime == 0) ? 0 : System.currentTimeMillis();
+        if (entry.isValid(time)) {
+            V value = entry.getValue();
+            entry.invalidate();
+            return value;
+        } else {
+            if (DEBUG) {
+                System.out.println("Ignoring expired entry");
+            }
+            return null;
         }
     }
 


### PR DESCRIPTION
I would like to backport JDK-8241248 to 13u
The patch applied clean
sun/security/ssl and javax/net/ssl tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8241248](https://bugs.openjdk.java.net/browse/JDK-8241248): NullPointerException in sun.security.ssl.HKDF.extract(HKDF.java:93)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/204.diff">https://git.openjdk.java.net/jdk13u-dev/pull/204.diff</a>

</details>
