### PR TITLE
8244151: Update MUSCLE PC/SC-Lite headers to the latest release 1.8.26

### DIFF
--- a/src/java.smartcardio/unix/legal/pcsclite.md
+++ b/src/java.smartcardio/unix/legal/pcsclite.md
@@ -1,4 +1,4 @@
-## PC/SC Lite v1.8.24
+## PC/SC Lite v1.8.26
 
 ### PC/SC Lite License
 <pre>

--- a/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/pcsclite.h
+++ b/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/pcsclite.h
@@ -279,7 +279,7 @@ extern const SCARD_IO_REQUEST g_rgSCardT0Pci, g_rgSCardT1Pci, g_rgSCardRawPci;
 #define INFINITE                  0xFFFFFFFF      /**< Infinite timeout */
 #endif
 
-#define PCSCLITE_VERSION_NUMBER            "1.8.24"      /**< Current version */
+#define PCSCLITE_VERSION_NUMBER            "1.8.26"      /**< Current version */
 /** Maximum readers context (a slot is count as a reader) */
 #define PCSCLITE_MAX_READERS_CONTEXTS                  16
 


### PR DESCRIPTION
8244151: Update MUSCLE PC/SC-Lite headers to the latest release 1.8.26

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8244151](https://bugs.openjdk.java.net/browse/JDK-8244151): Update MUSCLE PC/SC-Lite headers to the latest release 1.8.26


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/206/head:pull/206` \
`$ git checkout pull/206`

Update a local copy of the PR: \
`$ git checkout pull/206` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 206`

View PR using the GUI difftool: \
`$ git pr show -t 206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/206.diff">https://git.openjdk.java.net/jdk13u-dev/pull/206.diff</a>

</details>
