### PR TITLE
8225773: jdeps --check produces NPE if there is any missing module dependence

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -986,7 +986,7 @@ class JdepsTask {
                 throw new UncheckedBadArgs(new BadArgs("err.invalid.options",
                                                        list, "--check"));
             }
-            return new ModuleAnalyzer(config, log, modules).run();
+            return new ModuleAnalyzer(config, log, modules).run(options.ignoreMissingDeps);
         }
 
         /*

--- a/test/langtools/tools/jdeps/missingDeps/MissingDepsTest.java
+++ b/test/langtools/tools/jdeps/missingDeps/MissingDepsTest.java
@@ -84,6 +84,14 @@ public class MissingDepsTest {
     }
 
     @Test
+    public void checkModuleDeps() {
+        JdepsTest test = new JdepsTest();
+        test.options(List.of("--module-path", "m1.jar", "--multi-release", VERSION, "--check", "m1"));
+        test.checkMissingDeps();
+        test.ignoreMissingDeps("requires java.management");
+    }
+
+    @Test
     public void genModuleInfo() {
         JdepsTest test = new JdepsTest();
         test.options(List.of("--generate-module-info", ".", "--multi-release", VERSION, "mr.jar"));

--- a/test/langtools/tools/jdeps/modules/CheckModuleTest.java
+++ b/test/langtools/tools/jdeps/modules/CheckModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class CheckModuleTest {
             jdeps.appModulePath(MODS_DIR.toString());
 
             ModuleAnalyzer analyzer = jdeps.getModuleAnalyzer(Set.of(name));
-            assertTrue(analyzer.run());
+            assertTrue(analyzer.run(false));
             jdeps.dumpOutput(System.err);
 
             ModuleDescriptor[] descriptors = analyzer.descriptors(name);
@@ -146,7 +146,7 @@ public class CheckModuleTest {
             jdeps.appModulePath(MODS_DIR.toString());
 
             ModuleAnalyzer analyzer = jdeps.getModuleAnalyzer(Set.of(name));
-            assertTrue(analyzer.run());
+            assertTrue(analyzer.run(false));
             jdeps.dumpOutput(System.err);
 
             // compare the module descriptors and the suggested versions


### PR DESCRIPTION
should backport this very useful change to 13u, too. All jdeps tests pass OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8225773](https://bugs.openjdk.java.net/browse/JDK-8225773): jdeps --check produces NPE if there is any missing module dependence


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/224.diff">https://git.openjdk.java.net/jdk13u-dev/pull/224.diff</a>

</details>
