### PR TITLE
8229243: SunPKCS11-Solaris provider tests failing on Solaris 11.4

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Digest.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Digest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,9 +103,11 @@ final class P11Digest extends MessageDigestSpi implements Cloneable,
             digestLength = 20;
             break;
         case (int)CKM_SHA224:
+        case (int)CKM_SHA512_224:
             digestLength = 28;
             break;
         case (int)CKM_SHA256:
+        case (int)CKM_SHA512_256:
             digestLength = 32;
             break;
         case (int)CKM_SHA384:

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,9 +91,11 @@ final class P11Mac extends MacSpi {
             macLength = 20;
             break;
         case (int)CKM_SHA224_HMAC:
+        case (int)CKM_SHA512_224_HMAC:
             macLength = 28;
             break;
         case (int)CKM_SHA256_HMAC:
+        case (int)CKM_SHA512_256_HMAC:
             macLength = 32;
             break;
         case (int)CKM_SHA384_HMAC:

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -302,29 +302,30 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
      CK_TLS12_KEY_MAT_PARAMS* tlsKmTmp;
 
      if (mechPtr != NULL) {
-         TRACE2("DEBUG: free mech %lX (mech id = 0x%lX)\n",
-                 ptr_to_jlong(mechPtr),  mechPtr->mechanism);
+         TRACE2("DEBUG freeCKMechanismPtr: free pMech %p (mech 0x%lX)\n",
+                 mechPtr,  mechPtr->mechanism);
          if (mechPtr->pParameter != NULL) {
+             tmp = mechPtr->pParameter;
              switch (mechPtr->mechanism) {
                  case CKM_AES_GCM:
-                     tmp = mechPtr->pParameter;
-                     TRACE1("\t=> free GCM_PARAMS %lX\n",
-                             ptr_to_jlong(tmp));
-                     free(((CK_GCM_PARAMS*)tmp)->pIv);
-                     free(((CK_GCM_PARAMS*)tmp)->pAAD);
+                     if (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS_NO_IVBITS)) {
+                         TRACE0("[ GCM_PARAMS w/o ulIvBits ]\n");
+                         free(((CK_GCM_PARAMS_NO_IVBITS*)tmp)->pIv);
+                         free(((CK_GCM_PARAMS_NO_IVBITS*)tmp)->pAAD);
+                     } else if (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS)) {
+                         TRACE0("[ GCM_PARAMS ]\n");
+                         free(((CK_GCM_PARAMS*)tmp)->pIv);
+                         free(((CK_GCM_PARAMS*)tmp)->pAAD);
+                     }
                      break;
                  case CKM_AES_CCM:
-                     tmp = mechPtr->pParameter;
-                     TRACE1("\t=> free CK_CCM_PARAMS %lX\n",
-                             ptr_to_jlong(tmp));
+                     TRACE0("[ CK_CCM_PARAMS ]\n");
                      free(((CK_CCM_PARAMS*)tmp)->pNonce);
                      free(((CK_CCM_PARAMS*)tmp)->pAAD);
                      break;
                  case CKM_TLS_PRF:
                  case CKM_NSS_TLS_PRF_GENERAL:
-                     tmp = mechPtr->pParameter;
-                     TRACE1("\t=> free CK_TLS_PRF_PARAMS %lX\n",
-                         ptr_to_jlong(tmp));
+                     TRACE0("[ CK_TLS_PRF_PARAMS ]\n");
                      free(((CK_TLS_PRF_PARAMS*)tmp)->pSeed);
                      free(((CK_TLS_PRF_PARAMS*)tmp)->pLabel);
                      free(((CK_TLS_PRF_PARAMS*)tmp)->pulOutputLen);
@@ -334,18 +335,16 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
                  case CKM_TLS_MASTER_KEY_DERIVE:
                  case CKM_SSL3_MASTER_KEY_DERIVE_DH:
                  case CKM_TLS_MASTER_KEY_DERIVE_DH:
-                     sslMkdTmp = mechPtr->pParameter;
-                     TRACE1("\t=> free CK_SSL3_MASTER_KEY_DERIVE_PARAMS %lX\n",
-                         ptr_to_jlong(sslMkdTmp));
+                     sslMkdTmp = tmp;
+                     TRACE0("[ CK_SSL3_MASTER_KEY_DERIVE_PARAMS ]\n");
                      free(sslMkdTmp->RandomInfo.pClientRandom);
                      free(sslMkdTmp->RandomInfo.pServerRandom);
                      free(sslMkdTmp->pVersion);
                      break;
                  case CKM_SSL3_KEY_AND_MAC_DERIVE:
                  case CKM_TLS_KEY_AND_MAC_DERIVE:
-                     sslKmTmp = mechPtr->pParameter;
-                     TRACE1("\t=> free CK_SSL3_KEY_MAT_PARAMS %lX\n",
-                         ptr_to_jlong(sslKmTmp));
+                     sslKmTmp = tmp;
+                     TRACE0("[ CK_SSL3_KEY_MAT_PARAMS ]\n");
                      free(sslKmTmp->RandomInfo.pClientRandom);
                      free(sslKmTmp->RandomInfo.pServerRandom);
                      if (sslKmTmp->pReturnedKeyMaterial != NULL) {
@@ -356,17 +355,15 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
                      break;
                  case CKM_TLS12_MASTER_KEY_DERIVE:
                  case CKM_TLS12_MASTER_KEY_DERIVE_DH:
-                     tlsMkdTmp = mechPtr->pParameter;
-                     TRACE1("\t=> CK_TLS12_MASTER_KEY_DERIVE_PARAMS %lX\n",
-                         ptr_to_jlong(tlsMkdTmp));
+                     tlsMkdTmp = tmp;
+                     TRACE0("[ CK_TLS12_MASTER_KEY_DERIVE_PARAMS ]\n");
                      free(tlsMkdTmp->RandomInfo.pClientRandom);
                      free(tlsMkdTmp->RandomInfo.pServerRandom);
                      free(tlsMkdTmp->pVersion);
                      break;
                  case CKM_TLS12_KEY_AND_MAC_DERIVE:
-                     tlsKmTmp = mechPtr->pParameter;
-                     TRACE1("\t=> free CK_TLS12_KEY_MAT_PARAMS %lX\n",
-                         ptr_to_jlong(tlsKmTmp));
+                     tlsKmTmp = tmp;
+                     TRACE0("[ CK_TLS12_KEY_MAT_PARAMS ]\n");
                      free(tlsKmTmp->RandomInfo.pClientRandom);
                      free(tlsKmTmp->RandomInfo.pServerRandom);
                      if (tlsKmTmp->pReturnedKeyMaterial != NULL) {
@@ -377,9 +374,7 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
                      break;
                  case CKM_ECDH1_DERIVE:
                  case CKM_ECDH1_COFACTOR_DERIVE:
-                     tmp = mechPtr->pParameter;
-                     TRACE1("\t=> free CK_ECDH1_DERIVE_PARAMS %lX\n",
-                         ptr_to_jlong(tmp));
+                     TRACE0("[ CK_ECDH1_DERIVE_PARAMS ]\n");
                      free(((CK_ECDH1_DERIVE_PARAMS *)tmp)->pSharedData);
                      free(((CK_ECDH1_DERIVE_PARAMS *)tmp)->pPublicData);
                      break;
@@ -387,7 +382,6 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
                  case CKM_AES_CTR:
                  case CKM_RSA_PKCS_PSS:
                  case CKM_CAMELLIA_CTR:
-                     TRACE0("\t=> NO OP\n");
                      // params do not contain pointers
                      break;
                  default:
@@ -399,15 +393,57 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
                      // CKM_EXTRACT_KEY_FROM_KEY, CKM_OTP, CKM_KIP,
                      // CKM_DSA_PARAMETER_GEN?, CKM_GOSTR3410_*
                      // CK_any_CBC_ENCRYPT_DATA?
-                     TRACE0("\t=> ERROR UNSUPPORTED CK PARAMS\n");
+                     TRACE0("ERROR: UNSUPPORTED CK_MECHANISM\n");
                      break;
              }
-             free(mechPtr->pParameter);
+             TRACE1("\t=> freed param %p\n", tmp);
+             free(tmp);
          } else {
-             TRACE0("DEBUG => Parameter NULL\n");
+             TRACE0("\t=> param NULL\n");
          }
          free(mechPtr);
+         TRACE0("FINISHED\n");
      }
+}
+
+/* This function replaces the CK_GCM_PARAMS_NO_IVBITS structure associated
+ * with the specified CK_MECHANISM structure with CK_GCM_PARAMS
+ * structure.
+ *
+ * @param mechPtr pointer to the CK_MECHANISM structure containing
+ * the to-be-converted CK_GCM_PARAMS_NO_IVBITS structure.
+ * @return pointer to the CK_MECHANISM structure containing the
+ * converted CK_GCM_PARAMS structure or NULL if no conversion took place.
+ */
+CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr) {
+    CK_GCM_PARAMS* pGcmParams2 = NULL;
+    CK_GCM_PARAMS_NO_IVBITS* pParams = NULL;
+    if ((mechPtr->mechanism == CKM_AES_GCM) &&
+            (mechPtr->pParameter != NULL_PTR) &&
+            (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS_NO_IVBITS))) {
+        pGcmParams2 = calloc(1, sizeof(CK_GCM_PARAMS));
+        if (pGcmParams2 == NULL) {
+            throwOutOfMemoryError(env, 0);
+            return NULL;
+        }
+        pParams = (CK_GCM_PARAMS_NO_IVBITS*) mechPtr->pParameter;
+        pGcmParams2->pIv = pParams->pIv;
+        pGcmParams2->ulIvLen = pParams->ulIvLen;
+        pGcmParams2->ulIvBits = (pGcmParams2->ulIvLen << 3);
+        pGcmParams2->pAAD = pParams->pAAD;
+        pGcmParams2->ulAADLen = pParams->ulAADLen;
+        pGcmParams2->ulTagBits = pParams->ulTagBits;
+        TRACE1("DEBUG updateGCMParams: pMech %p\n", mechPtr);
+        TRACE2("\t=> GCM param w/o ulIvBits %p => GCM param %p\n", pParams,
+                pGcmParams2);
+        free(pParams);
+        mechPtr->pParameter = pGcmParams2;
+        mechPtr->ulParameterLen = sizeof(CK_GCM_PARAMS);
+        return mechPtr;
+    } else {
+        TRACE0("DEBUG updateGCMParams: no conversion done\n");
+    }
+    return NULL;
 }
 
 /*

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11gcm2.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11gcm2.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* There is a known incompatibility for CK_GCM_PARAMS structure.
+ * PKCS#11 v2.40 standard mechanisms specification specifies
+ * CK_GCM_PARAMS as
+ *     typedef struct CK_GCM_PARAMS {
+ *         CK_BYTE_PTR       pIv;
+ *         CK_ULONG          ulIvLen;
+ *         CK_BYTE_PTR       pAAD;
+ *         CK_ULONG          ulAADLen;
+ *         CK_ULONG          ulTagBits;
+ *     } CK_GCM_PARAMS;
+ * However, the official header file of PKCS#11 v2.40 defines the
+ * CK_GCM_PARAMS with an extra "ulIvBits" field (type CK_ULONG).
+ * NSS uses the spec version while Solaris and SoftHSM2 use the header
+ * version. In order to work with both sides, SunPKCS11 provider defines
+ * the spec version of CK_GCM_PARAMS as CK_GCM_PARAMS_NO_IVBITS (as in this
+ * file) and uses it first before failing over to the header version.
+ */
+#ifndef _PKCS11GCM2_H_
+#define _PKCS11GCM2_H_ 1
+
+/* include the platform dependent part of the header */
+typedef struct CK_GCM_PARAMS_NO_IVBITS {
+    CK_BYTE_PTR       pIv;
+    CK_ULONG          ulIvLen;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulTagBits;
+} CK_GCM_PARAMS_NO_IVBITS;
+
+typedef CK_GCM_PARAMS_NO_IVBITS CK_PTR CK_GCM_PARAMS_NO_IVBITS_PTR;
+
+#endif /* _PKCS11GCM2_H_ */

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
@@ -1833,6 +1833,7 @@ typedef CK_AES_CTR_PARAMS CK_PTR CK_AES_CTR_PARAMS_PTR;
 typedef struct CK_GCM_PARAMS {
     CK_BYTE_PTR       pIv;
     CK_ULONG          ulIvLen;
+    CK_ULONG          ulIvBits;
     CK_BYTE_PTR       pAAD;
     CK_ULONG          ulAADLen;
     CK_ULONG          ulTagBits;
@@ -1962,7 +1963,7 @@ typedef struct CK_TLS_KDF_PARAMS {
 typedef CK_TLS_KDF_PARAMS CK_PTR CK_TLS_KDF_PARAMS_PTR;
 
 typedef struct CK_TLS_MAC_PARAMS {
-    CK_MECHANISM_TYPE         prfMechanism;
+    CK_MECHANISM_TYPE         prfHashMechanism;
     CK_ULONG                  ulMacLength;
     CK_ULONG                  ulServerOrClient;
 } CK_TLS_MAC_PARAMS;
@@ -1999,4 +2000,5 @@ typedef CK_SEED_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
                                         CK_SEED_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 #endif /* _PKCS11T_H_ */
+
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
@@ -159,7 +159,6 @@
 /* include the platform dependent part of the header */
 #include "p11_md.h"
 
-#include "pkcs11.h"
 #include <jni.h>
 #include <jni_util.h>
 #include <stdarg.h>
@@ -296,6 +295,10 @@ void printDebug(const char *format, ...);
 #define CLASS_TLS_PRF_PARAMS "sun/security/pkcs11/wrapper/CK_TLS_PRF_PARAMS"
 #define CLASS_TLS_MAC_PARAMS "sun/security/pkcs11/wrapper/CK_TLS_MAC_PARAMS"
 
+/* function to update the CK_NSS_GCM_PARAMS in mechanism pointer with
+ * CK_GCM_PARAMS
+ */
+CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr);
 
 /* function to convert a PKCS#11 return value other than CK_OK into a Java Exception
  * or to throw a PKCS11RuntimeException

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.h
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.h
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+
+/*
  * reserved comment block
  * DO NOT REMOVE OR ALTER!
  */
@@ -69,6 +73,7 @@
 #endif
 
 #include "pkcs11.h"
+#include "pkcs11gcm2.h"
 
 #include "jni.h"
 

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.h
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.h
@@ -1,4 +1,8 @@
 /*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+
+/*
  * reserved comment block
  * DO NOT REMOVE OR ALTER!
  */
@@ -77,6 +81,7 @@
 #endif /* CreateMutex */
 
 #include "pkcs11.h"
+#include "pkcs11gcm2.h"
 
 /* statement according to PKCS11 docu */
 #pragma pack(pop, cryptoki)


### PR DESCRIPTION
8229243: SunPKCS11-Solaris provider tests failing on Solaris 11.4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8229243](https://bugs.openjdk.java.net/browse/JDK-8229243): SunPKCS11-Solaris provider tests failing on Solaris 11.4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/214.diff">https://git.openjdk.java.net/jdk13u-dev/pull/214.diff</a>

</details>
