### PR TITLE
8241082: Upgrade IANA Language Subtag Registry data to 03-16-2020 version

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2019-09-16
+File-Date: 2020-03-16
 %%
 Type: language
 Subtag: aa
@@ -47127,6 +47127,16 @@ Added: 2009-09-05
 Prefix: djk
 Comments: Pamaka dialect of the "Busi Nenge Tongo" English-based
   Creole continuum in Eastern Suriname and Western French Guiana
+%%
+Type: variant
+Subtag: peano
+Description: Latino Sine Flexione
+Description: Interlingua de API
+Description: Interlingua de Peano
+Prefix: la
+Comments: Peano’s Interlingua, created in 1903 by Giuseppe Peano as an
+  international auxiliary language
+Added: 2020-03-12
 %%
 Type: variant
 Subtag: petr1708

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,10 +215,7 @@ public class EquivMapsGenerator {
         + "    static final Map<String, String[]> multiEquivsMap;\n"
         + "    static final Map<String, String> regionVariantEquivMap;\n\n"
         + "    static {\n"
-        + "        singleEquivMap = new HashMap<>();\n"
-        + "        multiEquivsMap = new HashMap<>();\n"
-        + "        regionVariantEquivMap = new HashMap<>();\n\n"
-        + "        // This is an auto-generated file and should not be manually edited.\n";
+        + "        singleEquivMap = new HashMap<>(";
 
     private static final String footerText =
         "    }\n\n"
@@ -242,6 +239,12 @@ public class EquivMapsGenerator {
                 Paths.get(fileName))) {
             writer.write(getOpenJDKCopyright());
             writer.write(headerText
+                + (int)(sortedLanguageMap1.size() / 0.75f + 1) + ");\n"
+                + "        multiEquivsMap = new HashMap<>("
+                + (int)(sortedLanguageMap2.size() / 0.75f + 1) + ");\n"
+                + "        regionVariantEquivMap = new HashMap<>("
+                + (int)(sortedRegionVariantMap.size() / 0.75f + 1) + ");\n\n"
+                + "        // This is an auto-generated file and should not be manually edited.\n"
                 + "        //   LSR Revision: " + LSRrevisionDate);
             writer.newLine();
 

--- a/test/jdk/java/util/Locale/Bug8040211.java
+++ b/test/jdk/java/util/Locale/Bug8040211.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8040211 8191404 8203872 8222980 8225435
+ * @bug 8040211 8191404 8203872 8222980 8225435 8241082
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2019-09-16) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2020-03-16) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main Bug8040211
  */


### PR DESCRIPTION
The change should be backported to 13u too, to keep it up to date. Applies cleanly, test do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8241082](https://bugs.openjdk.java.net/browse/JDK-8241082): Upgrade IANA Language Subtag Registry data to 03-16-2020 version


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/217.diff">https://git.openjdk.java.net/jdk13u-dev/pull/217.diff</a>

</details>
