### PR TITLE
8267235: [macos_aarch64] InterpreterRuntime::throw_pending_exception messing up LR results in crash

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -697,6 +697,11 @@ void MacroAssembler::call_VM_base(Register oop_result,
   // do the call, remove parameters
   MacroAssembler::call_VM_leaf_base(entry_point, number_of_arguments, &l);
 
+  // lr could be poisoned with PAC signature during throw_pending_exception
+  // if it was tail-call optimized by compiler, since lr is not callee-saved
+  // reload it with proper value
+  adr(lr, l);
+
   // reset last Java frame
   // Only interpreter should have to clear fp
   reset_last_Java_frame(true);


### PR DESCRIPTION
This issue affects all aarch64 platforms, but to make java crash the platform need to pac-sign LR register, on the rest of aarch64 platform it effectively NO-OP
Applies clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267235](https://bugs.openjdk.java.net/browse/JDK-8267235): [macos_aarch64] InterpreterRuntime::throw_pending_exception messing up LR results in crash


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/226.diff">https://git.openjdk.java.net/jdk13u-dev/pull/226.diff</a>

</details>
