### PR TITLE
8242010: Update IANA Language Subtag Registry to Version 2020-04-01

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2020-03-16
+File-Date: 2020-04-01
 %%
 Type: language
 Subtag: aa
@@ -1530,7 +1530,7 @@ Added: 2005-10-16
 %%
 Type: language
 Subtag: adb
-Description: Adabe
+Description: Atauran
 Added: 2009-07-29
 %%
 Type: language
@@ -2707,6 +2707,7 @@ Type: language
 Subtag: aoh
 Description: Arma
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: aoi
@@ -3770,6 +3771,7 @@ Type: language
 Subtag: ayy
 Description: Tayabas Ayta
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: ayz
@@ -4085,6 +4087,7 @@ Type: language
 Subtag: bbz
 Description: Babalia Creole Arabic
 Added: 2009-07-29
+Deprecated: 2020-03-28
 Macrolanguage: ar
 %%
 Type: language
@@ -5755,6 +5758,7 @@ Type: language
 Subtag: bpb
 Description: Barbacoas
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: bpd
@@ -6011,7 +6015,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: brf
-Description: Bera
+Description: Bira
 Added: 2009-07-29
 %%
 Type: language
@@ -7374,6 +7378,7 @@ Type: language
 Subtag: cca
 Description: Cauca
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: ccc
@@ -7480,6 +7485,7 @@ Type: language
 Subtag: cdg
 Description: Chamari
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: cdh
@@ -7875,6 +7881,11 @@ Description: Cibak
 Added: 2009-07-29
 %%
 Type: language
+Subtag: ckm
+Description: Chakavian
+Added: 2020-03-28
+%%
+Type: language
 Subtag: ckn
 Description: Kaang Chin
 Added: 2013-09-10
@@ -8119,6 +8130,13 @@ Type: language
 Subtag: cno
 Description: Con
 Added: 2009-07-29
+%%
+Type: language
+Subtag: cnp
+Description: Northern Ping Chinese
+Description: Northern Pinghua
+Added: 2020-03-28
+Macrolanguage: zh
 %%
 Type: language
 Subtag: cnr
@@ -8562,6 +8580,13 @@ Subtag: cso
 Description: Sochiapam Chinantec
 Description: Sochiapan Chinantec
 Added: 2009-07-29
+%%
+Type: language
+Subtag: csp
+Description: Southern Ping Chinese
+Description: Southern Pinghua
+Added: 2020-03-28
+Macrolanguage: zh
 %%
 Type: language
 Subtag: csq
@@ -9318,6 +9343,7 @@ Macrolanguage: doi
 Type: language
 Subtag: dgr
 Description: Dogrib
+Description: Tłı̨chǫ
 Added: 2005-10-16
 %%
 Type: language
@@ -9334,6 +9360,7 @@ Type: language
 Subtag: dgu
 Description: Degaru
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: dgw
@@ -9720,6 +9747,11 @@ Description: Dugwor
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dmf
+Description: Medefaidrin
+Added: 2020-03-28
+%%
+Type: language
 Subtag: dmg
 Description: Upper Kinabatangan
 Added: 2009-07-29
@@ -10041,6 +10073,8 @@ Type: language
 Subtag: drr
 Description: Dororo
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Preferred-Value: kzk
 %%
 Type: language
 Subtag: drs
@@ -10330,6 +10364,11 @@ Description: Diri
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dwk
+Description: Dawik Kui
+Added: 2020-03-28
+%%
+Type: language
 Subtag: dwl
 Description: Walo Kumbe Dogon
 Added: 2009-07-29
@@ -10455,6 +10494,11 @@ Description: Karenggapa
 Added: 2013-09-10
 %%
 Type: language
+Subtag: ebc
+Description: Beginci
+Added: 2020-03-28
+%%
+Type: language
 Subtag: ebg
 Description: Ebughu
 Added: 2009-07-29
@@ -10576,6 +10620,7 @@ Type: language
 Subtag: ekc
 Description: Eastern Karnic
 Added: 2013-09-10
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: eke
@@ -11881,6 +11926,7 @@ Added: 2009-07-29
 Type: language
 Subtag: gdh
 Description: Gadjerawang
+Description: Gajirrabeng
 Added: 2009-07-29
 %%
 Type: language
@@ -11968,6 +12014,11 @@ Type: language
 Subtag: ged
 Description: Gade
 Added: 2009-07-29
+%%
+Type: language
+Subtag: gef
+Description: Gerai
+Added: 2020-03-28
 %%
 Type: language
 Subtag: geg
@@ -12381,6 +12432,8 @@ Type: language
 Subtag: gli
 Description: Guliguli
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Preferred-Value: kzk
 %%
 Type: language
 Subtag: glj
@@ -12479,6 +12532,12 @@ Type: language
 Subtag: gmu
 Description: Gumalu
 Added: 2009-07-29
+%%
+Type: language
+Subtag: gmr
+Description: Mirning
+Description: Mirniny
+Added: 2020-03-28
 %%
 Type: language
 Subtag: gmv
@@ -13155,6 +13214,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: gwc
+Description: Gawri
 Description: Kalami
 Added: 2009-07-29
 %%
@@ -13859,6 +13919,11 @@ Description: Chhattisgarhi
 Added: 2009-07-29
 %%
 Type: language
+Subtag: hng
+Description: Hungu
+Added: 2020-03-28
+%%
+Type: language
 Subtag: hnh
 Description: ǁAni
 Added: 2009-07-29
@@ -14140,6 +14205,7 @@ Added: 2009-07-29
 Type: language
 Subtag: huc
 Description: ǂHua
+Description: ǂʼAmkhoe
 Added: 2009-07-29
 %%
 Type: language
@@ -15910,6 +15976,7 @@ Added: 2009-07-29
 Type: language
 Subtag: kaa
 Description: Kara-Kalpak
+Description: Karakalpak
 Added: 2005-10-16
 %%
 Type: language
@@ -17067,8 +17134,9 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kjf
-Description: Khalaj
+Description: Khalaj [Indo-Iranian]
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: kjg
@@ -17248,7 +17316,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kkq
-Description: Kaiku
+Description: Kaeku
 Added: 2009-07-29
 %%
 Type: language
@@ -17344,7 +17412,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: klj
-Description: Turkic Khalaj
+Description: Khalaj
 Added: 2009-07-29
 %%
 Type: language
@@ -18497,6 +18565,7 @@ Added: 2009-07-29
 Type: language
 Subtag: kui
 Description: Kuikúro-Kalapálo
+Description: Kalapalo
 Added: 2009-07-29
 %%
 Type: language
@@ -18908,6 +18977,8 @@ Type: language
 Subtag: kxl
 Description: Nepali Kurux
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Preferred-Value: kru
 %%
 Type: language
 Subtag: kxm
@@ -18953,6 +19024,8 @@ Type: language
 Subtag: kxu
 Description: Kui (India)
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Comments: see dwk, uki
 %%
 Type: language
 Subtag: kxv
@@ -20337,6 +20410,7 @@ Type: language
 Subtag: lmz
 Description: Lumbee
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: lna
@@ -22788,6 +22862,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: moe
+Description: Innu
 Description: Montagnais
 Added: 2009-07-29
 %%
@@ -26199,6 +26274,11 @@ Description: Sangtam Naga
 Added: 2009-07-29
 %%
 Type: language
+Subtag: nsb
+Description: Lower Nossob
+Added: 2020-03-28
+%%
+Type: language
 Subtag: nsc
 Description: Nshi
 Added: 2009-07-29
@@ -26667,6 +26747,8 @@ Type: language
 Subtag: nxu
 Description: Narau
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Preferred-Value: bpp
 %%
 Type: language
 Subtag: nxx
@@ -28166,7 +28248,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: pfe
-Description: Peere
+Description: Pere
 Added: 2009-07-29
 %%
 Type: language
@@ -28572,6 +28654,7 @@ Type: language
 Subtag: plp
 Description: Palpa
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: plq
@@ -31132,6 +31215,8 @@ Type: language
 Subtag: sdm
 Description: Semandang
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Comments: see ebc, gef, sdq
 %%
 Type: language
 Subtag: sdn
@@ -31148,6 +31233,11 @@ Type: language
 Subtag: sdp
 Description: Sherdukpen
 Added: 2009-07-29
+%%
+Type: language
+Subtag: sdq
+Description: Semandang
+Added: 2020-03-28
 %%
 Type: language
 Subtag: sdr
@@ -33502,6 +33592,7 @@ Type: language
 Subtag: tbb
 Description: Tapeba
 Added: 2009-07-29
+Deprecated: 2020-03-28
 %%
 Type: language
 Subtag: tbc
@@ -36240,6 +36331,11 @@ Description: Ukhwejo
 Added: 2009-07-29
 %%
 Type: language
+Subtag: uki
+Description: Kui (India)
+Added: 2020-03-28
+%%
+Type: language
 Subtag: ukk
 Description: Muak Sa-aak
 Added: 2017-02-23
@@ -36269,6 +36365,11 @@ Type: language
 Subtag: uku
 Description: Ukue
 Added: 2009-07-29
+%%
+Type: language
+Subtag: ukv
+Description: Kuku
+Added: 2020-03-28
 %%
 Type: language
 Subtag: ukw
@@ -37760,6 +37861,11 @@ Description: Kunbarlang
 Added: 2009-07-29
 %%
 Type: language
+Subtag: wlh
+Description: Welaun
+Added: 2020-03-28
+%%
+Type: language
 Subtag: wli
 Description: Waioli
 Added: 2009-07-29
@@ -39232,6 +39338,11 @@ Description: Nganakarti
 Added: 2013-09-10
 %%
 Type: language
+Subtag: xnm
+Description: Ngumbarl
+Added: 2020-03-28
+%%
+Type: language
 Subtag: xnn
 Description: Northern Kankanay
 Added: 2009-07-29
@@ -39334,9 +39445,20 @@ Description: Pirriya
 Added: 2013-09-10
 %%
 Type: language
+Subtag: xpb
+Description: Northeastern Tasmanian
+Description: Pyemmairrener
+Added: 2020-03-28
+%%
+Type: language
 Subtag: xpc
 Description: Pecheneg
 Added: 2009-07-29
+%%
+Type: language
+Subtag: xpd
+Description: Oyster Bay Tasmanian
+Added: 2020-03-28
 %%
 Type: language
 Subtag: xpe
@@ -39345,9 +39467,21 @@ Added: 2009-07-29
 Macrolanguage: kpe
 %%
 Type: language
+Subtag: xpf
+Description: Southeast Tasmanian
+Description: Nuenonne
+Added: 2020-03-28
+%%
+Type: language
 Subtag: xpg
 Description: Phrygian
 Added: 2009-07-29
+%%
+Type: language
+Subtag: xph
+Description: North Midlands Tasmanian
+Description: Tyerrenoterpanner
+Added: 2020-03-28
 %%
 Type: language
 Subtag: xpi
@@ -39363,6 +39497,11 @@ Type: language
 Subtag: xpk
 Description: Kulina Pano
 Added: 2009-07-29
+%%
+Type: language
+Subtag: xpl
+Description: Port Sorell Tasmanian
+Added: 2020-03-28
 %%
 Type: language
 Subtag: xpm
@@ -39410,9 +39549,32 @@ Description: Punic
 Added: 2009-07-29
 %%
 Type: language
+Subtag: xpv
+Description: Northern Tasmanian
+Description: Tommeginne
+Added: 2020-03-28
+%%
+Type: language
+Subtag: xpw
+Description: Northwestern Tasmanian
+Description: Peerapper
+Added: 2020-03-28
+%%
+Type: language
+Subtag: xpx
+Description: Southwestern Tasmanian
+Description: Toogee
+Added: 2020-03-28
+%%
+Type: language
 Subtag: xpy
 Description: Puyo
 Added: 2009-07-29
+%%
+Type: language
+Subtag: xpz
+Description: Bruny Island Tasmanian
+Added: 2020-03-28
 %%
 Type: language
 Subtag: xqa
@@ -39468,6 +39630,8 @@ Type: language
 Subtag: xrq
 Description: Karranga
 Added: 2013-09-10
+Deprecated: 2020-03-28
+Preferred-Value: dmw
 %%
 Type: language
 Subtag: xrr
@@ -39700,6 +39864,8 @@ Type: language
 Subtag: xtz
 Description: Tasmanian
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Comments: see xpb, xpd, xpf, xph, xpl, xpv, xpw, xpx, xpz
 %%
 Type: language
 Subtag: xua
@@ -39729,6 +39895,7 @@ Added: 2009-07-29
 Type: language
 Subtag: xul
 Description: Ngunawal
+Description: Nunukul
 Added: 2013-09-10
 %%
 Type: language
@@ -41321,6 +41488,11 @@ Description: Zari
 Added: 2009-07-29
 %%
 Type: language
+Subtag: zba
+Description: Balaibalan
+Added: 2020-03-28
+%%
+Type: language
 Subtag: zbc
 Description: Central Berawan
 Added: 2009-07-29
@@ -41486,6 +41658,8 @@ Type: language
 Subtag: zir
 Description: Ziriya
 Added: 2009-07-29
+Deprecated: 2020-03-28
+Preferred-Value: scv
 %%
 Type: language
 Subtag: ziw
@@ -42463,6 +42637,7 @@ Type: extlang
 Subtag: bbz
 Description: Babalia Creole Arabic
 Added: 2009-07-29
+Deprecated: 2020-03-28
 Preferred-Value: bbz
 Prefix: ar
 Macrolanguage: ar
@@ -42580,6 +42755,15 @@ Prefix: zh
 Macrolanguage: zh
 %%
 Type: extlang
+Subtag: cnp
+Description: Northern Ping Chinese
+Description: Northern Pinghua
+Added: 2020-03-28
+Preferred-Value: cnp
+Prefix: zh
+Macrolanguage: zh
+%%
+Type: extlang
 Subtag: coa
 Description: Cocos Islands Malay
 Added: 2009-07-29
@@ -42645,6 +42829,15 @@ Description: Colombian Sign Language
 Added: 2009-07-29
 Preferred-Value: csn
 Prefix: sgn
+%%
+Type: extlang
+Subtag: csp
+Description: Southern Ping Chinese
+Description: Southern Pinghua
+Added: 2020-03-28
+Preferred-Value: csp
+Prefix: zh
+Macrolanguage: zh
 %%
 Type: extlang
 Subtag: csq
@@ -46630,6 +46823,12 @@ Comments: Denotes conventions established by the Academia Brasileira de
   Letras in 1943 and generally used in Brazil until 2009
 %%
 Type: variant
+Subtag: akuapem
+Description: Akuapem Twi
+Added: 2017-06-05
+Prefix: tw
+%%
+Type: variant
 Subtag: alalc97
 Description: ALA-LC Romanization, 1997 edition
 Added: 2009-12-09
@@ -46646,12 +46845,6 @@ Added: 2009-09-05
 Prefix: djk
 Comments: Aluku dialect of the "Busi Nenge Tongo" English-based Creole
   continuum in Eastern Suriname and Western French Guiana
-%%
-Type: variant
-Subtag: akuapem
-Description: Akuapem Twi
-Added: 2017-06-05
-Prefix: tw
 %%
 Type: variant
 Subtag: ao1990

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -33,10 +33,12 @@ import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * This tool reads the IANA Language Subtag Registry data file downloaded from
@@ -75,32 +77,49 @@ public class EquivMapsGenerator {
         String type = null;
         String tag = null;
         String preferred = null;
+        String prefix = null;
 
         for (String line : Files.readAllLines(Paths.get(filename),
                                               Charset.forName("UTF-8"))) {
             line = line.toLowerCase(Locale.ROOT);
-            int index = line.indexOf(' ')+1;
+            int index = line.indexOf(' ') + 1;
             if (line.startsWith("file-date:")) {
                 LSRrevisionDate = line.substring(index);
             } else if (line.startsWith("type:")) {
                 type = line.substring(index);
             } else if (line.startsWith("tag:") || line.startsWith("subtag:")) {
                 tag = line.substring(index);
-            } else if (line.startsWith("preferred-value:")
-                       && !type.equals("extlang")) {
+            } else if (line.startsWith("preferred-value:")) {
                 preferred = line.substring(index);
-                processDeprecatedData(type, tag, preferred);
+            } else if (line.startsWith("prefix:")) {
+                prefix = line.substring(index);
             } else if (line.equals("%%")) {
+                processDeprecatedData(type, tag, preferred, prefix);
                 type = null;
                 tag = null;
+                preferred = null;
+                prefix = null;
             }
         }
+
+        // Last entry
+        processDeprecatedData(type, tag, preferred, prefix);
     }
 
     private static void processDeprecatedData(String type,
                                               String tag,
-                                              String preferred) {
+                                              String preferred,
+                                              String prefix) {
         StringBuilder sb;
+
+        if (type == null || tag == null || preferred == null) {
+            return;
+        }
+
+        if (type.equals("extlang") && prefix != null) {
+            tag = prefix + "-" + tag;
+        }
+
         if (type.equals("region") || type.equals("variant")) {
             if (!initialRegionVariantMap.containsKey(preferred)) {
                 sb = new StringBuilder("-");
@@ -113,7 +132,7 @@ public class EquivMapsGenerator {
                     + " A region/variant subtag \"" + preferred
                     + "\" is registered for more than one subtags.");
             }
-        } else { // language, grandfahered, and redundant
+        } else { // language, extlang, grandfathered, and redundant
             if (!initialLanguageMap.containsKey(preferred)) {
                 sb = new StringBuilder(preferred);
                 sb.append(',');
@@ -131,7 +150,12 @@ public class EquivMapsGenerator {
     private static void generateEquivalentMap() {
         String[] subtags;
         for (String preferred : initialLanguageMap.keySet()) {
-            subtags = initialLanguageMap.get(preferred).toString().split(",");
+            // There are cases where the same tag may appear in two entries, e.g.,
+            // "yue" is defined both as extlang and redundant. Remove the dup.
+            subtags = Arrays.stream(initialLanguageMap.get(preferred).toString().split(","))
+                    .distinct()
+                    .collect(Collectors.toList())
+                    .toArray(new String[0]);
 
             if (subtags.length == 2) {
                 sortedLanguageMap1.put(subtags[0], subtags[1]);

--- a/test/jdk/java/util/Locale/Bug7069824.java
+++ b/test/jdk/java/util/Locale/Bug7069824.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7069824 8042360 8032842 8175539 8210443
+ * @bug 7069824 8042360 8032842 8175539 8210443 8242010
  * @summary Verify implementation for Locale matching.
  * @run testng/othervm Bug7069824
  */
@@ -118,9 +118,10 @@ public class Bug7069824 {
                                 new LanguageRange("hak-CN", 0.8),
                                 new LanguageRange("zh-hakka-CN", 0.8),
                                 new LanguageRange("i-hak-CN", 0.8),
+                                new LanguageRange("zh-hak-CN", 0.8),
                                 new LanguageRange("cmn-CN", 0.1),
-                                new LanguageRange("zh-cmn-CN", 0.1),
-                                new LanguageRange("zh-guoyu-CN", 0.1))},
+                                new LanguageRange("zh-guoyu-CN", 0.1),
+                                new LanguageRange("zh-cmn-CN", 0.1))},
                 {"Accept-Language: rki;q=0.4, no-bok-NO;q=0.9, ccq;q=0.5",
                         List.of(new LanguageRange("no-bok-no", 0.9),
                                 new LanguageRange("nb-no", 0.9),

--- a/test/jdk/java/util/Locale/Bug8040211.java
+++ b/test/jdk/java/util/Locale/Bug8040211.java
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8040211 8191404 8203872 8222980 8225435 8241082
+ * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2020-03-16) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2020-04-01) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main Bug8040211
  */
@@ -43,9 +43,9 @@ public class Bug8040211 {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aog, aue, bcg, cey, cqu, dif, ema,"
-        + " en-gb-oed, gti, kdz, koj, kwq, kxe, lii, lmm, lsn, lsv, lvi, mtm,"
-        + " ngv, nns, oyb, phr, pnd, pub, snz, suj, szy,taj, tjj, tjp, tvx,"
+        "Accept-Language: aam, adp, aog, aue, bcg, bpp, cey, cnp, cqu, csp, dif, dmw, ema,"
+        + " en-gb-oed, gti, kdz, koj, kru, kwq, kxe, kzk, lii, lmm, lsn, lsv, lvi, mtm,"
+        + " ngv, nns, oyb, phr, pnd, pub, scv, snz, suj, szy, taj, tjj, tjp, tvx,"
         + " uss, uth, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
     private static final List<LanguageRange> EXPECTED_RANGE_LIST = List.of(
             new LanguageRange("aam", 1.0),
@@ -58,11 +58,19 @@ public class Bug8040211 {
             new LanguageRange("ktz", 1.0),
             new LanguageRange("bcg", 1.0),
             new LanguageRange("bgm", 1.0),
+            new LanguageRange("bpp", 1.0),
+            new LanguageRange("nxu", 1.0),
             new LanguageRange("cey", 1.0),
+            new LanguageRange("cnp", 1.0),
+            new LanguageRange("zh-cnp", 1.0),
             new LanguageRange("cqu", 1.0),
             new LanguageRange("quh", 1.0),
+            new LanguageRange("csp", 1.0),
+            new LanguageRange("zh-csp", 1.0),
             new LanguageRange("dif", 1.0),
             new LanguageRange("dit", 1.0),
+            new LanguageRange("dmw", 1.0),
+            new LanguageRange("xrq", 1.0),
             new LanguageRange("ema", 1.0),
             new LanguageRange("uok", 1.0),
             new LanguageRange("en-gb-oed", 1.0),
@@ -73,16 +81,23 @@ public class Bug8040211 {
             new LanguageRange("ncp", 1.0),
             new LanguageRange("koj", 1.0),
             new LanguageRange("kwv", 1.0),
+            new LanguageRange("kru", 1.0),
+            new LanguageRange("kxl", 1.0),
             new LanguageRange("kwq", 1.0),
             new LanguageRange("yam", 1.0),
             new LanguageRange("kxe", 1.0),
             new LanguageRange("tvd", 1.0),
+            new LanguageRange("kzk", 1.0),
+            new LanguageRange("gli", 1.0),
+            new LanguageRange("drr", 1.0),
             new LanguageRange("lii", 1.0),
             new LanguageRange("raq", 1.0),
             new LanguageRange("lmm", 1.0),
             new LanguageRange("rmx", 1.0),
             new LanguageRange("lsn", 1.0),
+            new LanguageRange("sgn-lsn", 1.0),
             new LanguageRange("lsv", 1.0),
+            new LanguageRange("sgn-lsv", 1.0),
             new LanguageRange("lvi", 1.0),
             new LanguageRange("mtm", 1.0),
             new LanguageRange("ymt", 1.0),
@@ -99,6 +114,8 @@ public class Bug8040211 {
             new LanguageRange("pnd", 1.0),
             new LanguageRange("pub", 1.0),
             new LanguageRange("puz", 1.0),
+            new LanguageRange("scv", 1.0),
+            new LanguageRange("zir", 1.0),
             new LanguageRange("snz", 1.0),
             new LanguageRange("asd", 1.0),
             new LanguageRange("suj", 1.0),

--- a/test/jdk/java/util/Locale/LSRDataTest.java
+++ b/test/jdk/java/util/Locale/LSRDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8204938
+ * @bug 8204938 8242010
  * @summary Checks the IANA language subtag registry data update
  *          with Locale.LanguageRange parse method.
  * @run main LSRDataTest
@@ -100,7 +100,8 @@ public class LSRDataTest {
     private static void loadLSRData(Path path) throws IOException {
         String type = null;
         String tag = null;
-        String preferred;
+        String preferred = null;
+        String prefix = null;
 
         for (String line : Files.readAllLines(path, Charset.forName("UTF-8"))) {
             line = line.toLowerCase(Locale.ROOT);
@@ -109,20 +110,36 @@ public class LSRDataTest {
                 type = line.substring(index);
             } else if (line.startsWith("tag:") || line.startsWith("subtag:")) {
                 tag = line.substring(index);
-            } else if (line.startsWith("preferred-value:") && !type.equals("extlang")) {
+            } else if (line.startsWith("preferred-value:")) {
                 preferred = line.substring(index);
-                processDataAndGenerateMaps(type, tag, preferred);
+            } else if (line.startsWith("prefix:")) {
+                prefix = line.substring(index);
             } else if (line.equals("%%")) {
+                processDataAndGenerateMaps(type, tag, preferred, prefix);
                 type = null;
                 tag = null;
+                preferred = null;
+                prefix = null;
             }
         }
+
+        // Last entry
+        processDataAndGenerateMaps(type, tag, preferred, prefix);
     }
 
     private static void processDataAndGenerateMaps(String type,
             String tag,
-            String preferred) {
-        StringBuilder sb;
+            String preferred,
+            String prefix) {
+
+        if (type == null || tag == null || preferred == null) {
+            return;
+        }
+
+        if (type.equals("extlang") && prefix != null) {
+            tag = prefix + "-" + tag;
+        }
+
         if (type.equals("region") || type.equals("variant")) {
             if (!regionVariantEquivMap.containsKey(preferred)) {
                 String tPref = HYPHEN + preferred;
@@ -134,7 +151,7 @@ public class LSRDataTest {
                         + " A region/variant subtag \"" + preferred
                         + "\" is registered for more than one subtags.");
             }
-        } else { // language, grandfathered, and redundant
+        } else { // language, extlang, grandfathered, and redundant
             if (!singleLangEquivMap.containsKey(preferred)
                     && !multiLangEquivsMap.containsKey(preferred)) {
                 // new entry add it into single equiv map


### PR DESCRIPTION
should be backported for consistency. Applies cleanly; tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8242010](https://bugs.openjdk.java.net/browse/JDK-8242010): Update IANA Language Subtag Registry to Version 2020-04-01


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/218.diff">https://git.openjdk.java.net/jdk13u-dev/pull/218.diff</a>

</details>
