### PR TITLE
8243452: JFR: Could not create chunk in repository with over 200 recordings

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -84,7 +84,7 @@ public final class Repository {
             }
             return new RepositoryChunk(repository, timestamp);
         } catch (Exception e) {
-            String errorMsg = String.format("Could not create chunk in repository %s, %s", repository, e.getMessage());
+            String errorMsg = String.format("Could not create chunk in repository %s, %s: %s", repository, e.getClass(), e.getMessage());
             Logger.log(LogTag.JFR, LogLevel.ERROR, errorMsg);
             jvm.abort(errorMsg);
             throw new InternalError("Could not abort after JFR disk creation error");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -80,7 +80,7 @@ final class RepositoryChunk {
             p = directory.toPath().resolve(extendedName);
         }
         p = directory.toPath().resolve(name + "_" + System.currentTimeMillis() + extension);
-        return SecuritySupport.toRealPath(new SafePath(p));
+        return new SafePath(p);
     }
 
     public SafePath getUnfishedFile() {


### PR DESCRIPTION
I'd like to backport JDK-8243452 to 13u for parity with 11u.
The patch doesn't apply cleanly due to context difference in jdk/jfr/internal/RepositoryChunk.java (JDK-8244463 is not in 13u), reapplied manually.
Tested with tier1 and jdk/jfr tests; the test attached to the issue fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8243452](https://bugs.openjdk.java.net/browse/JDK-8243452): JFR: Could not create chunk in repository with over 200 recordings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/221.diff">https://git.openjdk.java.net/jdk13u-dev/pull/221.diff</a>

</details>
