### PR TITLE
8247432: Update IANA Language Subtag Registry to Version 2020-09-29

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2020-04-01
+File-Date: 2020-09-29
 %%
 Type: language
 Subtag: aa
@@ -11260,6 +11260,11 @@ Description: Fyer
 Added: 2009-07-29
 %%
 Type: language
+Subtag: fif
+Description: Faifi
+Added: 2020-06-08
+%%
+Type: language
 Subtag: fil
 Description: Filipino
 Description: Pilipino
@@ -12529,15 +12534,15 @@ Added: 2009-07-29
 Scope: collection
 %%
 Type: language
-Subtag: gmu
-Description: Gumalu
-Added: 2009-07-29
-%%
-Type: language
 Subtag: gmr
 Description: Mirning
 Description: Mirniny
 Added: 2020-03-28
+%%
+Type: language
+Subtag: gmu
+Description: Gumalu
+Added: 2009-07-29
 %%
 Type: language
 Subtag: gmv
@@ -34310,6 +34315,8 @@ Type: language
 Subtag: thw
 Description: Thudam
 Added: 2009-07-29
+Deprecated: 2020-06-08
+Preferred-Value: ola
 %%
 Type: language
 Subtag: thx
@@ -45121,6 +45128,11 @@ Description: Tirhuta
 Added: 2011-08-16
 %%
 Type: script
+Subtag: Toto
+Description: Toto
+Added: 2020-05-12
+%%
+Type: script
 Subtag: Ugar
 Description: Ugaritic
 Added: 2005-10-16
@@ -47469,6 +47481,23 @@ Comments: The subtag represents Branislau Taraskievic's Belarusian
   Miensk 2005).
 %%
 Type: variant
+Subtag: tongyong
+Description: Tongyong Pinyin romanization
+Added: 2020-06-08
+Prefix: zh-Latn
+Comments: Former official transcription standard for Mandarin Chinese in
+  Taiwan.
+%%
+Type: variant
+Subtag: tunumiit
+Description: Tunumiisiut
+Description: East Greenlandic
+Description: Østgrønlandsk
+Added: 2020-07-16
+Prefix: kl
+Comments: Also known as Tunumiit oraasiat
+%%
+Type: variant
 Subtag: uccor
 Description: Unified Cornish orthography of Revived Cornish
 Added: 2008-10-14
@@ -47519,6 +47548,14 @@ Added: 2010-06-29
 Prefix: rm
 Comments: Vallader is one of the five traditional written standards or
   "idioms" of the Romansh language.
+%%
+Type: variant
+Subtag: vecdruka
+Description: Latvian orthography used before 1920s ("vecā druka")
+Added: 2020-09-26
+Prefix: lv
+Comments: The subtag represents the old orthography of the Latvian
+  language used during c. 1600s–1920s.
 %%
 Type: variant
 Subtag: vivaraup

--- a/test/jdk/java/util/Locale/Bug8040211.java
+++ b/test/jdk/java/util/Locale/Bug8040211.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010
+ * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  * @summary Checks the IANA language subtag registry data update
  *          (LSR Revision: 2020-04-01) with Locale and Locale.LanguageRange
  *          class methods.
@@ -45,7 +45,7 @@ public class Bug8040211 {
     private static final String ACCEPT_LANGUAGE =
         "Accept-Language: aam, adp, aog, aue, bcg, bpp, cey, cnp, cqu, csp, dif, dmw, ema,"
         + " en-gb-oed, gti, kdz, koj, kru, kwq, kxe, kzk, lii, lmm, lsn, lsv, lvi, mtm,"
-        + " ngv, nns, oyb, phr, pnd, pub, scv, snz, suj, szy, taj, tjj, tjp, tvx,"
+        + " ngv, nns, ola, oyb, phr, pnd, pub, scv, snz, suj, szy, taj, tjj, tjp, tvx,"
         + " uss, uth, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
     private static final List<LanguageRange> EXPECTED_RANGE_LIST = List.of(
             new LanguageRange("aam", 1.0),
@@ -105,6 +105,8 @@ public class Bug8040211 {
             new LanguageRange("nnx", 1.0),
             new LanguageRange("nns", 1.0),
             new LanguageRange("nbr", 1.0),
+            new LanguageRange("ola", 1.0),
+            new LanguageRange("thw", 1.0),
             new LanguageRange("oyb", 1.0),
             new LanguageRange("thx", 1.0),
             new LanguageRange("skk", 1.0),


### PR DESCRIPTION
should be ported here, too, after 8241082 and 8242010. Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8247432](https://bugs.openjdk.java.net/browse/JDK-8247432): Update IANA Language Subtag Registry to Version 2020-09-29


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/219/head:pull/219` \
`$ git checkout pull/219`

Update a local copy of the PR: \
`$ git checkout pull/219` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 219`

View PR using the GUI difftool: \
`$ git pr show -t 219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/219.diff">https://git.openjdk.java.net/jdk13u-dev/pull/219.diff</a>

</details>
