### PR TITLE
8235368: Update BCEL to Version 6.4.1

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/Const.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/Const.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,8 +25,8 @@ import java.util.Collections;
 /**
  * Constants for the project, mostly defined in the JVM specification.
  *
- * @version $Id$
  * @since 6.0 (intended to replace the Constants interface)
+ * @LastModified: Jan 2020
  */
 public final class Const {
 
@@ -180,6 +180,18 @@ public final class Const {
    *  */
   public static final short MINOR_13 = 0;
 
+  /** Major version number of class files for Java 14.
+   *  @see #MINOR_14
+   *  @since 6.4.0
+   *  */
+  public static final short MAJOR_14 = 58;
+
+  /** Minor version number of class files for Java 14.
+   *  @see #MAJOR_14
+   *  @since 6.4.0
+   *  */
+  public static final short MINOR_14 = 0;
+
   /** Default major version number.  Class file is for Java 1.1.
    *  @see #MAJOR_1_1
    *  */
@@ -199,12 +211,14 @@ public final class Const {
   public static final int MAX_BYTE  = 255; // 2^8 - 1
 
   /** One of the access flags for fields, methods, or classes.
-   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.5'>
-   *  Flag definitions for Fields in the Java Virtual Machine Specification (Java SE 8 Edition).</a>
-   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.6'>
-   *  Flag definitions for Methods in the Java Virtual Machine Specification (Java SE 8 Edition).</a>
-   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.6-300-D.1-D.1'>
-   *  Flag definitions for Classes in the Java Virtual Machine Specification (Java SE 8 Edition).</a>
+   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.1-200-E.1'>
+   *  Flag definitions for Classes in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
+   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.5'>
+   *  Flag definitions for Fields in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
+   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.6'>
+   *  Flag definitions for Methods in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
+   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.6-300-D.1-D.1'>
+   *  Flag definitions for Inner Classes in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
    */
   public static final short ACC_PUBLIC       = 0x0001;
 
@@ -228,89 +242,123 @@ public final class Const {
    */
   public static final short ACC_FINAL        = 0x0010;
 
-  /** One of the access flags for fields, methods, or classes.
+  /** One of the access flags for the Module attribute.
    *  @see #ACC_PUBLIC
    */
-  public static final short ACC_SYNCHRONIZED = 0x0020;
+  public static final short ACC_OPEN         = 0x0020;
 
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_VOLATILE     = 0x0040;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_BRIDGE       = 0x0040;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_TRANSIENT    = 0x0080;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_VARARGS      = 0x0080;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_NATIVE       = 0x0100;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_INTERFACE    = 0x0200;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_ABSTRACT     = 0x0400;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_STRICT       = 0x0800;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_SYNTHETIC    = 0x1000;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_ANNOTATION   = 0x2000;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_ENUM         = 0x4000;
-
-  /** One of the access flags for fields, methods, or classes.
-   *  @see #ACC_PUBLIC
-   */
-  public static final short ACC_MANDATED     = (short) 0x8000;
-
-  // Applies to classes compiled by new compilers only
-  /** One of the access flags for fields, methods, or classes.
+  /** One of the access flags for classes.
    *  @see #ACC_PUBLIC
    */
   public static final short ACC_SUPER        = 0x0020;
 
-  /** One of the access flags for fields, methods, or classes.
+  /** One of the access flags for methods.
    *  @see #ACC_PUBLIC
    */
+  public static final short ACC_SYNCHRONIZED = 0x0020;
+
+  /** One of the access flags for the Module attribute.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_TRANSITIVE   = 0x0020;
+
+  /** One of the access flags for methods.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_BRIDGE       = 0x0040;
+
+  /** One of the access flags for the Module attribute.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_STATIC_PHASE = 0x0040;
+
+  /** One of the access flags for fields.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_VOLATILE     = 0x0040;
+
+  /** One of the access flags for fields.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_TRANSIENT    = 0x0080;
+
+  /** One of the access flags for methods.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_VARARGS      = 0x0080;
+
+  /** One of the access flags for methods.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_NATIVE       = 0x0100;
+
+  /** One of the access flags for classes.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_INTERFACE    = 0x0200;
+
+  /** One of the access flags for methods or classes.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_ABSTRACT     = 0x0400;
+
+  /** One of the access flags for methods.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_STRICT       = 0x0800;
+
+  /** One of the access flags for fields, methods, classes, MethodParameter attribute, or Module attribute.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_SYNTHETIC    = 0x1000;
+
+  /** One of the access flags for classes.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_ANNOTATION   = 0x2000;
+
+  /** One of the access flags for fields or classes.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_ENUM         = 0x4000;
+
+  // Applies to classes compiled by new compilers only
+  /** One of the access flags for MethodParameter or Module attributes.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_MANDATED     = (short) 0x8000;
+
+  /** One of the access flags for classes.
+   *  @see #ACC_PUBLIC
+   */
+  public static final short ACC_MODULE       = (short) 0x8000;
+
+  /** One of the access flags for fields, methods, or classes.
+   *  @see #ACC_PUBLIC
+   *  @deprecated Use {@link #MAX_ACC_FLAG_I}
+   */
+  @Deprecated
   public static final short MAX_ACC_FLAG     = ACC_ENUM;
 
+  /** One of the access flags for fields, methods, or classes.
+   * ACC_MODULE is negative as a short.
+   * @see #ACC_PUBLIC
+   * @since 6.4.0
+   */
+  public static final int MAX_ACC_FLAG_I = 0x8000; // ACC_MODULE is negative as a short
+
+  // Note that do to overloading:
+  // 'synchronized' is for methods, might be 'open' (if Module), 'super' (if class), or 'transitive' (if Module).
+  // 'volatile'     is for fields,  might be 'bridge' (if method) or 'static_phase' (if Module)
+  // 'transient'    is for fields,  might be 'varargs' (if method)
+  // 'module'       is for classes, might be 'mandated' (if Module or MethodParameters)
   /**
    * The names of the access flags.
    */
   private static final String[] ACCESS_NAMES = {
     "public", "private", "protected", "static", "final", "synchronized",
     "volatile", "transient", "native", "interface", "abstract", "strictfp",
-    "synthetic", "annotation", "enum"
+    "synthetic", "annotation", "enum", "module"
   };
 
   /** @since 6.0 */
@@ -2279,8 +2327,13 @@ public final class Const {
   public static final byte ATTR_STACK_MAP_TABLE                         = 19;
   public static final byte ATTR_BOOTSTRAP_METHODS                       = 20;
   public static final byte ATTR_METHOD_PARAMETERS                       = 21;
+  public static final byte ATTR_MODULE                                  = 22;
+  public static final byte ATTR_MODULE_PACKAGES                         = 23;
+  public static final byte ATTR_MODULE_MAIN_CLASS                       = 24;
+  public static final byte ATTR_NEST_HOST                               = 25;
+  public static final byte ATTR_NEST_MEMBERS                            = 26;
 
-  public static final short KNOWN_ATTRIBUTES = 22; // count of attributes
+  public static final short KNOWN_ATTRIBUTES = 27; // count of attributes
 
   private static final String[] ATTRIBUTE_NAMES = {
     "SourceFile", "ConstantValue", "Code", "Exceptions",
@@ -2290,7 +2343,8 @@ public final class Const {
     "RuntimeVisibleAnnotations", "RuntimeInvisibleAnnotations",
     "RuntimeVisibleParameterAnnotations", "RuntimeInvisibleParameterAnnotations",
     "AnnotationDefault", "LocalVariableTypeTable", "EnclosingMethod", "StackMapTable",
-    "BootstrapMethods", "MethodParameters"
+    "BootstrapMethods", "MethodParameters", "Module", "ModulePackages",
+    "ModuleMainClass", "NestHost", "NestMembers"
   };
 
   /**

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/ExceptionConst.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/ExceptionConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -23,7 +23,7 @@ package com.sun.org.apache.bcel.internal;
 /**
  * Exception constants.
  * @since 6.0 (intended to replace the InstructionConstant interface)
- * @LastModified: Oct 2017
+ * @LastModified: Jan 2020
  */
 public final class ExceptionConst {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/Repository.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,8 +31,7 @@ import com.sun.org.apache.bcel.internal.util.SyntheticRepository;
  * @see com.sun.org.apache.bcel.internal.util.Repository
  * @see SyntheticRepository
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class Repository {
 
@@ -40,21 +39,24 @@ public abstract class Repository {
             = SyntheticRepository.getInstance();
 
 
-    /** @return currently used repository instance
+    /**
+     * @return currently used repository instance
      */
     public static com.sun.org.apache.bcel.internal.util.Repository getRepository() {
         return repository;
     }
 
 
-    /** Set repository instance to be used for class loading
+    /**
+     * Sets repository instance to be used for class loading
      */
     public static void setRepository( final com.sun.org.apache.bcel.internal.util.Repository rep ) {
         repository = rep;
     }
 
 
-    /** Lookup class somewhere found on your CLASSPATH, or whereever the
+    /**
+     * Lookups class somewhere found on your CLASSPATH, or whereever the
      * repository instance looks for it.
      *
      * @return class object for given fully qualified class name
@@ -67,7 +69,8 @@ public abstract class Repository {
 
 
     /**
-     * Try to find class source using the internal repository instance.
+     * Tries to find class source using the internal repository instance.
+     *
      * @see Class
      * @return JavaClass object for given runtime class
      * @throws ClassNotFoundException if the class could not be found or
@@ -87,7 +90,7 @@ public abstract class Repository {
 
 
     /**
-     * Add clazz to repository if there isn't an equally named class already in there.
+     * Adds clazz to repository if there isn't an equally named class already in there.
      *
      * @return old entry in repository
      */
@@ -99,7 +102,7 @@ public abstract class Repository {
 
 
     /**
-     * Remove class with given (fully qualified) name from repository.
+     * Removes class with given (fully qualified) name from repository.
      */
     public static void removeClass( final String clazz ) {
         repository.removeClass(repository.findClass(clazz));
@@ -107,7 +110,7 @@ public abstract class Repository {
 
 
     /**
-     * Remove given class from repository.
+     * Removes given class from repository.
      */
     public static void removeClass( final JavaClass clazz ) {
         repository.removeClass(clazz);

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AccessFlags.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AccessFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,8 +25,7 @@ import com.sun.org.apache.bcel.internal.Const;
  * Super class for all objects that have modifiers like private, final, ... I.e.
  * classes, fields, and methods.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class AccessFlags {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationDefault.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationDefault.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * Represents the default value of a annotation for a method info
  *
- * @version $Id: AnnotationDefault 1 2005-02-13 03:15:08Z dbrosius $
  * @since 6.0
  */
 public class AnnotationDefault extends Attribute {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationEntry.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationEntry.java
@@ -33,7 +33,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * represents one annotation in the annotation table
  *
- * @version $Id: AnnotationEntry
  * @since 6.0
  */
 public class AnnotationEntry implements Node {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Annotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Annotations.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 /**
  * base class for annotations
  *
- * @version $Id: Annotations
  * @since 6.0
  */
 public abstract class Annotations extends Attribute {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Attribute.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -36,7 +36,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * <em>Synthetic</em> attributes are supported. The <em>Unknown</em>
  * attribute stands for non-standard-attributes.
  *
- * @version $Id$
  * @see ConstantValue
  * @see SourceFile
  * @see Code
@@ -48,43 +47,14 @@ import com.sun.org.apache.bcel.internal.Const;
  * @see Synthetic
  * @see Deprecated
  * @see Signature
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class Attribute implements Cloneable, Node {
-
+    private static final boolean debug = false;
     private int name_index; // Points to attribute name in constant pool
     private int length; // Content length of attribute field
     private final byte tag; // Tag to distinguish subclasses
     private ConstantPool constant_pool;
-
-    protected Attribute(final byte tag, final int name_index, final int length, final ConstantPool constant_pool) {
-        this.tag = tag;
-        this.name_index = name_index;
-        this.length = length;
-        this.constant_pool = constant_pool;
-    }
-
-    /**
-     * Called by objects that are traversing the nodes of the tree implicitely
-     * defined by the contents of a Java class. I.e., the hierarchy of methods,
-     * fields, attributes, etc. spawns a tree of objects.
-     *
-     * @param v Visitor object
-     */
-    @Override
-    public abstract void accept(Visitor v);
-
-    /**
-     * Dump attribute to file stream in binary format.
-     *
-     * @param file Output file stream
-     * @throws IOException
-     */
-    public void dump(final DataOutputStream file) throws IOException
-    {
-        file.writeShort(name_index);
-        file.writeInt(length);
-    }
 
     private static final Map<String, Object> readers = new HashMap<>();
 
@@ -101,34 +71,10 @@ public abstract class Attribute implements Cloneable, Node {
         readers.put(name, r);
     }
 
-    /**
-     * Remove attribute reader
-     *
-     * @param name the name of the attribute as stored in the class file
-     */
-    public static void removeAttributeReader(final String name)
-    {
-        readers.remove(name);
-    }
-
-    /**
-     * Class method reads one attribute from the input data stream. This method
-     * must not be accessible from the outside. It is called by the Field and
-     * Method constructor methods.
-     *
-     * @see Field
-     * @see Method
-     *
-     * @param file Input stream
-     * @param constant_pool Array of constants
-     * @return Attribute
-     * @throws IOException
-     * @throws ClassFormatException
-     */
-    public static Attribute readAttribute(final DataInputStream file, final ConstantPool constant_pool)
-            throws IOException, ClassFormatException
-    {
-        return readAttribute((DataInput) file, constant_pool);
+    protected static void println(final String msg) {
+        if (debug) {
+            System.err.println(msg);
+        }
     }
 
     /**
@@ -203,7 +149,7 @@ public abstract class Attribute implements Cloneable, Node {
             case Const.ATTR_STACK_MAP:
                 // old style stack map: unneeded for JDK5 and below;
                 // illegal(?) for JDK6 and above.  So just delete with a warning.
-                System.err.println("Warning: Obsolete StackMap attribute ignored.");
+                println("Warning: Obsolete StackMap attribute ignored.");
                 return new Unknown(name_index, length, file, constant_pool);
             case Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS:
                 return new RuntimeVisibleAnnotations(name_index, length, file, constant_pool);
@@ -227,6 +173,16 @@ public abstract class Attribute implements Cloneable, Node {
                 return new BootstrapMethods(name_index, length, file, constant_pool);
             case Const.ATTR_METHOD_PARAMETERS:
                 return new MethodParameters(name_index, length, file, constant_pool);
+            case Const.ATTR_MODULE:
+                return new Module(name_index, length, file, constant_pool);
+            case Const.ATTR_MODULE_PACKAGES:
+                return new ModulePackages(name_index, length, file, constant_pool);
+            case Const.ATTR_MODULE_MAIN_CLASS:
+                return new ModuleMainClass(name_index, length, file, constant_pool);
+            case Const.ATTR_NEST_HOST:
+                return new NestHost(name_index, length, file, constant_pool);
+            case Const.ATTR_NEST_MEMBERS:
+                return new NestMembers(name_index, length, file, constant_pool);
             default:
                 // Never reached
                 throw new IllegalStateException("Unrecognized attribute type tag parsed: " + tag);
@@ -234,72 +190,53 @@ public abstract class Attribute implements Cloneable, Node {
     }
 
     /**
-     * @return Name of attribute
-     * @since 6.0
+     * Class method reads one attribute from the input data stream. This method
+     * must not be accessible from the outside. It is called by the Field and
+     * Method constructor methods.
+     *
+     * @see Field
+     * @see Method
+     *
+     * @param file Input stream
+     * @param constant_pool Array of constants
+     * @return Attribute
+     * @throws IOException
+     * @throws ClassFormatException
      */
-    public String getName()
+    public static Attribute readAttribute(final DataInputStream file, final ConstantPool constant_pool)
+            throws IOException, ClassFormatException
     {
-        final ConstantUtf8 c = (ConstantUtf8) constant_pool.getConstant(name_index, Const.CONSTANT_Utf8);
-        return c.getBytes();
+        return readAttribute((DataInput) file, constant_pool);
     }
 
     /**
-     * @return Length of attribute field in bytes.
+     * Remove attribute reader
+     *
+     * @param name the name of the attribute as stored in the class file
      */
-    public final int getLength()
+    public static void removeAttributeReader(final String name)
     {
-        return length;
+        readers.remove(name);
     }
 
-    /**
-     * @param length length in bytes.
-     */
-    public final void setLength(final int length)
+    protected Attribute(final byte tag, final int name_index, final int length, final ConstantPool constant_pool)
     {
-        this.length = length;
-    }
-
-    /**
-     * @param name_index of attribute.
-     */
-    public final void setNameIndex(final int name_index)
-    {
+        this.tag = tag;
         this.name_index = name_index;
-    }
-
-    /**
-     * @return Name index in constant pool of attribute name.
-     */
-    public final int getNameIndex()
-    {
-        return name_index;
-    }
-
-    /**
-     * @return Tag of attribute, i.e., its type. Value may not be altered, thus there is no setTag() method.
-     */
-    public final byte getTag()
-    {
-        return tag;
-    }
-
-    /**
-     * @return Constant pool used by this object.
-     * @see ConstantPool
-     */
-    public final ConstantPool getConstantPool()
-    {
-        return constant_pool;
-    }
-
-    /**
-     * @param constant_pool Constant pool to be used for this object.
-     * @see ConstantPool
-     */
-    public final void setConstantPool(final ConstantPool constant_pool)
-    {
+        this.length = length;
         this.constant_pool = constant_pool;
     }
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v
+     *            Visitor object
+     */
+    @Override
+    public abstract void accept(Visitor v);
 
     /**
      * Use copy() if you want to have a deep copy(), i.e., with all references
@@ -326,6 +263,87 @@ public abstract class Attribute implements Cloneable, Node {
      * @return deep copy of this attribute
      */
     public abstract Attribute copy(ConstantPool _constant_pool);
+
+    /**
+     * Dump attribute to file stream in binary format.
+     *
+     * @param file
+     *            Output file stream
+     * @throws IOException
+     */
+    public void dump(final DataOutputStream file) throws IOException
+    {
+        file.writeShort(name_index);
+        file.writeInt(length);
+    }
+
+    /**
+     * @return Constant pool used by this object.
+     * @see ConstantPool
+     */
+    public final ConstantPool getConstantPool()
+    {
+        return constant_pool;
+    }
+
+    /**
+     * @return Length of attribute field in bytes.
+     */
+    public final int getLength()
+    {
+        return length;
+    }
+
+    /**
+     * @return Name of attribute
+     * @since 6.0
+     */
+    public String getName()
+    {
+        final ConstantUtf8 c = (ConstantUtf8) constant_pool.getConstant(name_index, Const.CONSTANT_Utf8);
+        return c.getBytes();
+    }
+
+    /**
+     * @return Name index in constant pool of attribute name.
+     */
+    public final int getNameIndex()
+    {
+        return name_index;
+    }
+
+    /**
+     * @return Tag of attribute, i.e., its type. Value may not be altered, thus there is no setTag() method.
+     */
+    public final byte getTag()
+    {
+        return tag;
+    }
+
+    /**
+     * @param constant_pool Constant pool to be used for this object.
+     * @see ConstantPool
+     */
+    public final void setConstantPool(final ConstantPool constant_pool)
+    {
+        this.constant_pool = constant_pool;
+    }
+
+    /**
+     * @param length length in bytes.
+     */
+    public final void setLength(final int length)
+    {
+        this.length = length;
+    }
+
+    /**
+     * @param name_index of attribute.
+     */
+    public final void setNameIndex(final int name_index)
+    {
+        this.name_index = name_index;
+    }
 
     /**
      * @return attribute name.

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AttributeReader.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AttributeReader.java
@@ -27,7 +27,6 @@ package com.sun.org.apache.bcel.internal.classfile;
  * method. These factory objects should implement this interface.
 
  * @see Attribute
- * @version $Id$
  *
  * @deprecated Use UnknownAttributeReader instead
  */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethod.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethod.java
@@ -74,7 +74,7 @@ public class BootstrapMethod implements Cloneable {
 
     /**
      * @param bootstrap_method_ref int index into constant_pool of CONSTANT_MethodHandle
-     * @param bootstrap_arguments int[] indices into constant_pool of CONSTANT_<type>_info
+     * @param bootstrap_arguments int[] indices into constant_pool of CONSTANT_[type]_info
      */
     public BootstrapMethod(final int bootstrap_method_ref, final int[] bootstrap_arguments) {
         this.bootstrap_method_ref = bootstrap_method_ref;
@@ -96,7 +96,7 @@ public class BootstrapMethod implements Cloneable {
     }
 
     /**
-     * @return int[] of bootstrap_method indices into constant_pool of CONSTANT_<type>_info
+     * @return int[] of bootstrap_method indices into constant_pool of CONSTANT_[type]_info
      */
     public int[] getBootstrapArguments() {
         return bootstrap_arguments;
@@ -110,7 +110,7 @@ public class BootstrapMethod implements Cloneable {
     }
 
     /**
-     * @param bootstrap_arguments int[] indices into constant_pool of CONSTANT_<type>_info
+     * @param bootstrap_arguments int[] indices into constant_pool of CONSTANT_[type]_info
      */
     public void setBootstrapArguments(final int[] bootstrap_arguments) {
         this.bootstrap_arguments = bootstrap_arguments;
@@ -133,12 +133,12 @@ public class BootstrapMethod implements Cloneable {
         String bootstrap_method_name;
         bootstrap_method_name = constant_pool.constantToString(bootstrap_method_ref,
                 Const.CONSTANT_MethodHandle);
-        buf.append(Utility.compactClassName(bootstrap_method_name));
+        buf.append(Utility.compactClassName(bootstrap_method_name, false));
         final int num_bootstrap_arguments = bootstrap_arguments.length;
         if (num_bootstrap_arguments > 0) {
-            buf.append("\n     Method Arguments:");
+            buf.append("\nMethod Arguments:");
             for (int i = 0; i < num_bootstrap_arguments; i++) {
-                buf.append("\n     ").append(i).append(": ");
+                buf.append("\n  ").append(i).append(": ");
                 buf.append(constant_pool.constantToString(constant_pool.getConstant(bootstrap_arguments[i])));
             }
         }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethods.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethods.java
@@ -138,10 +138,17 @@ public class BootstrapMethods extends Attribute {
         final StringBuilder buf = new StringBuilder();
         buf.append("BootstrapMethods(");
         buf.append(bootstrap_methods.length);
-        buf.append("):\n");
+        buf.append("):");
         for (int i = 0; i < bootstrap_methods.length; i++) {
+            buf.append("\n");
+            final int start = buf.length();
             buf.append("  ").append(i).append(": ");
-            buf.append(bootstrap_methods[i].toString(super.getConstantPool())).append("\n");
+            final int indent_count = buf.length() - start;
+            final String[] lines = (bootstrap_methods[i].toString(super.getConstantPool())).split("\\r?\\n");
+            buf.append(lines[0]);
+            for (int j = 1; j < lines.length; j++) {
+                buf.append("\n").append("          ".substring(0,indent_count)).append(lines[j]);
+            }
         }
         return buf.toString();
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ClassFormatException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ClassFormatException.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.classfile;
  * that the file is malformed or otherwise cannot be interpreted as a
  * class file.
  *
- * @version $Id$
  */
 public class ClassFormatException extends RuntimeException {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ClassParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ClassParser.java
@@ -43,7 +43,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * JVM specification 1.0</a>. See this paper for
  * further details about the structure of a bytecode file.
  *
- * @version $Id$
  */
 public final class ClassParser {
 
@@ -66,7 +65,7 @@ public final class ClassParser {
 
 
     /**
-     * Parse class from the given stream.
+     * Parses class from the given stream.
      *
      * @param inputStream Input stream
      * @param file_name File name
@@ -84,7 +83,7 @@ public final class ClassParser {
     }
 
 
-    /** Parse class from given .class file.
+    /** Parses class from given .class file.
      *
      * @param file_name file name
      */
@@ -95,7 +94,7 @@ public final class ClassParser {
     }
 
 
-    /** Parse class from given .class file in a ZIP-archive
+    /** Parses class from given .class file in a ZIP-archive
      *
      * @param zip_file zip file name
      * @param file_name file name
@@ -109,7 +108,7 @@ public final class ClassParser {
 
 
     /**
-     * Parse the given Java class file and return an object that represents
+     * Parses the given Java class file and return an object that represents
      * the contained data, i.e., constants, methods, fields and commands.
      * A <em>ClassFormatException</em> is raised, if the file is not a valid
      * .class file. (This does not include verification of the byte code as it
@@ -199,7 +198,7 @@ public final class ClassParser {
 
 
     /**
-     * Read information about the attributes of the class.
+     * Reads information about the attributes of the class.
      * @throws  IOException
      * @throws  ClassFormatException
      */
@@ -213,7 +212,7 @@ public final class ClassParser {
 
 
     /**
-     * Read information about the class and its super class.
+     * Reads information about the class and its super class.
      * @throws  IOException
      * @throws  ClassFormatException
      */
@@ -235,7 +234,7 @@ public final class ClassParser {
 
 
     /**
-     * Read constant pool entries.
+     * Reads constant pool entries.
      * @throws  IOException
      * @throws  ClassFormatException
      */
@@ -245,7 +244,7 @@ public final class ClassParser {
 
 
     /**
-     * Read information about the fields of the class, i.e., its variables.
+     * Reads information about the fields of the class, i.e., its variables.
      * @throws  IOException
      * @throws  ClassFormatException
      */
@@ -260,7 +259,7 @@ public final class ClassParser {
 
     /******************** Private utility methods **********************/
     /**
-     * Check whether the header of the file is ok.
+     * Checks whether the header of the file is ok.
      * Of course, this has to be the first action on successive file reads.
      * @throws  IOException
      * @throws  ClassFormatException
@@ -273,7 +272,7 @@ public final class ClassParser {
 
 
     /**
-     * Read information about the interfaces implemented by this class.
+     * Reads information about the interfaces implemented by this class.
      * @throws  IOException
      * @throws  ClassFormatException
      */
@@ -287,7 +286,7 @@ public final class ClassParser {
 
 
     /**
-     * Read information about the methods of the class.
+     * Reads information about the methods of the class.
      * @throws  IOException
      * @throws  ClassFormatException
      */
@@ -301,7 +300,7 @@ public final class ClassParser {
 
 
     /**
-     * Read major and minor version of compiler which created the file.
+     * Reads major and minor version of compiler which created the file.
      * @throws  IOException
      * @throws  ClassFormatException
      */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Code.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Code.java
@@ -39,7 +39,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * is used for debugging purposes and <em>LocalVariableTable</em> which
  * contains information about the local variables.
  *
- * @version $Id$
  * @see     Attribute
  * @see     CodeException
  * @see     LineNumberTable
@@ -144,7 +143,7 @@ public final class Code extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(max_stack);
         file.writeShort(max_locals);
@@ -165,7 +164,7 @@ public final class Code extends Attribute {
      * @return Collection of code attributes.
      * @see Attribute
      */
-    public final Attribute[] getAttributes() {
+    public Attribute[] getAttributes() {
         return attributes;
     }
 
@@ -199,7 +198,7 @@ public final class Code extends Attribute {
     /**
      * @return Actual byte code of the method.
      */
-    public final byte[] getCode() {
+    public byte[] getCode() {
         return code;
     }
 
@@ -208,7 +207,7 @@ public final class Code extends Attribute {
      * @return Table of handled exceptions.
      * @see CodeException
      */
-    public final CodeException[] getExceptionTable() {
+    public CodeException[] getExceptionTable() {
         return exception_table;
     }
 
@@ -216,7 +215,7 @@ public final class Code extends Attribute {
     /**
      * @return Number of local variables.
      */
-    public final int getMaxLocals() {
+    public int getMaxLocals() {
         return max_locals;
     }
 
@@ -224,7 +223,7 @@ public final class Code extends Attribute {
     /**
      * @return Maximum size of stack used by this method.
      */
-    public final int getMaxStack() {
+    public int getMaxStack() {
         return max_stack;
     }
 
@@ -260,7 +259,7 @@ public final class Code extends Attribute {
     /**
      * @param attributes the attributes to set for this Code
      */
-    public final void setAttributes( final Attribute[] attributes ) {
+    public void setAttributes( final Attribute[] attributes ) {
         this.attributes = attributes != null ? attributes : new Attribute[0];
         super.setLength(calculateLength()); // Adjust length
     }
@@ -269,7 +268,7 @@ public final class Code extends Attribute {
     /**
      * @param code byte code
      */
-    public final void setCode( final byte[] code ) {
+    public void setCode( final byte[] code ) {
         this.code = code != null ? code : new byte[0];
         super.setLength(calculateLength()); // Adjust length
     }
@@ -278,7 +277,7 @@ public final class Code extends Attribute {
     /**
      * @param exception_table exception table
      */
-    public final void setExceptionTable( final CodeException[] exception_table ) {
+    public void setExceptionTable( final CodeException[] exception_table ) {
         this.exception_table = exception_table != null ? exception_table : new CodeException[0];
         super.setLength(calculateLength()); // Adjust length
     }
@@ -287,7 +286,7 @@ public final class Code extends Attribute {
     /**
      * @param max_locals maximum number of local variables
      */
-    public final void setMaxLocals( final int max_locals ) {
+    public void setMaxLocals( final int max_locals ) {
         this.max_locals = max_locals;
     }
 
@@ -295,7 +294,7 @@ public final class Code extends Attribute {
     /**
      * @param max_stack maximum stack size
      */
-    public final void setMaxStack( final int max_stack ) {
+    public void setMaxStack( final int max_stack ) {
         this.max_stack = max_stack;
     }
 
@@ -303,7 +302,7 @@ public final class Code extends Attribute {
     /**
      * @return String representation of code chunk.
      */
-    public final String toString( final boolean verbose ) {
+    public String toString( final boolean verbose ) {
         final StringBuilder buf = new StringBuilder(100); // CHECKSTYLE IGNORE MagicNumber
         buf.append("Code(max_stack = ").append(max_stack).append(", max_locals = ").append(
                 max_locals).append(", code_length = ").append(code.length).append(")\n").append(
@@ -328,7 +327,7 @@ public final class Code extends Attribute {
      * @return String representation of code chunk.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return toString(true);
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/CodeException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/CodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,9 +31,8 @@ import com.sun.org.apache.bcel.internal.Const;
  * attribute and is used only there. It contains a range in which a
  * particular exception handler is active.
  *
- * @version $Id$
  * @see     Code
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public final class CodeException implements Cloneable, Node {
 
@@ -104,7 +103,7 @@ public final class CodeException implements Cloneable, Node {
      * @param file Output file stream
      * @throws IOException
      */
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeShort(start_pc);
         file.writeShort(end_pc);
         file.writeShort(handler_pc);
@@ -116,7 +115,7 @@ public final class CodeException implements Cloneable, Node {
      * @return 0, if the handler catches any exception, otherwise it points to
      * the exception class which is to be caught.
      */
-    public final int getCatchType() {
+    public int getCatchType() {
         return catch_type;
     }
 
@@ -124,7 +123,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @return Exclusive end index of the region where the handler is active.
      */
-    public final int getEndPC() {
+    public int getEndPC() {
         return end_pc;
     }
 
@@ -132,7 +131,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @return Starting address of exception handler, relative to the code.
      */
-    public final int getHandlerPC() {
+    public int getHandlerPC() {
         return handler_pc;
     }
 
@@ -140,7 +139,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @return Inclusive start index of the region where the handler is active.
      */
-    public final int getStartPC() {
+    public int getStartPC() {
         return start_pc;
     }
 
@@ -148,7 +147,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @param catch_type the type of exception that is caught
      */
-    public final void setCatchType( final int catch_type ) {
+    public void setCatchType( final int catch_type ) {
         this.catch_type = catch_type;
     }
 
@@ -156,7 +155,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @param end_pc end of handled block
      */
-    public final void setEndPC( final int end_pc ) {
+    public void setEndPC( final int end_pc ) {
         this.end_pc = end_pc;
     }
 
@@ -164,7 +163,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @param handler_pc where the actual code is
      */
-    public final void setHandlerPC( final int handler_pc ) { // TODO unused
+    public void setHandlerPC( final int handler_pc ) { // TODO unused
         this.handler_pc = handler_pc;
     }
 
@@ -172,7 +171,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @param start_pc start of handled block
      */
-    public final void setStartPC( final int start_pc ) { // TODO unused
+    public void setStartPC( final int start_pc ) { // TODO unused
         this.start_pc = start_pc;
     }
 
@@ -181,7 +180,7 @@ public final class CodeException implements Cloneable, Node {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return "CodeException(start_pc = " + start_pc + ", end_pc = " + end_pc + ", handler_pc = "
                 + handler_pc + ", catch_type = " + catch_type + ")";
     }
@@ -190,7 +189,7 @@ public final class CodeException implements Cloneable, Node {
     /**
      * @return String representation.
      */
-    public final String toString( final ConstantPool cp, final boolean verbose ) {
+    public String toString( final ConstantPool cp, final boolean verbose ) {
         String str;
         if (catch_type == 0) {
             str = "<Any exception>(0)";
@@ -202,7 +201,7 @@ public final class CodeException implements Cloneable, Node {
     }
 
 
-    public final String toString( final ConstantPool cp ) {
+    public String toString( final ConstantPool cp ) {
         return toString(cp, true);
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Constant.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,8 +32,7 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * in the constant pool of a class file. The classes keep closely to
  * the JVM specification.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class Constant implements Cloneable, Node {
 
@@ -64,11 +63,9 @@ public abstract class Constant implements Cloneable, Node {
      */
     private byte tag;
 
-
     Constant(final byte tag) {
         this.tag = tag;
     }
-
 
     /**
      * Called by objects that are traversing the nodes of the tree implicitely
@@ -80,9 +77,7 @@ public abstract class Constant implements Cloneable, Node {
     @Override
     public abstract void accept( Visitor v );
 
-
     public abstract void dump( DataOutputStream file ) throws IOException;
-
 
     /**
      * @return Tag of constant, i.e., its type. No setTag() method to avoid
@@ -92,7 +87,6 @@ public abstract class Constant implements Cloneable, Node {
         return tag;
     }
 
-
     /**
      * @return String representation.
      */
@@ -100,7 +94,6 @@ public abstract class Constant implements Cloneable, Node {
     public String toString() {
         return Const.getConstantName(tag) + "[" + tag + "]";
     }
-
 
     /**
      * @return deep copy of this constant
@@ -114,7 +107,6 @@ public abstract class Constant implements Cloneable, Node {
         return null;
     }
 
-
     @Override
     public Object clone() {
         try {
@@ -124,9 +116,8 @@ public abstract class Constant implements Cloneable, Node {
         }
     }
 
-
     /**
-     * Read one constant from the given input, the type depends on a tag byte.
+     * Reads one constant from the given input, the type depends on a tag byte.
      *
      * @param dataInput Input stream
      * @return Constant object
@@ -183,7 +174,6 @@ public abstract class Constant implements Cloneable, Node {
         return bcelComparator;
     }
 
-
     /**
      * @param comparator Comparison strategy object
      */
@@ -191,9 +181,8 @@ public abstract class Constant implements Cloneable, Node {
         bcelComparator = comparator;
     }
 
-
     /**
-     * Return value as defined by given BCELComparator strategy.
+     * Returns value as defined by given BCELComparator strategy.
      * By default two Constant objects are said to be equal when
      * the result of toString() is equal.
      *
@@ -204,9 +193,8 @@ public abstract class Constant implements Cloneable, Node {
         return bcelComparator.equals(this, obj);
     }
 
-
     /**
-     * Return value as defined by given BCELComparator strategy.
+     * Returns value as defined by given BCELComparator strategy.
      * By default return the hashcode of the result of toString().
      *
      * @see java.lang.Object#hashCode()

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantCP.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantCP.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * Abstract super class for Fieldref, Methodref, InterfaceMethodref and
  *                          InvokeDynamic constants.
  *
- * @version $Id$
  * @see     ConstantFieldref
  * @see     ConstantMethodref
  * @see     ConstantInterfaceMethodref

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantClass.java
@@ -87,7 +87,7 @@ public final class ConstantClass extends Constant implements ConstantObject {
      * @throws IOException if an I/O error occurs writing to the DataOutputStream.
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeShort(name_index);
     }
@@ -96,7 +96,7 @@ public final class ConstantClass extends Constant implements ConstantObject {
     /**
      * @return Name index in constant pool of class name.
      */
-    public final int getNameIndex() {
+    public int getNameIndex() {
         return name_index;
     }
 
@@ -104,7 +104,7 @@ public final class ConstantClass extends Constant implements ConstantObject {
     /**
      * @param name_index the name index in the constant pool of this Constant Class
      */
-    public final void setNameIndex( final int name_index ) {
+    public void setNameIndex( final int name_index ) {
         this.name_index = name_index;
     }
 
@@ -129,7 +129,7 @@ public final class ConstantClass extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(name_index = " + name_index + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantDouble.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantDouble.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class is derived from the abstract  {@link Constant}
  * and represents a reference to a Double object.
  *
- * @version $Id$
  * @see     Constant
  * @LastModified: Jun 2019
  */
@@ -87,7 +86,7 @@ public final class ConstantDouble extends Constant implements ConstantObject {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeDouble(bytes);
     }
@@ -96,7 +95,7 @@ public final class ConstantDouble extends Constant implements ConstantObject {
     /**
      * @return data, i.e., 8 bytes.
      */
-    public final double getBytes() {
+    public double getBytes() {
         return bytes;
     }
 
@@ -104,7 +103,7 @@ public final class ConstantDouble extends Constant implements ConstantObject {
     /**
      * @param bytes the raw bytes that represent the double value
      */
-    public final void setBytes( final double bytes ) {
+    public void setBytes( final double bytes ) {
         this.bytes = bytes;
     }
 
@@ -113,7 +112,7 @@ public final class ConstantDouble extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(bytes = " + bytes + ")";
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantDynamic.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantDynamic.java
@@ -80,7 +80,7 @@ public final class ConstantDynamic extends ConstantCP {
      * for use by ConstantInvokeDynamic.
      * @since 6.0
      */
-    public final int getBootstrapMethodAttrIndex() {
+    public int getBootstrapMethodAttrIndex() {
         return super.getClassIndex();  // AKA bootstrap_method_attr_index
     }
 
@@ -88,7 +88,7 @@ public final class ConstantDynamic extends ConstantCP {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString().replace("class_index", "bootstrap_method_attr_index");
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantFieldref.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantFieldref.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * This class represents a constant pool reference to a field.
  *
- * @version $Id$
  */
 public final class ConstantFieldref extends ConstantCP {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantFloat.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantFloat.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class is derived from the abstract {@link Constant}
  * and represents a reference to a float object.
  *
- * @version $Id$
  * @see     Constant
  * @LastModified: Jun 2019
  */
@@ -88,7 +87,7 @@ public final class ConstantFloat extends Constant implements ConstantObject {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeFloat(bytes);
     }
@@ -97,7 +96,7 @@ public final class ConstantFloat extends Constant implements ConstantObject {
     /**
      * @return data, i.e., 4 bytes.
      */
-    public final float getBytes() {
+    public float getBytes() {
         return bytes;
     }
 
@@ -105,7 +104,7 @@ public final class ConstantFloat extends Constant implements ConstantObject {
     /**
      * @param bytes the raw bytes that represent this float
      */
-    public final void setBytes( final float bytes ) {
+    public void setBytes( final float bytes ) {
         this.bytes = bytes;
     }
 
@@ -114,7 +113,7 @@ public final class ConstantFloat extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(bytes = " + bytes + ")";
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInteger.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInteger.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class is derived from the abstract {@link Constant}
  * and represents a reference to an int object.
  *
- * @version $Id$
  * @see     Constant
  * @LastModified: Jun 2019
  */
@@ -87,7 +86,7 @@ public final class ConstantInteger extends Constant implements ConstantObject {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeInt(bytes);
     }
@@ -96,7 +95,7 @@ public final class ConstantInteger extends Constant implements ConstantObject {
     /**
      * @return data, i.e., 4 bytes.
      */
-    public final int getBytes() {
+    public int getBytes() {
         return bytes;
     }
 
@@ -104,7 +103,7 @@ public final class ConstantInteger extends Constant implements ConstantObject {
     /**
      * @param bytes the raw bytes that represent this integer
      */
-    public final void setBytes( final int bytes ) {
+    public void setBytes( final int bytes ) {
         this.bytes = bytes;
     }
 
@@ -113,7 +112,7 @@ public final class ConstantInteger extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(bytes = " + bytes + ")";
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInterfaceMethodref.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInterfaceMethodref.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * This class represents a constant pool reference to an interface method.
  *
- * @version $Id$
  */
 public final class ConstantInterfaceMethodref extends ConstantCP {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInvokeDynamic.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInvokeDynamic.java
@@ -80,7 +80,7 @@ public final class ConstantInvokeDynamic extends ConstantCP {
      * for use by ConstantInvokeDynamic.
      * @since 6.0
      */
-    public final int getBootstrapMethodAttrIndex() {
+    public int getBootstrapMethodAttrIndex() {
         return super.getClassIndex();  // AKA bootstrap_method_attr_index
     }
 
@@ -88,7 +88,7 @@ public final class ConstantInvokeDynamic extends ConstantCP {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString().replace("class_index", "bootstrap_method_attr_index");
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantLong.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,8 +30,8 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class is derived from the abstract {@link Constant}
  * and represents a reference to a long object.
  *
- * @version $Id$
  * @see     Constant
+ * @LastModified: Jan 2020
  */
 public final class ConstantLong extends Constant implements ConstantObject {
 
@@ -86,7 +86,7 @@ public final class ConstantLong extends Constant implements ConstantObject {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeLong(bytes);
     }
@@ -95,7 +95,7 @@ public final class ConstantLong extends Constant implements ConstantObject {
     /**
      * @return data, i.e., 8 bytes.
      */
-    public final long getBytes() {
+    public long getBytes() {
         return bytes;
     }
 
@@ -103,7 +103,7 @@ public final class ConstantLong extends Constant implements ConstantObject {
     /**
      * @param bytes the raw bytes that represent this long
      */
-    public final void setBytes( final long bytes ) {
+    public void setBytes( final long bytes ) {
         this.bytes = bytes;
     }
 
@@ -112,7 +112,7 @@ public final class ConstantLong extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(bytes = " + bytes + ")";
     }
 
@@ -121,6 +121,6 @@ public final class ConstantLong extends Constant implements ConstantObject {
      */
     @Override
     public Object getConstantValue( final ConstantPool cp ) {
-        return Long.valueOf(bytes);
+        return bytes;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodHandle.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodHandle.java
@@ -86,7 +86,7 @@ public final class ConstantMethodHandle extends Constant {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeByte(reference_kind);
         file.writeShort(reference_index);
@@ -117,7 +117,7 @@ public final class ConstantMethodHandle extends Constant {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(reference_kind = " + reference_kind +
                 ", reference_index = " + reference_index + ")";
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodType.java
@@ -84,7 +84,7 @@ public final class ConstantMethodType extends Constant {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeShort(descriptor_index);
     }
@@ -104,7 +104,7 @@ public final class ConstantMethodType extends Constant {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(descriptor_index = " + descriptor_index + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodref.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodref.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * This class represents a constant pool reference to a method.
  *
- * @version $Id$
  */
 public final class ConstantMethodref extends ConstantCP {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantModule.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantModule.java
@@ -90,7 +90,7 @@ public final class ConstantModule extends Constant implements ConstantObject {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeShort(name_index);
     }
@@ -99,7 +99,7 @@ public final class ConstantModule extends Constant implements ConstantObject {
     /**
      * @return Name index in constant pool of module name.
      */
-    public final int getNameIndex() {
+    public int getNameIndex() {
         return name_index;
     }
 
@@ -107,7 +107,7 @@ public final class ConstantModule extends Constant implements ConstantObject {
     /**
      * @param name_index the name index in the constant pool of this Constant Module
      */
-    public final void setNameIndex( final int name_index ) {
+    public void setNameIndex( final int name_index ) {
         this.name_index = name_index;
     }
 
@@ -132,7 +132,7 @@ public final class ConstantModule extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(name_index = " + name_index + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantNameAndType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantNameAndType.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * and represents a reference to the name and signature
  * of a field or method.
  *
- * @version $Id$
  * @see     Constant
  */
 public final class ConstantNameAndType extends Constant {
@@ -91,7 +90,7 @@ public final class ConstantNameAndType extends Constant {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeShort(name_index);
         file.writeShort(signature_index);
@@ -101,14 +100,14 @@ public final class ConstantNameAndType extends Constant {
     /**
      * @return Name index in constant pool of field/method name.
      */
-    public final int getNameIndex() {
+    public int getNameIndex() {
         return name_index;
     }
 
 
     /** @return name
      */
-    public final String getName( final ConstantPool cp ) {
+    public String getName( final ConstantPool cp ) {
         return cp.constantToString(getNameIndex(), Const.CONSTANT_Utf8);
     }
 
@@ -116,14 +115,14 @@ public final class ConstantNameAndType extends Constant {
     /**
      * @return Index in constant pool of field/method signature.
      */
-    public final int getSignatureIndex() {
+    public int getSignatureIndex() {
         return signature_index;
     }
 
 
     /** @return signature
      */
-    public final String getSignature( final ConstantPool cp ) {
+    public String getSignature( final ConstantPool cp ) {
         return cp.constantToString(getSignatureIndex(), Const.CONSTANT_Utf8);
     }
 
@@ -131,7 +130,7 @@ public final class ConstantNameAndType extends Constant {
     /**
      * @param name_index the name index of this constant
      */
-    public final void setNameIndex( final int name_index ) {
+    public void setNameIndex( final int name_index ) {
         this.name_index = name_index;
     }
 
@@ -139,7 +138,7 @@ public final class ConstantNameAndType extends Constant {
     /**
      * @param signature_index the signature index in the constant pool of this type
      */
-    public final void setSignatureIndex( final int signature_index ) {
+    public void setSignatureIndex( final int signature_index ) {
         this.signature_index = signature_index;
     }
 
@@ -148,7 +147,7 @@ public final class ConstantNameAndType extends Constant {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(name_index = " + name_index + ", signature_index = "
                 + signature_index + ")";
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantObject.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantObject.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.classfile;
  * This interface denotes those constants that have a "natural" value,
  * such as ConstantLong, ConstantString, etc..
  *
- * @version $Id$
  * @see     Constant
  */
 public interface ConstantObject {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPackage.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPackage.java
@@ -71,7 +71,7 @@ public final class ConstantPackage extends Constant implements ConstantObject {
 
 
     /**
-     * Called by objects that are traversing the nodes of the tree implicitely
+     * Called by objects that are traversing the nodes of the tree implicitly
      * defined by the contents of a Java class. I.e., the hierarchy of methods,
      * fields, attributes, etc. spawns a tree of objects.
      *
@@ -90,7 +90,7 @@ public final class ConstantPackage extends Constant implements ConstantObject {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeShort(name_index);
     }
@@ -99,7 +99,7 @@ public final class ConstantPackage extends Constant implements ConstantObject {
     /**
      * @return Name index in constant pool of package name.
      */
-    public final int getNameIndex() {
+    public int getNameIndex() {
         return name_index;
     }
 
@@ -107,7 +107,7 @@ public final class ConstantPackage extends Constant implements ConstantObject {
     /**
      * @param name_index the name index in the constant pool of this Constant Package
      */
-    public final void setNameIndex( final int name_index ) {
+    public void setNameIndex( final int name_index ) {
         this.name_index = name_index;
     }
 
@@ -132,7 +132,7 @@ public final class ConstantPackage extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(name_index = " + name_index + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPool.java
@@ -35,14 +35,12 @@ import com.sun.org.apache.bcel.internal.Const;
  * programatically should see <a href="../generic/ConstantPoolGen.html">
  * ConstantPoolGen</a>.
 
- * @version $Id$
  * @see     Constant
  * @see     com.sun.org.apache.bcel.internal.generic.ConstantPoolGen
  */
 public class ConstantPool implements Cloneable, Node {
 
     private Constant[] constant_pool;
-
 
     /**
      * @param constant_pool Array of constants
@@ -51,9 +49,8 @@ public class ConstantPool implements Cloneable, Node {
         this.constant_pool = constant_pool;
     }
 
-
     /**
-     * Read constants from given input stream.
+     * Reads constants from given input stream.
      *
      * @param input Input stream
      * @throws IOException
@@ -82,7 +79,6 @@ public class ConstantPool implements Cloneable, Node {
         }
     }
 
-
     /**
      * Called by objects that are traversing the nodes of the tree implicitely
      * defined by the contents of a Java class. I.e., the hierarchy of methods,
@@ -95,9 +91,8 @@ public class ConstantPool implements Cloneable, Node {
         v.visitConstantPool(this);
     }
 
-
     /**
-     * Resolve constant to a string representation.
+     * Resolves constant to a string representation.
      *
      * @param  c Constant to be printed
      * @return String representation
@@ -163,12 +158,21 @@ public class ConstantPool implements Cloneable, Node {
                         + ":" + constantToString(cid.getNameAndTypeIndex(),
                         Const.CONSTANT_NameAndType);
                 break;
+            case Const.CONSTANT_Module:
+                i = ((ConstantModule) c).getNameIndex();
+                c = getConstant(i, Const.CONSTANT_Utf8);
+                str = Utility.compactClassName(((ConstantUtf8) c).getBytes(), false);
+                break;
+            case Const.CONSTANT_Package:
+                i = ((ConstantPackage) c).getNameIndex();
+                c = getConstant(i, Const.CONSTANT_Utf8);
+                str = Utility.compactClassName(((ConstantUtf8) c).getBytes(), false);
+                break;
             default: // Never reached
                 throw new RuntimeException("Unknown constant type " + tag);
         }
         return str;
     }
-
 
     private static String escape( final String str ) {
         final int len = str.length();
@@ -198,9 +202,8 @@ public class ConstantPool implements Cloneable, Node {
         return buf.toString();
     }
 
-
     /**
-     * Retrieve constant at `index' from constant pool and resolve it to
+     * Retrieves constant at `index' from constant pool and resolve it to
      * a string representation.
      *
      * @param  index of constant in constant pool
@@ -211,7 +214,6 @@ public class ConstantPool implements Cloneable, Node {
         final Constant c = getConstant(index, tag);
         return constantToString(c);
     }
-
 
     /**
      * Dump constant pool to file stream in binary format.
@@ -228,9 +230,8 @@ public class ConstantPool implements Cloneable, Node {
         }
     }
 
-
     /**
-     * Get constant from constant pool.
+     * Gets constant from constant pool.
      *
      * @param  index Index in constant pool
      * @return Constant value
@@ -244,9 +245,8 @@ public class ConstantPool implements Cloneable, Node {
         return constant_pool[index];
     }
 
-
     /**
-     * Get constant from constant pool and check whether it has the
+     * Gets constant from constant pool and check whether it has the
      * expected type.
      *
      * @param  index Index in constant pool
@@ -268,7 +268,6 @@ public class ConstantPool implements Cloneable, Node {
         return c;
     }
 
-
     /**
      * @return Array of constants.
      * @see    Constant
@@ -277,9 +276,8 @@ public class ConstantPool implements Cloneable, Node {
         return constant_pool;
     }
 
-
     /**
-     * Get string from constant pool and bypass the indirection of
+     * Gets string from constant pool and bypass the indirection of
      * `ConstantClass' and `ConstantString' objects. I.e. these classes have
      * an index field that points to another entry of the constant pool of
      * type `ConstantUtf8' which contains the real data.
@@ -295,7 +293,7 @@ public class ConstantPool implements Cloneable, Node {
         Constant c;
         int i;
         c = getConstant(index, tag);
-        /* This switch() is not that elegant, since the two classes have the
+        /* This switch() is not that elegant, since the four classes have the
          * same contents, they just differ in the name of the index
          * field variable.
          * But we want to stick to the JVM naming conventions closely though
@@ -308,6 +306,12 @@ public class ConstantPool implements Cloneable, Node {
                 break;
             case Const.CONSTANT_String:
                 i = ((ConstantString) c).getStringIndex();
+                break;
+            case Const.CONSTANT_Module:
+                i = ((ConstantModule) c).getNameIndex();
+                break;
+            case Const.CONSTANT_Package:
+                i = ((ConstantPackage) c).getNameIndex();
                 break;
             default:
                 throw new RuntimeException("getConstantString called with illegal tag " + tag);

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantString.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantString.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class is derived from the abstract {@link Constant}
  * and represents a reference to a String object.
  *
- * @version $Id$
  * @see     Constant
  */
 public final class ConstantString extends Constant implements ConstantObject {
@@ -87,7 +86,7 @@ public final class ConstantString extends Constant implements ConstantObject {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
         file.writeShort(string_index);
     }
@@ -96,7 +95,7 @@ public final class ConstantString extends Constant implements ConstantObject {
     /**
      * @return Index in constant pool of the string (ConstantUtf8).
      */
-    public final int getStringIndex() {
+    public int getStringIndex() {
         return string_index;
     }
 
@@ -104,7 +103,7 @@ public final class ConstantString extends Constant implements ConstantObject {
     /**
      * @param string_index the index into the constant of the string value
      */
-    public final void setStringIndex( final int string_index ) {
+    public void setStringIndex( final int string_index ) {
         this.string_index = string_index;
     }
 
@@ -113,7 +112,7 @@ public final class ConstantString extends Constant implements ConstantObject {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return super.toString() + "(string_index = " + string_index + ")";
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantUtf8.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantUtf8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -29,185 +29,180 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * This class is derived from the abstract {@link Constant}
- * and represents a reference to a Utf8 encoded string.
+ * Extends the abstract {@link Constant} to represent a reference to a UTF-8 encoded string.
  *
- * @version $Id$
- * @see     Constant
- * @LastModified: Jun 2019
+ * @see Constant
+ * @LastModified: Jan 2020
  */
 public final class ConstantUtf8 extends Constant {
 
-    private final String bytes;
+    private static class Cache {
 
-    // TODO these should perhaps be AtomicInt?
-    private static volatile int considered = 0;
-    private static volatile int hits = 0;
-    private static volatile int skipped = 0;
-    private static volatile int created = 0;
+        private static final boolean BCEL_STATISTICS = false;
+        private static final int MAX_ENTRIES = 20000;
+        private static final int INITIAL_CAPACITY = (int) (MAX_ENTRIES / 0.75);
 
-    // Set the size to 0 or below to skip caching entirely
-    private static final int MAX_CACHED_SIZE = 200;
-    private static final boolean BCEL_STATISTICS = false;
+        private static final HashMap<String, ConstantUtf8> CACHE = new LinkedHashMap<String, ConstantUtf8>(
+            INITIAL_CAPACITY, 0.75f, true) {
 
-
-    private static class CACHE_HOLDER {
-
-        private static final int MAX_CACHE_ENTRIES = 20000;
-        private static final int INITIAL_CACHE_CAPACITY = (int)(MAX_CACHE_ENTRIES/0.75);
-
-        private static final HashMap<String, ConstantUtf8> CACHE =
-                new LinkedHashMap<String, ConstantUtf8>(INITIAL_CACHE_CAPACITY, 0.75f, true) {
             private static final long serialVersionUID = -8506975356158971766L;
 
             @Override
             protected boolean removeEldestEntry(final Map.Entry<String, ConstantUtf8> eldest) {
-                 return size() > MAX_CACHE_ENTRIES;
+                return size() > MAX_ENTRIES;
             }
         };
 
-    }
+        // Set the size to 0 or below to skip caching entirely
+        private static final int MAX_ENTRY_SIZE = 200;
 
-    // for accesss by test code
-    static void printStats() {
-        System.err.println("Cache hit " + hits + "/" + considered +", " + skipped + " skipped");
-        System.err.println("Total of " + created + " ConstantUtf8 objects created");
-    }
-
-    // for accesss by test code
-    static void clearStats() {
-        hits = considered = skipped = created = 0;
-    }
-
-    static {
-        if (BCEL_STATISTICS) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    printStats();
-                }
-            });
+        static boolean isEnabled() {
+            return Cache.MAX_ENTRIES > 0 && MAX_ENTRY_SIZE > 0;
         }
+
     }
 
     /**
+     * Clears the cache.
+     *
+     * @since 6.4.0
+     */
+    public static synchronized void clearCache() {
+        Cache.CACHE.clear();
+    }
+
+    /**
+     * Gets a new or cached instance of the given value.
+     * <p>
+     * See {@link ConstantUtf8} class Javadoc for details.
+     * </p>
+     *
+     * @param value the value.
+     * @return a new or cached instance of the given value.
      * @since 6.0
      */
-    public static ConstantUtf8 getCachedInstance(final String s) {
-        if (s.length() > MAX_CACHED_SIZE) {
-            skipped++;
-            return  new ConstantUtf8(s);
+    public static ConstantUtf8 getCachedInstance(final String value) {
+        if (value.length() > Cache.MAX_ENTRY_SIZE) {
+            return new ConstantUtf8(value);
         }
-        considered++;
+
         synchronized (ConstantUtf8.class) { // might be better with a specific lock object
-            ConstantUtf8 result = CACHE_HOLDER.CACHE.get(s);
+            ConstantUtf8 result = Cache.CACHE.get(value);
             if (result != null) {
-                    hits++;
-                    return result;
-                }
-            result = new ConstantUtf8(s);
-            CACHE_HOLDER.CACHE.put(s, result);
+                return result;
+            }
+            result = new ConstantUtf8(value);
+            Cache.CACHE.put(value, result);
             return result;
         }
     }
 
     /**
-     * @since 6.0
-     */
-    public static ConstantUtf8 getInstance(final String s) {
-        return new ConstantUtf8(s);
-    }
-
-    /**
-     * @since 6.0
-     */
-    public static ConstantUtf8 getInstance (final DataInput input)  throws IOException {
-        return getInstance(input.readUTF());
-    }
-
-    /**
-     * Initialize from another object.
-     */
-    public ConstantUtf8(final ConstantUtf8 c) {
-        this(c.getBytes());
-    }
-
-
-    /**
-     * Initialize instance from file data.
+     * Gets a new or cached instance of the given value.
+     * <p>
+     * See {@link ConstantUtf8} class Javadoc for details.
+     * </p>
      *
-     * @param file Input stream
+     * @param dataInput the value.
+     * @return a new or cached instance of the given value.
+     * @throws IOException if an I/O error occurs.
+     * @since 6.0
+     */
+    public static ConstantUtf8 getInstance(final DataInput dataInput) throws IOException {
+        return getInstance(dataInput.readUTF());
+    }
+
+    /**
+     * Gets a new or cached instance of the given value.
+     * <p>
+     * See {@link ConstantUtf8} class Javadoc for details.
+     * </p>
+     *
+     * @param value the value.
+     * @return a new or cached instance of the given value.
+     * @since 6.0
+     */
+    public static ConstantUtf8 getInstance(final String value) {
+        return Cache.isEnabled() ? getCachedInstance(value) : new ConstantUtf8(value);
+    }
+
+    private final String value;
+
+    /**
+     * Initializes from another object.
+     *
+     * @param constantUtf8 the value.
+     */
+    public ConstantUtf8(final ConstantUtf8 constantUtf8) {
+        this(constantUtf8.getBytes());
+    }
+
+    /**
+     * Initializes instance from file data.
+     *
+     * @param dataInput Input stream
      * @throws IOException
      */
-    ConstantUtf8(final DataInput file) throws IOException {
+    ConstantUtf8(final DataInput dataInput) throws IOException {
         super(Const.CONSTANT_Utf8);
-        bytes = file.readUTF();
-        created++;
+        value = dataInput.readUTF();
     }
 
-
     /**
-     * @param bytes Data
+     * @param value Data
      */
-    public ConstantUtf8(final String bytes) {
+    public ConstantUtf8(final String value) {
         super(Const.CONSTANT_Utf8);
-        if (bytes == null) {
-            throw new IllegalArgumentException("bytes must not be null!");
+        if (value == null) {
+            throw new IllegalArgumentException("Value must not be null.");
         }
-        this.bytes = bytes;
-        created++;
+        this.value = value;
     }
 
-
     /**
-     * Called by objects that are traversing the nodes of the tree implicitely
-     * defined by the contents of a Java class. I.e., the hierarchy of methods,
-     * fields, attributes, etc. spawns a tree of objects.
+     * Called by objects that are traversing the nodes of the tree implicitely defined by the contents of a Java class.
+     * I.e., the hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
      *
      * @param v Visitor object
      */
     @Override
-    public void accept( final Visitor v ) {
+    public void accept(final Visitor v) {
         v.visitConstantUtf8(this);
     }
 
-
     /**
-     * Dump String in Utf8 format to file stream.
+     * Dumps String in Utf8 format to file stream.
      *
      * @param file Output file stream
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump(final DataOutputStream file) throws IOException {
         file.writeByte(super.getTag());
-        file.writeUTF(bytes);
+        file.writeUTF(value);
     }
-
 
     /**
      * @return Data converted to string.
      */
-    public final String getBytes() {
-        return bytes;
+    public String getBytes() {
+        return value;
     }
 
-
     /**
-     * @param bytes the raw bytes of this Utf-8
+     * @param bytes the raw bytes of this UTF-8
      * @deprecated (since 6.0)
      */
     @java.lang.Deprecated
-    public final void setBytes( final String bytes ) {
+    public void setBytes(final String bytes) {
         throw new UnsupportedOperationException();
     }
-
 
     /**
      * @return String representation
      */
     @Override
-    public final String toString() {
-        return super.toString() + "(\"" + Utility.replace(bytes, "\n", "\\n") + "\")";
+    public String toString() {
+        return super.toString() + "(\"" + Utility.replace(value, "\n", "\\n") + "\")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantValue.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * value, i.e., a default value for initializing a class field.
  * This class is instantiated by the <em>Attribute.readAttribute()</em> method.
  *
- * @version $Id$
  * @see     Attribute
  */
 public final class ConstantValue extends Attribute {
@@ -96,7 +95,7 @@ public final class ConstantValue extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(constantvalue_index);
     }
@@ -105,7 +104,7 @@ public final class ConstantValue extends Attribute {
     /**
      * @return Index in constant pool of constant value.
      */
-    public final int getConstantValueIndex() {
+    public int getConstantValueIndex() {
         return constantvalue_index;
     }
 
@@ -113,7 +112,7 @@ public final class ConstantValue extends Attribute {
     /**
      * @param constantvalue_index the index info the constant pool of this constant value
      */
-    public final void setConstantValueIndex( final int constantvalue_index ) {
+    public void setConstantValueIndex( final int constantvalue_index ) {
         this.constantvalue_index = constantvalue_index;
     }
 
@@ -122,7 +121,7 @@ public final class ConstantValue extends Attribute {
      * @return String representation of constant value.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         Constant c = super.getConstantPool().getConstant(constantvalue_index);
         String buf;
         int i;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Deprecated.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Deprecated.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * deprecated method.
  * It is instantiated from the <em>Attribute.readAttribute()</em> method.
  *
- * @version $Id$
  * @see     Attribute
  */
 public final class Deprecated extends Attribute {
@@ -75,7 +74,7 @@ public final class Deprecated extends Attribute {
         if (length > 0) {
             bytes = new byte[length];
             input.readFully(bytes);
-            System.err.println("Deprecated attribute with length > 0");
+            println("Deprecated attribute with length > 0");
         }
     }
 
@@ -100,7 +99,7 @@ public final class Deprecated extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         if (super.getLength() > 0) {
             file.write(bytes, 0, super.getLength());
@@ -111,7 +110,7 @@ public final class Deprecated extends Attribute {
     /**
      * @return data bytes.
      */
-    public final byte[] getBytes() {
+    public byte[] getBytes() {
         return bytes;
     }
 
@@ -119,7 +118,7 @@ public final class Deprecated extends Attribute {
     /**
      * @param bytes the raw bytes that represents this byte array
      */
-    public final void setBytes( final byte[] bytes ) {
+    public void setBytes( final byte[] bytes ) {
         this.bytes = bytes;
     }
 
@@ -128,7 +127,7 @@ public final class Deprecated extends Attribute {
      * @return attribute name
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return Const.getAttributeName(Const.ATTR_DEPRECATED);
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/DescendingVisitor.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/DescendingVisitor.java
@@ -26,7 +26,6 @@ import java.util.Stack;
  * applied to all components of a JavaClass object. I.e. this class supplies the
  * traversal strategy, other classes can make use of it.
  *
- * @version $Id$
  */
 public class DescendingVisitor implements Visitor
 {
@@ -503,6 +502,21 @@ public class DescendingVisitor implements Visitor
     {
         stack.push(obj);
         obj.accept(visitor);
+        final MethodParameter[] table = obj.getParameters();
+        for (final MethodParameter element : table) {
+            element.accept(this);
+        }
+        stack.pop();
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    @Override
+    public void visitMethodParameter(final MethodParameter obj)
+    {
+        stack.push(obj);
+        obj.accept(visitor);
         stack.pop();
     }
 
@@ -549,6 +563,94 @@ public class DescendingVisitor implements Visitor
     /** @since 6.3 */
     @Override
     public void visitConstantDynamic(final ConstantDynamic obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModule(final Module obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        final ModuleRequires[] rtable = obj.getRequiresTable();
+        for (final ModuleRequires element : rtable) {
+            element.accept(this);
+        }
+        final ModuleExports[] etable = obj.getExportsTable();
+        for (final ModuleExports element : etable) {
+            element.accept(this);
+        }
+        final ModuleOpens[] otable = obj.getOpensTable();
+        for (final ModuleOpens element : otable) {
+            element.accept(this);
+        }
+        final ModuleProvides[] ptable = obj.getProvidesTable();
+        for (final ModuleProvides element : ptable) {
+            element.accept(this);
+        }
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleRequires(final ModuleRequires obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleExports(final ModuleExports obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleOpens(final ModuleOpens obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleProvides(final ModuleProvides obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModulePackages(final ModulePackages obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleMainClass(final ModuleMainClass obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitNestHost(final NestHost obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitNestMembers(final NestMembers obj) {
         stack.push(obj);
         obj.accept(visitor);
         stack.pop();

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ElementValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ElementValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,9 +25,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
- * @version $Id: ElementValue
  * @since 6.0
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class ElementValue
 {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ElementValuePair.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ElementValuePair.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * an annotation's element value pair
  *
- * @version $Id: ElementValuePair
  * @since 6.0
  */
 public class ElementValuePair

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/EmptyVisitor.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/EmptyVisitor.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.classfile;
  * with the DescendingVisitor class, e.g. By courtesy of David Spencer.
  *
  * @see DescendingVisitor
- * @version $Id$
  */
 public class EmptyVisitor implements Visitor
 {
@@ -280,6 +279,14 @@ public class EmptyVisitor implements Visitor
     }
 
     /**
+     * @since 6.4.0
+     */
+    @Override
+    public void visitMethodParameter(final MethodParameter obj)
+    {
+    }
+
+    /**
      * @since 6.0
      */
     @Override
@@ -315,11 +322,55 @@ public class EmptyVisitor implements Visitor
     public void visitConstantModule(final ConstantModule constantModule) {
     }
 
-
     /**
      * @since 6.3
      */
     @Override
     public void visitConstantDynamic(final ConstantDynamic obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModule(final Module obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleRequires(final ModuleRequires obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleExports(final ModuleExports obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleOpens(final ModuleOpens obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleProvides(final ModuleProvides obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModulePackages(final ModulePackages obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitModuleMainClass(final ModuleMainClass obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitNestHost(final NestHost obj) {
+    }
+
+    /** @since 6.4.0 */
+    @Override
+    public void visitNestMembers(final NestMembers obj) {
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ExceptionTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ExceptionTable.java
@@ -35,7 +35,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * attribute using the name <em>Exceptions</em> (which is inconsistent
  * with the other classes).
  *
- * @version $Id$
  * @see     Code
  */
 public final class ExceptionTable extends Attribute {
@@ -103,7 +102,7 @@ public final class ExceptionTable extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(exception_index_table.length);
         for (final int index : exception_index_table) {
@@ -115,7 +114,7 @@ public final class ExceptionTable extends Attribute {
     /**
      * @return Array of indices into constant pool of thrown exceptions.
      */
-    public final int[] getExceptionIndexTable() {
+    public int[] getExceptionIndexTable() {
         return exception_index_table;
     }
 
@@ -123,7 +122,7 @@ public final class ExceptionTable extends Attribute {
     /**
      * @return Length of exception table.
      */
-    public final int getNumberOfExceptions() {
+    public int getNumberOfExceptions() {
         return exception_index_table == null ? 0 : exception_index_table.length;
     }
 
@@ -131,7 +130,7 @@ public final class ExceptionTable extends Attribute {
     /**
      * @return class names of thrown exceptions
      */
-    public final String[] getExceptionNames() {
+    public String[] getExceptionNames() {
         final String[] names = new String[exception_index_table.length];
         for (int i = 0; i < exception_index_table.length; i++) {
             names[i] = super.getConstantPool().getConstantString(exception_index_table[i],
@@ -145,7 +144,7 @@ public final class ExceptionTable extends Attribute {
      * @param exception_index_table the list of exception indexes
      * Also redefines number_of_exceptions according to table length.
      */
-    public final void setExceptionIndexTable( final int[] exception_index_table ) {
+    public void setExceptionIndexTable( final int[] exception_index_table ) {
         this.exception_index_table = exception_index_table != null ? exception_index_table : new int[0];
     }
 
@@ -154,7 +153,7 @@ public final class ExceptionTable extends Attribute {
      * @return String representation, i.e., a list of thrown exceptions.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder buf = new StringBuilder();
         String str;
         buf.append("Exceptions: ");

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Field.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Field.java
@@ -33,7 +33,6 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * This class represents the field info structure, i.e., the representation
  * for a variable in the class. See JVM specification for details.
  *
- * @version $Id$
  */
 public final class Field extends FieldOrMethod {
 
@@ -104,7 +103,7 @@ public final class Field extends FieldOrMethod {
     /**
      * @return constant value associated with this field (may be null)
      */
-    public final ConstantValue getConstantValue() {
+    public ConstantValue getConstantValue() {
         for (final Attribute attribute : super.getAttributes()) {
             if (attribute.getTag() == Const.ATTR_CONSTANT_VALUE) {
                 return (ConstantValue) attribute;
@@ -121,7 +120,7 @@ public final class Field extends FieldOrMethod {
      * @return String representation of field, including the signature.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         String name;
         String signature;
         String access; // Short cuts to constant pool
@@ -149,7 +148,7 @@ public final class Field extends FieldOrMethod {
     /**
      * @return deep copy of this field
      */
-    public final Field copy( final ConstantPool _constant_pool ) {
+    public Field copy( final ConstantPool _constant_pool ) {
         return (Field) copy_(_constant_pool);
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/FieldOrMethod.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/FieldOrMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -29,8 +29,7 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * Abstract super class for fields and methods.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class FieldOrMethod extends AccessFlags implements Cloneable, Node {
     private int name_index; // Points to field name in constant pool
@@ -69,7 +68,8 @@ public abstract class FieldOrMethod extends AccessFlags implements Cloneable, No
      * @deprecated (6.0) Use {@link #FieldOrMethod(java.io.DataInput, ConstantPool)} instead.
      */
     @java.lang.Deprecated
-    protected FieldOrMethod(final DataInputStream file, final ConstantPool constant_pool) throws IOException,
+    protected FieldOrMethod(final DataInputStream file, final ConstantPool constant_pool)
+            throws IOException,
             ClassFormatException {
         this((DataInput) file, constant_pool);
     }
@@ -80,8 +80,8 @@ public abstract class FieldOrMethod extends AccessFlags implements Cloneable, No
      * @throws IOException
      * @throws ClassFormatException
      */
-    protected FieldOrMethod(final DataInput file,
-            final ConstantPool constant_pool) throws IOException, ClassFormatException {
+    protected FieldOrMethod(final DataInput file, final ConstantPool constant_pool)
+            throws IOException, ClassFormatException {
         this(file.readUnsignedShort(), file.readUnsignedShort(), file.readUnsignedShort(), null,
                 constant_pool);
         final int attributes_count = file.readUnsignedShort();

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClass.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * indices of the inner and outer classes, the name and the attributes
  * of the inner class.
  *
- * @version $Id$
  * @see InnerClasses
  */
 public final class InnerClass implements Cloneable, Node {
@@ -97,7 +96,7 @@ public final class InnerClass implements Cloneable, Node {
      * @param file Output file stream
      * @throws IOException
      */
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeShort(inner_class_index);
         file.writeShort(outer_class_index);
         file.writeShort(inner_name_index);
@@ -108,7 +107,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @return access flags of inner class.
      */
-    public final int getInnerAccessFlags() {
+    public int getInnerAccessFlags() {
         return inner_access_flags;
     }
 
@@ -116,7 +115,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @return class index of inner class.
      */
-    public final int getInnerClassIndex() {
+    public int getInnerClassIndex() {
         return inner_class_index;
     }
 
@@ -124,7 +123,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @return name index of inner class.
      */
-    public final int getInnerNameIndex() {
+    public int getInnerNameIndex() {
         return inner_name_index;
     }
 
@@ -132,7 +131,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @return class index of outer class.
      */
-    public final int getOuterClassIndex() {
+    public int getOuterClassIndex() {
         return outer_class_index;
     }
 
@@ -140,7 +139,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @param inner_access_flags access flags for this inner class
      */
-    public final void setInnerAccessFlags( final int inner_access_flags ) {
+    public void setInnerAccessFlags( final int inner_access_flags ) {
         this.inner_access_flags = inner_access_flags;
     }
 
@@ -148,7 +147,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @param inner_class_index index into the constant pool for this class
      */
-    public final void setInnerClassIndex( final int inner_class_index ) {
+    public void setInnerClassIndex( final int inner_class_index ) {
         this.inner_class_index = inner_class_index;
     }
 
@@ -156,7 +155,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @param inner_name_index index into the constant pool for this class's name
      */
-    public final void setInnerNameIndex( final int inner_name_index ) { // TODO unused
+    public void setInnerNameIndex( final int inner_name_index ) { // TODO unused
         this.inner_name_index = inner_name_index;
     }
 
@@ -164,7 +163,7 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @param outer_class_index index into the constant pool for the owning class
      */
-    public final void setOuterClassIndex( final int outer_class_index ) { // TODO unused
+    public void setOuterClassIndex( final int outer_class_index ) { // TODO unused
         this.outer_class_index = outer_class_index;
     }
 
@@ -173,7 +172,7 @@ public final class InnerClass implements Cloneable, Node {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return "InnerClass(" + inner_class_index + ", " + outer_class_index + ", "
                 + inner_name_index + ", " + inner_access_flags + ")";
     }
@@ -182,16 +181,16 @@ public final class InnerClass implements Cloneable, Node {
     /**
      * @return Resolved string representation
      */
-    public final String toString( final ConstantPool constant_pool ) {
+    public String toString( final ConstantPool constant_pool ) {
         String outer_class_name;
         String inner_name;
         String inner_class_name = constant_pool.getConstantString(inner_class_index,
                 Const.CONSTANT_Class);
-        inner_class_name = Utility.compactClassName(inner_class_name);
+        inner_class_name = Utility.compactClassName(inner_class_name, false);
         if (outer_class_index != 0) {
             outer_class_name = constant_pool.getConstantString(outer_class_index,
                     Const.CONSTANT_Class);
-            outer_class_name = " of class " + Utility.compactClassName(outer_class_name);
+            outer_class_name = " of class " + Utility.compactClassName(outer_class_name, false);
         } else {
             outer_class_name = "";
         }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClasses.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClasses.java
@@ -33,7 +33,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * to the source file of this class.
  * It is instantiated from the <em>Attribute.readAttribute()</em> method.
  *
- * @version $Id$
  * @see     Attribute
  */
 public final class InnerClasses extends Attribute {
@@ -103,7 +102,7 @@ public final class InnerClasses extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(inner_classes.length);
         for (final InnerClass inner_class : inner_classes) {
@@ -115,7 +114,7 @@ public final class InnerClasses extends Attribute {
     /**
      * @return array of inner class "records"
      */
-    public final InnerClass[] getInnerClasses() {
+    public InnerClass[] getInnerClasses() {
         return inner_classes;
     }
 
@@ -123,7 +122,7 @@ public final class InnerClasses extends Attribute {
     /**
      * @param inner_classes the array of inner classes
      */
-    public final void setInnerClasses( final InnerClass[] inner_classes ) {
+    public void setInnerClasses( final InnerClass[] inner_classes ) {
         this.inner_classes = inner_classes != null ? inner_classes : new InnerClass[0];
     }
 
@@ -132,7 +131,7 @@ public final class InnerClasses extends Attribute {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder buf = new StringBuilder();
         buf.append("InnerClasses(");
         buf.append(inner_classes.length);
@@ -140,7 +139,7 @@ public final class InnerClasses extends Attribute {
         for (final InnerClass inner_class : inner_classes) {
             buf.append(inner_class.toString(super.getConstantPool())).append("\n");
         }
-        return buf.toString();
+        return buf.substring(0, buf.length()-1); // remove the last newline
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/JavaClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/JavaClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,16 +39,15 @@ import com.sun.org.apache.bcel.internal.util.ClassQueue;
 import com.sun.org.apache.bcel.internal.util.SyntheticRepository;
 
 /**
- * Represents a Java class, i.e., the data structures, constant pool, fields,
- * methods and commands contained in a Java .class file. See <a
- * href="http://docs.oracle.com/javase/specs/">JVM specification</a> for
- * details. The intent of this class is to represent a parsed or otherwise
- * existing class file. Those interested in programatically generating classes
+ * Represents a Java class, i.e., the data structures, constant pool,
+ * fields, methods and commands contained in a Java .class file.
+ * See <a href="http://docs.oracle.com/javase/specs/">JVM specification</a> for details.
+ * The intent of this class is to represent a parsed or otherwise existing
+ * class file.  Those interested in programatically generating classes
  * should see the <a href="../generic/ClassGen.html">ClassGen</a> class.
 
- * @version $Id$
  * @see com.sun.org.apache.bcel.internal.generic.ClassGen
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class JavaClass extends AccessFlags implements Cloneable, Node, Comparable<JavaClass> {
 
@@ -75,6 +74,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     public static final byte HEAP = 1;
     public static final byte FILE = 2;
     public static final byte ZIP = 3;
+    private static final boolean debug = false;
 
     private static BCELComparator bcelComparator = new BCELComparator() {
 
@@ -217,6 +217,16 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     public void accept( final Visitor v ) {
         v.visitJavaClass(this);
     }
+
+
+    /* Print debug information depending on `JavaClass.debug'
+     */
+    static void Debug( final String str ) {
+        if (debug) {
+            System.out.println(str);
+        }
+    }
+
 
     /**
      * Dump class to a file.
@@ -606,7 +616,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
             }
             buf.append('\n');
         }
-        buf.append("filename\t\t").append(file_name).append('\n');
+        buf.append("file name\t\t").append(file_name).append('\n');
         buf.append("compiled from\t\t").append(source_file_name).append('\n');
         buf.append("compiler version\t").append(major).append(".").append(minor).append('\n');
         buf.append("access flags\t\t").append(super.getAccessFlags()).append('\n');
@@ -716,7 +726,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
                       boolean innerClassAttributeRefersToMe = false;
                       String inner_class_name = constant_pool.getConstantString(innerClasse.getInnerClassIndex(),
                                  Const.CONSTANT_Class);
-                      inner_class_name = Utility.compactClassName(inner_class_name);
+                      inner_class_name = Utility.compactClassName(inner_class_name, false);
                       if (inner_class_name.equals(getClassName())) {
                           innerClassAttributeRefersToMe = true;
                       }
@@ -754,7 +764,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * Sets the ClassRepository which loaded the JavaClass.
      * Should be called immediately after parsing is done.
      */
-    public void setRepository(final com.sun.org.apache.bcel.internal.util.Repository repository) {
+    public void setRepository( final com.sun.org.apache.bcel.internal.util.Repository repository ) { // TODO make protected?
         this.repository = repository;
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumber.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumber.java
@@ -30,7 +30,6 @@ import java.io.IOException;
  * the source that corresponds to a relative address in the byte code. This
  * is used for debugging purposes.
  *
- * @version $Id$
  * @see     LineNumberTable
  */
 public final class LineNumber implements Cloneable, Node {
@@ -55,7 +54,7 @@ public final class LineNumber implements Cloneable, Node {
      * Construct object from file stream.
      *
      * @param file Input stream
-     * @throws IOEXception if an I/O Exception occurs in readUnsignedShort
+     * @throws IOException if an I/O Exception occurs in readUnsignedShort
      */
     LineNumber(final DataInput file) throws IOException {
         this(file.readUnsignedShort(), file.readUnsignedShort());
@@ -89,9 +88,9 @@ public final class LineNumber implements Cloneable, Node {
      * Dump line number/pc pair to file stream in binary format.
      *
      * @param file Output file stream
-     * @throws IOEXception if an I/O Exception occurs in writeShort
+     * @throws IOException if an I/O Exception occurs in writeShort
      */
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeShort(start_pc);
         file.writeShort(line_number);
     }
@@ -100,7 +99,7 @@ public final class LineNumber implements Cloneable, Node {
     /**
      * @return Corresponding source line
      */
-    public final int getLineNumber() {
+    public int getLineNumber() {
         return 0xffff & line_number;
     }
 
@@ -108,7 +107,7 @@ public final class LineNumber implements Cloneable, Node {
     /**
      * @return PC in code
      */
-    public final int getStartPC() {
+    public int getStartPC() {
         return  0xffff & start_pc;
     }
 
@@ -116,7 +115,7 @@ public final class LineNumber implements Cloneable, Node {
     /**
      * @param line_number the source line number
      */
-    public final void setLineNumber( final int line_number ) {
+    public void setLineNumber( final int line_number ) {
         this.line_number = (short) line_number;
     }
 
@@ -124,7 +123,7 @@ public final class LineNumber implements Cloneable, Node {
     /**
      * @param start_pc the pc for this line number
      */
-    public final void setStartPC( final int start_pc ) {
+    public void setStartPC( final int start_pc ) {
         this.start_pc = (short) start_pc;
     }
 
@@ -133,7 +132,7 @@ public final class LineNumber implements Cloneable, Node {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return "LineNumber(" + start_pc + ", " + line_number + ")";
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumberTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumberTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,10 +30,9 @@ import jdk.xml.internal.SecuritySupport;
  * purposes. This attribute is used by the <em>Code</em> attribute. It
  * contains pairs of PCs and line numbers.
  *
- * @version $Id$
  * @see     Code
  * @see LineNumber
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public final class LineNumberTable extends Attribute {
 
@@ -68,7 +67,7 @@ public final class LineNumberTable extends Attribute {
      * @param length Content length in bytes
      * @param input Input stream
      * @param constant_pool Array of constants
-     * @throws IOEXception if an I/O Exception occurs in readUnsignedShort
+     * @throws IOException if an I/O Exception occurs in readUnsignedShort
      */
     LineNumberTable(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool)
             throws IOException {
@@ -96,10 +95,10 @@ public final class LineNumberTable extends Attribute {
      * Dump line number table attribute to file stream in binary format.
      *
      * @param file Output file stream
-     * @throws IOEXception if an I/O Exception occurs in writeShort
+     * @throws IOException if an I/O Exception occurs in writeShort
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(line_number_table.length);
         for (final LineNumber lineNumber : line_number_table) {
@@ -110,14 +109,14 @@ public final class LineNumberTable extends Attribute {
     /**
      * @return Array of (pc offset, line number) pairs.
      */
-    public final LineNumber[] getLineNumberTable() {
+    public LineNumber[] getLineNumberTable() {
         return line_number_table;
     }
 
     /**
      * @param line_number_table the line number entries for this table
      */
-    public final void setLineNumberTable( final LineNumber[] line_number_table ) {
+    public void setLineNumberTable( final LineNumber[] line_number_table ) {
         this.line_number_table = line_number_table;
     }
 
@@ -125,7 +124,7 @@ public final class LineNumberTable extends Attribute {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder buf = new StringBuilder();
         final StringBuilder line = new StringBuilder();
 
@@ -161,7 +160,7 @@ public final class LineNumberTable extends Attribute {
         /* Do a binary search since the array is ordered.
          */
         do {
-            final int i = (l + r) / 2;
+            final int i = (l + r) >>> 1;
             final int j = line_number_table[i].getStartPC();
             if (j == pos) {
                 return line_number_table[i].getLineNumber();
@@ -204,7 +203,7 @@ public final class LineNumberTable extends Attribute {
         return c;
     }
 
-    public final int getTableLength() {
+    public int getTableLength() {
         return line_number_table == null ? 0 : line_number_table.length;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariable.java
@@ -28,19 +28,27 @@ import com.sun.org.apache.bcel.internal.Const;
 
 /**
  * This class represents a local variable within a method. It contains its
- * scope, name, signature and index on the method's frame.
+ * scope, name, signature and index on the method's frame.  It is used both
+ * to represent an element of the LocalVariableTable as well as an element
+ * of the LocalVariableTypeTable.  The nomenclature used here may be a bit confusing;
+ * while the two items have the same layout in a class file, a LocalVariableTable
+ * attribute contains a descriptor_index, not a signature_index.  The
+ * LocalVariableTypeTable attribute does have a signature_index.
+ * @see com.sun.org.apache.bcel.internal.classfile.Utility for more details on the difference.
  *
- * @version $Id$
  * @see     LocalVariableTable
- * @LastModified: Jun 2019
+ * @see     LocalVariableTypeTable
+ * @LastModified: Jan 2020
  */
 public final class LocalVariable implements Cloneable, Node {
 
     private int start_pc; // Range in which the variable is valid
     private int length;
     private int name_index; // Index in constant pool of variable name
+    // Technically, a decscriptor_index for a local variable table entry
+    // and a signature_index for a local variable type table entry.
     private int signature_index; // Index of variable signature
-    private int index; /* Variable is `index'th local variable on
+    private int index; /* Variable is index'th local variable on
      * this method's frame.
      */
     private ConstantPool constant_pool;
@@ -48,18 +56,19 @@ public final class LocalVariable implements Cloneable, Node {
 
 
     /**
-     * Initialize from another object. Note that both objects use the same
+     * Initializes from another LocalVariable. Note that both objects use the same
      * references (shallow copy). Use copy() for a physical copy.
+     *
+     * @param localVariable Another LocalVariable.
      */
-    public LocalVariable(final LocalVariable c) {
-        this(c.getStartPC(), c.getLength(), c.getNameIndex(), c.getSignatureIndex(), c.getIndex(),
-                c.getConstantPool());
-        this.orig_index = c.getOrigIndex();
+    public LocalVariable(final LocalVariable localVariable) {
+        this(localVariable.getStartPC(), localVariable.getLength(), localVariable.getNameIndex(),
+                localVariable.getSignatureIndex(), localVariable.getIndex(), localVariable.getConstantPool());
+        this.orig_index = localVariable.getOrigIndex();
     }
 
-
     /**
-     * Construct object from file stream.
+     * Constructs object from file stream.
      * @param file Input stream
      * @throws IOException
      */
@@ -124,24 +133,24 @@ public final class LocalVariable implements Cloneable, Node {
 
 
     /**
-     * Dump local variable to file stream in binary format.
+     * Dumps local variable to file stream in binary format.
      *
-     * @param file Output file stream
-     * @throws IOException
+     * @param dataOutputStream Output file stream
+     * @exception IOException if an I/O error occurs.
+     * @see java.io.FilterOutputStream#out
      */
-    public final void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(start_pc);
-        file.writeShort(length);
-        file.writeShort(name_index);
-        file.writeShort(signature_index);
-        file.writeShort(index);
+    public void dump(final DataOutputStream dataOutputStream) throws IOException {
+        dataOutputStream.writeShort(start_pc);
+        dataOutputStream.writeShort(length);
+        dataOutputStream.writeShort(name_index);
+        dataOutputStream.writeShort(signature_index);
+        dataOutputStream.writeShort(index);
     }
-
 
     /**
      * @return Constant pool used by this object.
      */
-    public final ConstantPool getConstantPool() {
+    public ConstantPool getConstantPool() {
         return constant_pool;
     }
 
@@ -149,7 +158,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @return Variable is valid within getStartPC() .. getStartPC()+getLength()
      */
-    public final int getLength() {
+    public int getLength() {
         return length;
     }
 
@@ -157,7 +166,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @return Variable name.
      */
-    public final String getName() {
+    public String getName() {
         ConstantUtf8 c;
         c = (ConstantUtf8) constant_pool.getConstant(name_index, Const.CONSTANT_Utf8);
         return c.getBytes();
@@ -167,7 +176,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @return Index in constant pool of variable name.
      */
-    public final int getNameIndex() {
+    public int getNameIndex() {
         return name_index;
     }
 
@@ -175,7 +184,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @return Signature.
      */
-    public final String getSignature() {
+    public String getSignature() {
         ConstantUtf8 c;
         c = (ConstantUtf8) constant_pool.getConstant(signature_index, Const.CONSTANT_Utf8);
         return c.getBytes();
@@ -185,7 +194,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @return Index in constant pool of variable signature.
      */
-    public final int getSignatureIndex() {
+    public int getSignatureIndex() {
         return signature_index;
     }
 
@@ -193,7 +202,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @return index of register where variable is stored
      */
-    public final int getIndex() {
+    public int getIndex() {
         return index;
     }
 
@@ -201,15 +210,15 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @return index of register where variable was originally stored
      */
-    public final int getOrigIndex() {
+    public int getOrigIndex() {
         return orig_index;
     }
 
 
     /**
-     * @return Start of range where he variable is valid
+     * @return Start of range where the variable is valid
      */
-    public final int getStartPC() {
+    public int getStartPC() {
         return start_pc;
     }
 
@@ -217,7 +226,7 @@ public final class LocalVariable implements Cloneable, Node {
     /*
      * Helper method shared with LocalVariableTypeTable
      */
-    final String toStringShared( final boolean typeTable ) {
+    String toStringShared( final boolean typeTable ) {
         final String name = getName();
         final String signature = Utility.signatureToString(getSignature(), false);
         final String label = "LocalVariable" + (typeTable ? "Types" : "" );
@@ -229,7 +238,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @param constant_pool Constant pool to be used for this object.
      */
-    public final void setConstantPool( final ConstantPool constant_pool ) {
+    public void setConstantPool( final ConstantPool constant_pool ) {
         this.constant_pool = constant_pool;
     }
 
@@ -237,7 +246,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @param length the length of this local variable
      */
-    public final void setLength( final int length ) {
+    public void setLength( final int length ) {
         this.length = length;
     }
 
@@ -245,7 +254,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @param name_index the index into the constant pool for the name of this variable
      */
-    public final void setNameIndex( final int name_index ) { // TODO unused
+    public void setNameIndex( final int name_index ) { // TODO unused
         this.name_index = name_index;
     }
 
@@ -253,7 +262,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @param signature_index the index into the constant pool for the signature of this variable
      */
-    public final void setSignatureIndex( final int signature_index ) { // TODO unused
+    public void setSignatureIndex( final int signature_index ) { // TODO unused
         this.signature_index = signature_index;
     }
 
@@ -261,7 +270,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @param index the index in the local variable table of this variable
      */
-    public final void setIndex( final int index ) { // TODO unused
+    public void setIndex( final int index ) { // TODO unused
         this.index = index;
     }
 
@@ -269,7 +278,7 @@ public final class LocalVariable implements Cloneable, Node {
     /**
      * @param start_pc Specify range where the local variable is valid.
      */
-    public final void setStartPC( final int start_pc ) { // TODO unused
+    public void setStartPC( final int start_pc ) { // TODO unused
         this.start_pc = start_pc;
     }
 
@@ -278,7 +287,7 @@ public final class LocalVariable implements Cloneable, Node {
      * @return string representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return toStringShared(false);
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariableTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariableTable.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class represents colection of local variables in a
  * method. This attribute is contained in the <em>Code</em> attribute.
  *
- * @version $Id$
  * @see     Code
  * @see LocalVariable
  */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Method.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Method.java
@@ -33,7 +33,6 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * for a method in the class. See JVM specification for details.
  * A method has access flags, a name, a signature and a number of attributes.
  *
- * @version $Id$
  */
 public final class Method extends FieldOrMethod {
 
@@ -116,7 +115,7 @@ public final class Method extends FieldOrMethod {
     /**
      * @return Code attribute of method, if any
      */
-    public final Code getCode() {
+    public Code getCode() {
         for (final Attribute attribute : super.getAttributes()) {
             if (attribute instanceof Code) {
                 return (Code) attribute;
@@ -130,7 +129,7 @@ public final class Method extends FieldOrMethod {
      * @return ExceptionTable attribute of method, if any, i.e., list all
      * exceptions the method may throw not exception handlers!
      */
-    public final ExceptionTable getExceptionTable() {
+    public ExceptionTable getExceptionTable() {
         for (final Attribute attribute : super.getAttributes()) {
             if (attribute instanceof ExceptionTable) {
                 return (ExceptionTable) attribute;
@@ -143,7 +142,7 @@ public final class Method extends FieldOrMethod {
     /** @return LocalVariableTable of code attribute if any, i.e. the call is forwarded
      * to the Code atribute.
      */
-    public final LocalVariableTable getLocalVariableTable() {
+    public LocalVariableTable getLocalVariableTable() {
         final Code code = getCode();
         if (code == null) {
             return null;
@@ -155,7 +154,7 @@ public final class Method extends FieldOrMethod {
     /** @return LineNumberTable of code attribute if any, i.e. the call is forwarded
      * to the Code atribute.
      */
-    public final LineNumberTable getLineNumberTable() {
+    public LineNumberTable getLineNumberTable() {
         final Code code = getCode();
         if (code == null) {
             return null;
@@ -171,7 +170,7 @@ public final class Method extends FieldOrMethod {
      * @return String representation of the method.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final String access = Utility.accessToString(super.getAccessFlags());
         // Get name and signature from constant pool
         ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(super.getSignatureIndex(), Const.CONSTANT_Utf8);
@@ -200,7 +199,7 @@ public final class Method extends FieldOrMethod {
     /**
      * @return deep copy of this method
      */
-    public final Method copy( final ConstantPool _constant_pool ) {
+    public Method copy( final ConstantPool _constant_pool ) {
         return (Method) copy_(_constant_pool);
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/MethodParameter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/MethodParameter.java
@@ -95,6 +95,10 @@ public class MethodParameter implements Cloneable {
         return (access_flags & Const.ACC_MANDATED) != 0;
     }
 
+    public void accept(final Visitor v) {
+        v.visitMethodParameter(this);
+    }
+
     /**
      * Dump object to file stream on binary format.
      *

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Module.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Module.java
@@ -1,0 +1,261 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class is derived from <em>Attribute</em> and represents the list of modules required, exported, opened or provided by a module.
+ * There may be at most one Module attribute in a ClassFile structure.
+ *
+ * @see   Attribute
+ * @since 6.4.0
+ */
+public final class Module extends Attribute {
+
+    private final int module_name_index;
+    private final int module_flags;
+    private final int module_version_index;
+
+    private ModuleRequires[] requires_table;
+    private ModuleExports[] exports_table;
+    private ModuleOpens[] opens_table;
+    private final int uses_count;
+    private final int[] uses_index;
+    private ModuleProvides[] provides_table;
+
+    /**
+     * Construct object from input stream.
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param input Input stream
+     * @param constant_pool Array of constants
+     * @throws IOException
+     */
+    Module(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
+        super(Const.ATTR_MODULE, name_index, length, constant_pool);
+
+        module_name_index = input.readUnsignedShort();
+        module_flags = input.readUnsignedShort();
+        module_version_index = input.readUnsignedShort();
+
+        final int requires_count = input.readUnsignedShort();
+        requires_table = new ModuleRequires[requires_count];
+        for (int i = 0; i < requires_count; i++) {
+            requires_table[i] = new ModuleRequires(input);
+        }
+
+        final int exports_count = input.readUnsignedShort();
+        exports_table = new ModuleExports[exports_count];
+        for (int i = 0; i < exports_count; i++) {
+            exports_table[i] = new ModuleExports(input);
+        }
+
+        final int opens_count = input.readUnsignedShort();
+        opens_table = new ModuleOpens[opens_count];
+        for (int i = 0; i < opens_count; i++) {
+            opens_table[i] = new ModuleOpens(input);
+        }
+
+        uses_count = input.readUnsignedShort();
+        uses_index = new int[uses_count];
+        for (int i = 0; i < uses_count; i++) {
+            uses_index[i] = input.readUnsignedShort();
+        }
+
+        final int provides_count = input.readUnsignedShort();
+        provides_table = new ModuleProvides[provides_count];
+        for (int i = 0; i < provides_count; i++) {
+            provides_table[i] = new ModuleProvides(input);
+        }
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitModule(this);
+    }
+
+    // TODO add more getters and setters?
+
+    /**
+     * @return table of required modules
+     * @see ModuleRequires
+     */
+    public ModuleRequires[] getRequiresTable() {
+        return requires_table;
+    }
+
+
+    /**
+     * @return table of exported interfaces
+     * @see ModuleExports
+     */
+    public ModuleExports[] getExportsTable() {
+        return exports_table;
+    }
+
+
+    /**
+     * @return table of provided interfaces
+     * @see ModuleOpens
+     */
+    public ModuleOpens[] getOpensTable() {
+        return opens_table;
+    }
+
+
+    /**
+     * @return table of provided interfaces
+     * @see ModuleProvides
+     */
+    public ModuleProvides[] getProvidesTable() {
+        return provides_table;
+    }
+
+
+    /**
+     * Dump Module attribute to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException
+     */
+    @Override
+    public void dump( final DataOutputStream file ) throws IOException {
+        super.dump(file);
+
+        file.writeShort(module_name_index);
+        file.writeShort(module_flags);
+        file.writeShort(module_version_index);
+
+        file.writeShort(requires_table.length);
+        for (final ModuleRequires entry : requires_table) {
+            entry.dump(file);
+        }
+
+        file.writeShort(exports_table.length);
+        for (final ModuleExports entry : exports_table) {
+            entry.dump(file);
+        }
+
+        file.writeShort(opens_table.length);
+        for (final ModuleOpens entry : opens_table) {
+            entry.dump(file);
+        }
+
+        file.writeShort(uses_index.length);
+        for (final int entry : uses_index) {
+            file.writeShort(entry);
+        }
+
+        file.writeShort(provides_table.length);
+        for (final ModuleProvides entry : provides_table) {
+            entry.dump(file);
+        }
+    }
+
+
+    /**
+     * @return String representation, i.e., a list of packages.
+     */
+    @Override
+    public String toString() {
+        final ConstantPool cp = super.getConstantPool();
+        final StringBuilder buf = new StringBuilder();
+        buf.append("Module:\n");
+        buf.append("  name:    ") .append(cp.getConstantString(module_name_index, Const.CONSTANT_Module).replace('/', '.')).append("\n");
+        buf.append("  flags:   ") .append(String.format("%04x", module_flags)).append("\n");
+        final String version = module_version_index == 0 ? "0" : cp.getConstantString(module_version_index, Const.CONSTANT_Utf8);
+        buf.append("  version: ") .append(version).append("\n");
+
+        buf.append("  requires(").append(requires_table.length).append("):\n");
+        for (final ModuleRequires module : requires_table) {
+            buf.append("    ").append(module.toString(cp)).append("\n");
+        }
+
+        buf.append("  exports(").append(exports_table.length).append("):\n");
+        for (final ModuleExports module : exports_table) {
+            buf.append("    ").append(module.toString(cp)).append("\n");
+        }
+
+        buf.append("  opens(").append(opens_table.length).append("):\n");
+        for (final ModuleOpens module : opens_table) {
+            buf.append("    ").append(module.toString(cp)).append("\n");
+        }
+
+        buf.append("  uses(").append(uses_index.length).append("):\n");
+        for (final int index : uses_index) {
+            final String class_name = cp.getConstantString(index, Const.CONSTANT_Class);
+            buf.append("    ").append(Utility.compactClassName(class_name, false)).append("\n");
+        }
+
+        buf.append("  provides(").append(provides_table.length).append("):\n");
+        for (final ModuleProvides module : provides_table) {
+            buf.append("    ").append(module.toString(cp)).append("\n");
+        }
+
+        return buf.substring(0, buf.length()-1); // remove the last newline
+    }
+
+
+    /**
+     * @return deep copy of this attribute
+     */
+    @Override
+    public Attribute copy( final ConstantPool _constant_pool ) {
+        final Module c = (Module) clone();
+
+        c.requires_table = new ModuleRequires[requires_table.length];
+        for (int i = 0; i < requires_table.length; i++) {
+            c.requires_table[i] = requires_table[i].copy();
+        }
+
+        c.exports_table = new ModuleExports[exports_table.length];
+        for (int i = 0; i < exports_table.length; i++) {
+            c.exports_table[i] = exports_table[i].copy();
+        }
+
+        c.opens_table = new ModuleOpens[opens_table.length];
+        for (int i = 0; i < opens_table.length; i++) {
+            c.opens_table[i] = opens_table[i].copy();
+        }
+
+        c.provides_table = new ModuleProvides[provides_table.length];
+        for (int i = 0; i < provides_table.length; i++) {
+            c.provides_table[i] = provides_table[i].copy();
+        }
+
+        c.setConstantPool(_constant_pool);
+        return c;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleExports.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleExports.java
@@ -1,0 +1,129 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class represents an entry in the exports table of the Module attribute.
+ * Each entry describes a package which may open the parent module.
+ *
+ * @see   Module
+ * @since 6.4.0
+ */
+public final class ModuleExports implements Cloneable, Node {
+
+    private final int exports_index;  // points to CONSTANT_Package_info
+    private final int exports_flags;
+    private final int exports_to_count;
+    private final int[] exports_to_index;  // points to CONSTANT_Module_info
+
+
+    /**
+     * Construct object from file stream.
+     *
+     * @param file Input stream
+     * @throws IOException if an I/O Exception occurs in readUnsignedShort
+     */
+    ModuleExports(final DataInput file) throws IOException {
+        exports_index = file.readUnsignedShort();
+        exports_flags = file.readUnsignedShort();
+        exports_to_count = file.readUnsignedShort();
+        exports_to_index = new int[exports_to_count];
+        for (int i = 0; i < exports_to_count; i++) {
+            exports_to_index[i] = file.readUnsignedShort();
+        }
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitModuleExports(this);
+    }
+
+    // TODO add more getters and setters?
+
+    /**
+     * Dump table entry to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException if an I/O Exception occurs in writeShort
+     */
+    public void dump( final DataOutputStream file ) throws IOException {
+        file.writeShort(exports_index);
+        file.writeShort(exports_flags);
+        file.writeShort(exports_to_count);
+        for (final int entry : exports_to_index) {
+            file.writeShort(entry);
+        }
+    }
+
+
+    /**
+     * @return String representation
+     */
+    @Override
+    public String toString() {
+        return "exports(" + exports_index + ", " + exports_flags + ", " + exports_to_count + ", ...)";
+    }
+
+
+    /**
+     * @return Resolved string representation
+     */
+    public String toString( final ConstantPool constant_pool ) {
+        final StringBuilder buf = new StringBuilder();
+        final String package_name = constant_pool.constantToString(exports_index, Const.CONSTANT_Package);
+        buf.append(Utility.compactClassName(package_name, false));
+        buf.append(", ").append(String.format("%04x", exports_flags));
+        buf.append(", to(").append(exports_to_count).append("):\n");
+        for (final int index : exports_to_index) {
+            final String module_name = constant_pool.getConstantString(index, Const.CONSTANT_Module);
+            buf.append("      ").append(Utility.compactClassName(module_name, false)).append("\n");
+        }
+        return buf.substring(0, buf.length()-1); // remove the last newline
+    }
+
+
+    /**
+     * @return deep copy of this object
+     */
+    public ModuleExports copy() {
+        try {
+            return (ModuleExports) clone();
+        } catch (final CloneNotSupportedException e) {
+            // TODO should this throw?
+        }
+        return null;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleMainClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleMainClass.java
@@ -1,0 +1,141 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class is derived from <em>Attribute</em> and indicates the main class of a module.
+ * There may be at most one ModuleMainClass attribute in a ClassFile structure.
+ *
+ * @see     Attribute
+ */
+public final class ModuleMainClass extends Attribute {
+
+    private int main_class_index;
+
+
+    /**
+     * Initialize from another object. Note that both objects use the same
+     * references (shallow copy). Use copy() for a physical copy.
+     */
+    public ModuleMainClass(final ModuleMainClass c) {
+        this(c.getNameIndex(), c.getLength(), c.getHostClassIndex(), c.getConstantPool());
+    }
+
+
+    /**
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param main_class_index Host class index
+     * @param constant_pool Array of constants
+     */
+    public ModuleMainClass(final int name_index, final int length, final int main_class_index,
+            final ConstantPool constant_pool) {
+        super(Const.ATTR_NEST_MEMBERS, name_index, length, constant_pool);
+        this.main_class_index = main_class_index;
+    }
+
+
+    /**
+     * Construct object from input stream.
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param input Input stream
+     * @param constant_pool Array of constants
+     * @throws IOException
+     */
+    ModuleMainClass(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
+        this(name_index, length, 0, constant_pool);
+        main_class_index = input.readUnsignedShort();
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitly
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitModuleMainClass(this);
+    }
+
+
+    /**
+     * Dump ModuleMainClass attribute to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException if an I/O error occurs.
+     */
+    @Override
+    public void dump( final DataOutputStream file ) throws IOException {
+        super.dump(file);
+        file.writeShort(main_class_index);
+    }
+
+
+    /**
+     * @return index into constant pool of host class name.
+     */
+    public int getHostClassIndex() {
+        return main_class_index;
+    }
+
+
+    /**
+     * @param main_class_index the host class index
+     */
+    public void setHostClassIndex( final int main_class_index ) {
+        this.main_class_index = main_class_index;
+    }
+
+
+    /**
+     * @return String representation
+     */
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("ModuleMainClass: ");
+        final String class_name = super.getConstantPool().getConstantString(main_class_index, Const.CONSTANT_Class);
+        buf.append(Utility.compactClassName(class_name, false));
+        return buf.toString();
+    }
+
+
+    /**
+     * @return deep copy of this attribute
+     */
+    @Override
+    public Attribute copy( final ConstantPool _constant_pool ) {
+        final ModuleMainClass c = (ModuleMainClass) clone();
+        c.setConstantPool(_constant_pool);
+        return c;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleOpens.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleOpens.java
@@ -1,0 +1,129 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class represents an entry in the opens table of the Module attribute.
+ * Each entry describes a package which the parent module opens.
+ *
+ * @see   Module
+ * @since 6.4.0
+ */
+public final class ModuleOpens implements Cloneable, Node {
+
+    private final int opens_index;  // points to CONSTANT_Package_info
+    private final int opens_flags;
+    private final int opens_to_count;
+    private final int[] opens_to_index;  // points to CONSTANT_Module_info
+
+
+    /**
+     * Construct object from file stream.
+     *
+     * @param file Input stream
+     * @throws IOException if an I/O Exception occurs in readUnsignedShort
+     */
+    ModuleOpens(final DataInput file) throws IOException {
+        opens_index = file.readUnsignedShort();
+        opens_flags = file.readUnsignedShort();
+        opens_to_count = file.readUnsignedShort();
+        opens_to_index = new int[opens_to_count];
+        for (int i = 0; i < opens_to_count; i++) {
+            opens_to_index[i] = file.readUnsignedShort();
+        }
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitModuleOpens(this);
+    }
+
+    // TODO add more getters and setters?
+
+    /**
+     * Dump table entry to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException if an I/O Exception occurs in writeShort
+     */
+    public void dump( final DataOutputStream file ) throws IOException {
+        file.writeShort(opens_index);
+        file.writeShort(opens_flags);
+        file.writeShort(opens_to_count);
+        for (final int entry : opens_to_index) {
+            file.writeShort(entry);
+        }
+    }
+
+
+    /**
+     * @return String representation
+     */
+    @Override
+    public String toString() {
+        return "opens(" + opens_index + ", " + opens_flags + ", " + opens_to_count + ", ...)";
+    }
+
+
+    /**
+     * @return Resolved string representation
+     */
+    public String toString( final ConstantPool constant_pool ) {
+        final StringBuilder buf = new StringBuilder();
+        final String package_name = constant_pool.constantToString(opens_index, Const.CONSTANT_Package);
+        buf.append(Utility.compactClassName(package_name, false));
+        buf.append(", ").append(String.format("%04x", opens_flags));
+        buf.append(", to(").append(opens_to_count).append("):\n");
+        for (final int index : opens_to_index) {
+            final String module_name = constant_pool.getConstantString(index, Const.CONSTANT_Module);
+            buf.append("      ").append(Utility.compactClassName(module_name, false)).append("\n");
+        }
+        return buf.substring(0, buf.length()-1); // remove the last newline
+    }
+
+
+    /**
+     * @return deep copy of this object
+     */
+    public ModuleOpens copy() {
+        try {
+            return (ModuleOpens) clone();
+        } catch (final CloneNotSupportedException e) {
+            // TODO should this throw?
+        }
+        return null;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModulePackages.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModulePackages.java
@@ -1,0 +1,179 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class is derived from <em>Attribute</em> and represents the list of packages that are exported or opened by the Module attribute.
+ * There may be at most one ModulePackages attribute in a ClassFile structure.
+ *
+ * @see     Attribute
+ */
+public final class ModulePackages extends Attribute {
+
+    private int[] package_index_table;
+
+
+    /**
+     * Initialize from another object. Note that both objects use the same
+     * references (shallow copy). Use copy() for a physical copy.
+     */
+    public ModulePackages(final ModulePackages c) {
+        this(c.getNameIndex(), c.getLength(), c.getPackageIndexTable(), c.getConstantPool());
+    }
+
+
+    /**
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param package_index_table Table of indices in constant pool
+     * @param constant_pool Array of constants
+     */
+    public ModulePackages(final int name_index, final int length, final int[] package_index_table,
+            final ConstantPool constant_pool) {
+        super(Const.ATTR_MODULE_PACKAGES, name_index, length, constant_pool);
+        this.package_index_table = package_index_table != null ? package_index_table : new int[0];
+    }
+
+
+    /**
+     * Construct object from input stream.
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param input Input stream
+     * @param constant_pool Array of constants
+     * @throws IOException
+     */
+    ModulePackages(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
+        this(name_index, length, (int[]) null, constant_pool);
+        final int number_of_packages = input.readUnsignedShort();
+        package_index_table = new int[number_of_packages];
+        for (int i = 0; i < number_of_packages; i++) {
+            package_index_table[i] = input.readUnsignedShort();
+        }
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitModulePackages(this);
+    }
+
+
+    /**
+     * Dump ModulePackages attribute to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException
+     */
+    @Override
+    public void dump( final DataOutputStream file ) throws IOException {
+        super.dump(file);
+        file.writeShort(package_index_table.length);
+        for (final int index : package_index_table) {
+            file.writeShort(index);
+        }
+    }
+
+
+    /**
+     * @return array of indices into constant pool of package names.
+     */
+    public int[] getPackageIndexTable() {
+        return package_index_table;
+    }
+
+
+    /**
+     * @return Length of package table.
+     */
+    public int getNumberOfPackages() {
+        return package_index_table == null ? 0 : package_index_table.length;
+    }
+
+
+    /**
+     * @return string array of package names
+     */
+    public String[] getPackageNames() {
+        final String[] names = new String[package_index_table.length];
+        for (int i = 0; i < package_index_table.length; i++) {
+            names[i] = super.getConstantPool().getConstantString(package_index_table[i],
+                    Const.CONSTANT_Package).replace('/', '.');
+        }
+        return names;
+    }
+
+
+    /**
+     * @param package_index_table the list of package indexes
+     * Also redefines number_of_packages according to table length.
+     */
+    public void setPackageIndexTable( final int[] package_index_table ) {
+        this.package_index_table = package_index_table != null ? package_index_table : new int[0];
+    }
+
+
+    /**
+     * @return String representation, i.e., a list of packages.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("ModulePackages(");
+        buf.append(package_index_table.length);
+        buf.append("):\n");
+        for (final int index : package_index_table) {
+            final String package_name = super.getConstantPool().getConstantString(index, Const.CONSTANT_Package);
+            buf.append("  ").append(Utility.compactClassName(package_name, false)).append("\n");
+        }
+        return buf.substring(0, buf.length()-1); // remove the last newline
+    }
+
+
+    /**
+     * @return deep copy of this attribute
+     */
+    @Override
+    public Attribute copy( final ConstantPool _constant_pool ) {
+        final ModulePackages c = (ModulePackages) clone();
+        if (package_index_table != null) {
+            c.package_index_table = new int[package_index_table.length];
+            System.arraycopy(package_index_table, 0, c.package_index_table, 0,
+                    package_index_table.length);
+        }
+        c.setConstantPool(_constant_pool);
+        return c;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleProvides.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleProvides.java
@@ -1,0 +1,125 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class represents an entry in the provides table of the Module attribute.
+ * Each entry describes a service implementation that the parent module provides.
+ *
+ * @see   Module
+ * @since 6.4.0
+ */
+public final class ModuleProvides implements Cloneable, Node {
+
+    private final int provides_index;  // points to CONSTANT_Class_info
+    private final int provides_with_count;
+    private final int[] provides_with_index;  // points to CONSTANT_Class_info
+
+
+    /**
+     * Construct object from file stream.
+     *
+     * @param file Input stream
+     * @throws IOException if an I/O Exception occurs in readUnsignedShort
+     */
+    ModuleProvides(final DataInput file) throws IOException {
+        provides_index = file.readUnsignedShort();
+        provides_with_count = file.readUnsignedShort();
+        provides_with_index = new int[provides_with_count];
+        for (int i = 0; i < provides_with_count; i++) {
+            provides_with_index[i] = file.readUnsignedShort();
+        }
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitModuleProvides(this);
+    }
+
+    // TODO add more getters and setters?
+
+    /**
+     * Dump table entry to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException if an I/O Exception occurs in writeShort
+     */
+    public void dump( final DataOutputStream file ) throws IOException {
+        file.writeShort(provides_index);
+        file.writeShort(provides_with_count);
+        for (final int entry : provides_with_index) {
+            file.writeShort(entry);
+        }
+    }
+
+
+    /**
+     * @return String representation
+     */
+    @Override
+    public String toString() {
+        return "provides(" + provides_index + ", " + provides_with_count + ", ...)";
+    }
+
+
+    /**
+     * @return Resolved string representation
+     */
+    public String toString( final ConstantPool constant_pool ) {
+        final StringBuilder buf = new StringBuilder();
+        final String interface_name = constant_pool.constantToString(provides_index, Const.CONSTANT_Class);
+        buf.append(Utility.compactClassName(interface_name, false));
+        buf.append(", with(").append(provides_with_count).append("):\n");
+        for (final int index : provides_with_index) {
+            final String class_name = constant_pool.getConstantString(index, Const.CONSTANT_Class);
+            buf.append("      ").append(Utility.compactClassName(class_name, false)).append("\n");
+        }
+        return buf.substring(0, buf.length()-1); // remove the last newline
+    }
+
+
+    /**
+     * @return deep copy of this object
+     */
+    public ModuleProvides copy() {
+        try {
+            return (ModuleProvides) clone();
+        } catch (final CloneNotSupportedException e) {
+            // TODO should this throw?
+        }
+        return null;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleRequires.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleRequires.java
@@ -1,0 +1,118 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class represents an entry in the requires table of the Module attribute.
+ * Each entry describes a module on which the parent module depends.
+ *
+ * @see   Module
+ * @since 6.4.0
+ */
+public final class ModuleRequires implements Cloneable, Node {
+
+    private final int requires_index;  // points to CONSTANT_Module_info
+    private final int requires_flags;
+    private final int requires_version_index;  // either 0 or points to CONSTANT_Utf8_info
+
+
+    /**
+     * Construct object from file stream.
+     *
+     * @param file Input stream
+     * @throws IOException if an I/O Exception occurs in readUnsignedShort
+     */
+    ModuleRequires(final DataInput file) throws IOException {
+        requires_index = file.readUnsignedShort();
+        requires_flags = file.readUnsignedShort();
+        requires_version_index = file.readUnsignedShort();
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitModuleRequires(this);
+    }
+
+    // TODO add more getters and setters?
+
+    /**
+     * Dump table entry to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException if an I/O Exception occurs in writeShort
+     */
+    public void dump( final DataOutputStream file ) throws IOException {
+        file.writeShort(requires_index);
+        file.writeShort(requires_flags);
+        file.writeShort(requires_version_index);
+    }
+
+
+    /**
+     * @return String representation
+     */
+    @Override
+    public String toString() {
+        return "requires(" + requires_index + ", " + String.format("%04x", requires_flags) + ", " + requires_version_index + ")";
+    }
+
+
+    /**
+     * @return Resolved string representation
+     */
+    public String toString( final ConstantPool constant_pool ) {
+        final StringBuilder buf = new StringBuilder();
+        final String module_name = constant_pool.constantToString(requires_index, Const.CONSTANT_Module);
+        buf.append(Utility.compactClassName(module_name, false));
+        buf.append(", ").append(String.format("%04x", requires_flags));
+        final String version = requires_version_index == 0 ? "0" : constant_pool.getConstantString(requires_version_index, Const.CONSTANT_Utf8);
+        buf.append(", ").append(version);
+        return buf.toString();
+    }
+
+
+    /**
+     * @return deep copy of this object
+     */
+    public ModuleRequires copy() {
+        try {
+            return (ModuleRequires) clone();
+        } catch (final CloneNotSupportedException e) {
+            // TODO should this throw?
+        }
+        return null;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/NestHost.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/NestHost.java
@@ -1,0 +1,142 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class is derived from <em>Attribute</em> and records the nest host of the nest
+ * to which the current class or interface claims to belong.
+ * There may be at most one NestHost attribute in a ClassFile structure.
+ *
+ * @see     Attribute
+ */
+public final class NestHost extends Attribute {
+
+    private int host_class_index;
+
+
+    /**
+     * Initializes from another object. Note that both objects use the same
+     * references (shallow copy). Use copy() for a physical copy.
+     */
+    public NestHost(final NestHost c) {
+        this(c.getNameIndex(), c.getLength(), c.getHostClassIndex(), c.getConstantPool());
+    }
+
+
+    /**
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param host_class_index Host class index
+     * @param constant_pool Array of constants
+     */
+    public NestHost(final int name_index, final int length, final int host_class_index,
+            final ConstantPool constant_pool) {
+        super(Const.ATTR_NEST_MEMBERS, name_index, length, constant_pool);
+        this.host_class_index = host_class_index;
+    }
+
+
+    /**
+     * Constructs object from input stream.
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param input Input stream
+     * @param constant_pool Array of constants
+     * @throws IOException
+     */
+    NestHost(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
+        this(name_index, length, 0, constant_pool);
+        host_class_index = input.readUnsignedShort();
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitNestHost(this);
+    }
+
+
+    /**
+     * Dumps NestHost attribute to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException if an I/O error occurs.
+     */
+    @Override
+    public void dump( final DataOutputStream file ) throws IOException {
+        super.dump(file);
+        file.writeShort(host_class_index);
+    }
+
+
+    /**
+     * @return index into constant pool of host class name.
+     */
+    public int getHostClassIndex() {
+        return host_class_index;
+    }
+
+
+    /**
+     * @param host_class_index the host class index
+     */
+    public void setHostClassIndex( final int host_class_index ) {
+        this.host_class_index = host_class_index;
+    }
+
+
+    /**
+     * @return String representation
+     */
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("NestHost: ");
+        final String class_name = super.getConstantPool().getConstantString(host_class_index, Const.CONSTANT_Class);
+        buf.append(Utility.compactClassName(class_name, false));
+        return buf.toString();
+    }
+
+
+    /**
+     * @return deep copy of this attribute
+     */
+    @Override
+    public Attribute copy( final ConstantPool _constant_pool ) {
+        final NestHost c = (NestHost) clone();
+        c.setConstantPool(_constant_pool);
+        return c;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/NestMembers.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/NestMembers.java
@@ -1,0 +1,180 @@
+/*
+ * reserved comment block
+ * DO NOT REMOVE OR ALTER!
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.sun.org.apache.bcel.internal.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import com.sun.org.apache.bcel.internal.Const;
+
+/**
+ * This class is derived from <em>Attribute</em> and records the classes and interfaces that
+ * are authorized to claim membership in the nest hosted by the current class or interface.
+ * There may be at most one NestMembers attribute in a ClassFile structure.
+ *
+ * @see     Attribute
+ */
+public final class NestMembers extends Attribute {
+
+    private int[] classes;
+
+
+    /**
+     * Initialize from another object. Note that both objects use the same
+     * references (shallow copy). Use copy() for a physical copy.
+     */
+    public NestMembers(final NestMembers c) {
+        this(c.getNameIndex(), c.getLength(), c.getClasses(), c.getConstantPool());
+    }
+
+
+    /**
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param classes Table of indices in constant pool
+     * @param constant_pool Array of constants
+     */
+    public NestMembers(final int name_index, final int length, final int[] classes,
+            final ConstantPool constant_pool) {
+        super(Const.ATTR_NEST_MEMBERS, name_index, length, constant_pool);
+        this.classes = classes != null ? classes : new int[0];
+    }
+
+
+    /**
+     * Construct object from input stream.
+     * @param name_index Index in constant pool
+     * @param length Content length in bytes
+     * @param input Input stream
+     * @param constant_pool Array of constants
+     * @throws IOException
+     */
+    NestMembers(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
+        this(name_index, length, (int[]) null, constant_pool);
+        final int number_of_classes = input.readUnsignedShort();
+        classes = new int[number_of_classes];
+        for (int i = 0; i < number_of_classes; i++) {
+            classes[i] = input.readUnsignedShort();
+        }
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitNestMembers(this);
+    }
+
+
+    /**
+     * Dump NestMembers attribute to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException
+     */
+    @Override
+    public void dump( final DataOutputStream file ) throws IOException {
+        super.dump(file);
+        file.writeShort(classes.length);
+        for (final int index : classes) {
+            file.writeShort(index);
+        }
+    }
+
+
+    /**
+     * @return array of indices into constant pool of class names.
+     */
+    public int[] getClasses() {
+        return classes;
+    }
+
+
+    /**
+     * @return Length of classes table.
+     */
+    public int getNumberClasses() {
+        return classes == null ? 0 : classes.length;
+    }
+
+
+    /**
+     * @return string array of class names
+     */
+    public String[] getClassNames() {
+        final String[] names = new String[classes.length];
+        for (int i = 0; i < classes.length; i++) {
+            names[i] = super.getConstantPool().getConstantString(classes[i],
+                    Const.CONSTANT_Class).replace('/', '.');
+        }
+        return names;
+    }
+
+
+    /**
+     * @param classes the list of class indexes
+     * Also redefines number_of_classes according to table length.
+     */
+    public void setClasses( final int[] classes ) {
+        this.classes = classes != null ? classes : new int[0];
+    }
+
+
+    /**
+     * @return String representation, i.e., a list of classes.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("NestMembers(");
+        buf.append(classes.length);
+        buf.append("):\n");
+        for (final int index : classes) {
+            final String class_name = super.getConstantPool().getConstantString(index, Const.CONSTANT_Class);
+            buf.append("  ").append(Utility.compactClassName(class_name, false)).append("\n");
+        }
+        return buf.substring(0, buf.length()-1); // remove the last newline
+    }
+
+
+    /**
+     * @return deep copy of this attribute
+     */
+    @Override
+    public Attribute copy( final ConstantPool _constant_pool ) {
+        final NestMembers c = (NestMembers) clone();
+        if (classes != null) {
+            c.classes = new int[classes.length];
+            System.arraycopy(classes, 0, c.classes, 0,
+                    classes.length);
+        }
+        c.setConstantPool(_constant_pool);
+        return c;
+    }
+}

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Node.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Node.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.classfile;
 /**
  * Denote class to have an accept method();
  *
- * @version $Id$
  */
 public interface Node {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/PMGClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/PMGClass.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class is derived from <em>Attribute</em> and represents a reference
  * to a PMG attribute.
  *
- * @version $Id$
  * @see     Attribute
  */
 public final class PMGClass extends Attribute {
@@ -88,7 +87,7 @@ public final class PMGClass extends Attribute {
      */
     @Override
     public void accept( final Visitor v ) {
-        System.err.println("Visiting non-standard PMGClass object");
+        println("Visiting non-standard PMGClass object");
     }
 
 
@@ -99,7 +98,7 @@ public final class PMGClass extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(pmg_index);
         file.writeShort(pmg_class_index);
@@ -109,7 +108,7 @@ public final class PMGClass extends Attribute {
     /**
      * @return Index in constant pool of source file name.
      */
-    public final int getPMGClassIndex() {
+    public int getPMGClassIndex() {
         return pmg_class_index;
     }
 
@@ -117,7 +116,7 @@ public final class PMGClass extends Attribute {
     /**
      * @param pmg_class_index
      */
-    public final void setPMGClassIndex( final int pmg_class_index ) {
+    public void setPMGClassIndex( final int pmg_class_index ) {
         this.pmg_class_index = pmg_class_index;
     }
 
@@ -125,7 +124,7 @@ public final class PMGClass extends Attribute {
     /**
      * @return Index in constant pool of source file name.
      */
-    public final int getPMGIndex() {
+    public int getPMGIndex() {
         return pmg_index;
     }
 
@@ -133,7 +132,7 @@ public final class PMGClass extends Attribute {
     /**
      * @param pmg_index
      */
-    public final void setPMGIndex( final int pmg_index ) {
+    public void setPMGIndex( final int pmg_index ) {
         this.pmg_index = pmg_index;
     }
 
@@ -141,7 +140,7 @@ public final class PMGClass extends Attribute {
     /**
      * @return PMG name.
      */
-    public final String getPMGName() {
+    public String getPMGName() {
         final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(pmg_index,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
@@ -151,7 +150,7 @@ public final class PMGClass extends Attribute {
     /**
      * @return PMG class name.
      */
-    public final String getPMGClassName() {
+    public String getPMGClassName() {
         final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(pmg_class_index,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
@@ -162,7 +161,7 @@ public final class PMGClass extends Attribute {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return "PMGClass(" + getPMGName() + ", " + getPMGClassName() + ")";
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotationEntry.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotationEntry.java
@@ -31,7 +31,6 @@ import java.util.List;
 /**
  * represents one parameter annotation in the parameter annotation table
  *
- * @version $Id: ParameterAnnotationEntry
  * @since 6.0
  */
 public class ParameterAnnotationEntry implements Node {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotations.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 /**
  * base class for parameter annotations
  *
- * @version $Id: ParameterAnnotations
  * @since 6.0
  */
 public abstract class ParameterAnnotations extends Attribute {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeInvisibleAnnotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeInvisibleAnnotations.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * represents an annotation that is represented in the class file but is not
  * provided to the JVM.
  *
- * @version $Id: RuntimeInvisibleAnnotations
  * @since 6.0
  */
 public class RuntimeInvisibleAnnotations extends Annotations

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeInvisibleParameterAnnotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeInvisibleParameterAnnotations.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * Represents a parameter annotation that is represented in the class file
  * but is not provided to the JVM.
  *
- * @version $Id: RuntimeInvisibleParameterAnnotations
  * @since 6.0
  */
 public class RuntimeInvisibleParameterAnnotations extends ParameterAnnotations {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeVisibleAnnotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeVisibleAnnotations.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * represents an annotation that is represented in the class file and is
  * provided to the JVM.
  *
- * @version $Id: RuntimeVisibleAnnotations
  * @since 6.0
  */
 public class RuntimeVisibleAnnotations extends Annotations

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeVisibleParameterAnnotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/RuntimeVisibleParameterAnnotations.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * Represents a parameter annotation that is represented in the class file
  * and is provided to the JVM.
  *
- * @version $Id: RuntimeVisibleParameterAnnotations
  * @since 6.0
  */
 public class RuntimeVisibleParameterAnnotations extends ParameterAnnotations {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Signature.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Signature.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class is derived from <em>Attribute</em> and represents a reference
  * to a GJ attribute.
  *
- * @version $Id$
  * @see     Attribute
  */
 public final class Signature extends Attribute {
@@ -96,7 +95,7 @@ public final class Signature extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(signature_index);
     }
@@ -105,7 +104,7 @@ public final class Signature extends Attribute {
     /**
      * @return Index in constant pool of source file name.
      */
-    public final int getSignatureIndex() {
+    public int getSignatureIndex() {
         return signature_index;
     }
 
@@ -113,7 +112,7 @@ public final class Signature extends Attribute {
     /**
      * @param signature_index the index info the constant pool of this signature
      */
-    public final void setSignatureIndex( final int signature_index ) {
+    public void setSignatureIndex( final int signature_index ) {
         this.signature_index = signature_index;
     }
 
@@ -121,7 +120,7 @@ public final class Signature extends Attribute {
     /**
      * @return GJ signature.
      */
-    public final String getSignature() {
+    public String getSignature() {
         final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(signature_index,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
@@ -137,12 +136,12 @@ public final class Signature extends Attribute {
         }
 
 
-        final String getData() {
+        String getData() {
             return new String(buf);
         }
 
 
-        final void unread() {
+        void unread() {
             if (pos > 0) {
                 pos--;
             }
@@ -258,7 +257,7 @@ public final class Signature extends Attribute {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final String s = getSignature();
         return "Signature: " + s;
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/SourceFile.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/SourceFile.java
@@ -33,7 +33,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * should appear per classfile.  The intention of this class is that it is
  * instantiated from the <em>Attribute.readAttribute()</em> method.
  *
- * @version $Id$
  * @see     Attribute
  */
 public final class SourceFile extends Attribute {
@@ -103,7 +102,7 @@ public final class SourceFile extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(sourcefile_index);
     }
@@ -112,7 +111,7 @@ public final class SourceFile extends Attribute {
     /**
      * @return Index in constant pool of source file name.
      */
-    public final int getSourceFileIndex() {
+    public int getSourceFileIndex() {
         return sourcefile_index;
     }
 
@@ -120,7 +119,7 @@ public final class SourceFile extends Attribute {
     /**
      * @param sourcefile_index
      */
-    public final void setSourceFileIndex( final int sourcefile_index ) {
+    public void setSourceFileIndex( final int sourcefile_index ) {
         this.sourcefile_index = sourcefile_index;
     }
 
@@ -128,7 +127,7 @@ public final class SourceFile extends Attribute {
     /**
      * @return Source file name.
      */
-    public final String getSourceFileName() {
+    public String getSourceFileName() {
         final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(sourcefile_index,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
@@ -139,7 +138,7 @@ public final class SourceFile extends Attribute {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return "SourceFile: " + getSourceFileName();
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMap.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMap.java
@@ -30,13 +30,12 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * This class represents a stack map attribute used for
  * preverification of Java classes for the <a
- * href="http://java.sun.com/j2me/"> Java 2 Micro Edition</a>
- * (J2ME). This attribute is used by the <a
- * href="http://java.sun.com/products/cldc/">KVM</a> and contained
- * within the Code attribute of a method. See CLDC specification
+ * href="https://www.oracle.com/java/technologies/javameoverview.html">Java Platform, Micro Edition</a>
+ * (Java ME). This attribute is used by the <a
+ * href="https://www.oracle.com/technetwork/java/embedded/javame/java-mobile/kvmwp-150240.pdf">KVM</a>
+ * and contained within the Code attribute of a method. See CLDC specification
  * 5.3.1.2
  *
- * @version $Id$
  * @see     Code
  * @see     StackMapEntry
  * @see     StackMapType
@@ -84,7 +83,7 @@ public final class StackMap extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         file.writeShort(map.length);
         for (final StackMapEntry entry : map) {
@@ -96,7 +95,7 @@ public final class StackMap extends Attribute {
     /**
      * @return Array of stack map entries
      */
-    public final StackMapEntry[] getStackMap() {
+    public StackMapEntry[] getStackMap() {
         return map;
     }
 
@@ -104,7 +103,7 @@ public final class StackMap extends Attribute {
     /**
      * @param map Array of stack map entries
      */
-    public final void setStackMap( final StackMapEntry[] map ) {
+    public void setStackMap( final StackMapEntry[] map ) {
         this.map = map;
         int len = 2; // Length of 'number_of_entries' field prior to the array of stack maps
         for (final StackMapEntry element : map) {
@@ -118,7 +117,7 @@ public final class StackMap extends Attribute {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder buf = new StringBuilder("StackMap(");
         for (int i = 0; i < map.length; i++) {
             buf.append(map[i]);
@@ -159,7 +158,7 @@ public final class StackMap extends Attribute {
     }
 
 
-    public final int getMapLength() {
+    public int getMapLength() {
         return map == null ? 0 : map.length;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapEntry.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapEntry.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * local variables and the the of stack items at a given byte code offset.
  * See CLDC specification 5.3.1.2
  *
- * @version $Id$
  * @see     StackMap
  * @see     StackMapType
  */
@@ -142,7 +141,7 @@ public final class StackMapEntry implements Node, Cloneable
      * @param file Output file stream
      * @throws IOException
      */
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.write(frame_type);
         if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
             // nothing to be done
@@ -182,7 +181,7 @@ public final class StackMapEntry implements Node, Cloneable
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder buf = new StringBuilder(64);
         buf.append("(");
         if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
@@ -426,7 +425,7 @@ public final class StackMapEntry implements Node, Cloneable
     /**
      * @return Constant pool used by this object.
      */
-    public final ConstantPool getConstantPool() {
+    public ConstantPool getConstantPool() {
         return constant_pool;
     }
 
@@ -434,7 +433,7 @@ public final class StackMapEntry implements Node, Cloneable
     /**
      * @param constant_pool Constant pool to be used for this object.
      */
-    public final void setConstantPool( final ConstantPool constant_pool ) {
+    public void setConstantPool( final ConstantPool constant_pool ) {
         this.constant_pool = constant_pool;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapType.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * This class represents the type of a local variable or item on stack
  * used in the StackMap entries.
  *
- * @version $Id$
  * @see     StackMapEntry
  * @see     StackMap
  * @see     Const
@@ -103,7 +102,7 @@ public final class StackMapType implements Cloneable {
      * @param file Output file stream
      * @throws IOException
      */
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(type);
         if (hasIndex()) {
             file.writeShort(getIndex());
@@ -113,7 +112,7 @@ public final class StackMapType implements Cloneable {
 
     /** @return true, if type is either ITEM_Object or ITEM_NewObject
      */
-    public final boolean hasIndex() {
+    public boolean hasIndex() {
         return type == Const.ITEM_Object || type == Const.ITEM_NewObject;
     }
 
@@ -136,7 +135,7 @@ public final class StackMapType implements Cloneable {
      * @return String representation
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return "(type=" + Const.getItemName(type) + printIndex() + ")";
     }
 
@@ -157,7 +156,7 @@ public final class StackMapType implements Cloneable {
     /**
      * @return Constant pool used by this object.
      */
-    public final ConstantPool getConstantPool() {
+    public ConstantPool getConstantPool() {
         return constant_pool;
     }
 
@@ -165,7 +164,7 @@ public final class StackMapType implements Cloneable {
     /**
      * @param constant_pool Constant pool to be used for this object.
      */
-    public final void setConstantPool( final ConstantPool constant_pool ) {
+    public void setConstantPool( final ConstantPool constant_pool ) {
         this.constant_pool = constant_pool;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Synthetic.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Synthetic.java
@@ -36,7 +36,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * is intended to be instantiated from the
  * <em>Attribute.readAttribute()</em> method.
  *
- * @version $Id$
  * @see     Attribute
  */
 public final class Synthetic extends Attribute {
@@ -82,7 +81,7 @@ public final class Synthetic extends Attribute {
         if (length > 0) {
             bytes = new byte[length];
             input.readFully(bytes);
-            System.err.println("Synthetic attribute with length > 0");
+            println("Synthetic attribute with length > 0");
         }
     }
 
@@ -107,7 +106,7 @@ public final class Synthetic extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         if (super.getLength() > 0) {
             file.write(bytes, 0, super.getLength());
@@ -118,7 +117,7 @@ public final class Synthetic extends Attribute {
     /**
      * @return data bytes.
      */
-    public final byte[] getBytes() {
+    public byte[] getBytes() {
         return bytes;
     }
 
@@ -126,7 +125,7 @@ public final class Synthetic extends Attribute {
     /**
      * @param bytes
      */
-    public final void setBytes( final byte[] bytes ) {
+    public void setBytes( final byte[] bytes ) {
         this.bytes = bytes;
     }
 
@@ -135,7 +134,7 @@ public final class Synthetic extends Attribute {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         final StringBuilder buf = new StringBuilder("Synthetic");
         if (super.getLength() > 0) {
             buf.append(" ").append(Utility.toHexString(bytes));

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Unknown.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Unknown.java
@@ -38,7 +38,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * {@link Attribute#addAttributeReader(String, UnknownAttributeReader)}.
 
  *
- * @version $Id$
  * @see Attribute
  * @see UnknownAttributeReader
  */
@@ -124,7 +123,7 @@ public final class Unknown extends Attribute {
      * @throws IOException
      */
     @Override
-    public final void dump( final DataOutputStream file ) throws IOException {
+    public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
         if (super.getLength() > 0) {
             file.write(bytes, 0, super.getLength());
@@ -135,7 +134,7 @@ public final class Unknown extends Attribute {
     /**
      * @return data bytes.
      */
-    public final byte[] getBytes() {
+    public byte[] getBytes() {
         return bytes;
     }
 
@@ -144,7 +143,7 @@ public final class Unknown extends Attribute {
      * @return name of attribute.
      */
     @Override
-    public final String getName() {
+    public String getName() {
         return name;
     }
 
@@ -152,7 +151,7 @@ public final class Unknown extends Attribute {
     /**
      * @param bytes the bytes to set
      */
-    public final void setBytes( final byte[] bytes ) {
+    public void setBytes( final byte[] bytes ) {
         this.bytes = bytes;
     }
 
@@ -161,7 +160,7 @@ public final class Unknown extends Attribute {
      * @return String representation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         if (super.getLength() == 0 || bytes == null) {
             return "(Unknown attribute " + name + ")";
         }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/UnknownAttributeReader.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/UnknownAttributeReader.java
@@ -27,7 +27,6 @@ package com.sun.org.apache.bcel.internal.classfile;
  * method. These factory objects should implement this interface.
  *
  * @see Attribute
- * @version $Id$
  * @since 6.0
  */
 public interface UnknownAttributeReader {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Visitor.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Visitor.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.classfile;
  * that implements this interface can traverse the contents of a Java class just
  * by calling the `accept' method which all classes have.
  *
- * @version $Id$
  */
 public interface Visitor
 {
@@ -137,6 +136,13 @@ public interface Visitor
     void visitMethodParameters(MethodParameters obj);
 
     /**
+     * @since 6.4.0
+     */
+    default void visitMethodParameter(final MethodParameter obj) {
+        // empty
+    }
+
+    /**
      * @since 6.0
      */
     void visitConstantMethodType(ConstantMethodType obj);
@@ -164,7 +170,70 @@ public interface Visitor
     /**
      * @since 6.3
      */
-    default void visitConstantDynamic(ConstantDynamic constantDynamic) {
+    default void visitConstantDynamic(final ConstantDynamic constantDynamic) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitModule(final Module constantModule) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitModuleRequires(final ModuleRequires constantModule) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitModuleExports(final ModuleExports constantModule) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitModuleOpens(final ModuleOpens constantModule) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitModuleProvides(final ModuleProvides constantModule) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitModulePackages(final ModulePackages constantModule) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitModuleMainClass(final ModuleMainClass obj) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitNestHost(final NestHost obj) {
+        // empty
+    }
+
+    /**
+     * @since 6.4.0
+     */
+    default void visitNestMembers(final NestMembers obj) {
         // empty
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AALOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * AALOAD - Load reference from array
  * <PRE>Stack: ..., arrayref, index -&gt; value</PRE>
  *
- * @version $Id$
  */
 public class AALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AASTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * AASTORE -  Store into reference array
  * <PRE>Stack: ..., arrayref, index, value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class AASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ACONST_NULL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ACONST_NULL.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * ACONST_NULL - Push null reference
  * <PRE>Stack: ... -&gt; ..., null</PRE>
  *
- * @version $Id$
  */
 public class ACONST_NULL extends Instruction implements PushInstruction, TypedInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ALOAD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.Const;
  * ALOAD - Load reference from local variable
  * <PRE>Stack: ... -&gt; ..., objectref</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class ALOAD extends LoadInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ANEWARRAY.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ANEWARRAY.java
@@ -27,7 +27,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * ANEWARRAY -  Create new array of references
  * <PRE>Stack: ..., count -&gt; ..., arrayref</PRE>
  *
- * @version $Id$
  */
 public class ANEWARRAY extends CPInstruction implements LoadClass, AllocationInstruction,
         ExceptionThrower, StackConsumer, StackProducer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ARETURN.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ARETURN.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * ARETURN -  Return reference from method
  * <PRE>Stack: ..., objectref -&gt; &lt;empty&gt;</PRE>
  *
- * @version $Id$
  */
 public class ARETURN extends ReturnInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ARRAYLENGTH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ARRAYLENGTH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,7 +26,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * ARRAYLENGTH -  Get length of array
  * <PRE>Stack: ..., arrayref -&gt; ..., length</PRE>
  *
- * @version $Id$
  * @LastModified: Jun 2019
  */
 public class ARRAYLENGTH extends Instruction

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ASTORE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,8 +25,7 @@ import com.sun.org.apache.bcel.internal.Const;
  * ASTORE - Store reference into local variable
  * <PRE>Stack ..., objectref -&gt; ... </PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class ASTORE extends StoreInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ATHROW.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ATHROW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * ATHROW -  Throw exception
  * <PRE>Stack: ..., objectref -&gt; objectref</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class ATHROW extends Instruction implements UnconditionalBranch, ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AllocationInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AllocationInstruction.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Denote family of instructions that allocates space in the heap.
  *
- * @version $Id$
  */
 public interface AllocationInstruction {
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AnnotationEntryGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AnnotationEntryGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -40,7 +40,7 @@ import com.sun.org.apache.bcel.internal.classfile.RuntimeVisibleParameterAnnotat
 
 /**
  * @since 6.0
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class AnnotationEntryGen {
     private int typeIndex;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArithmeticInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArithmeticInstruction.java
@@ -26,7 +26,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * Super class for the family of arithmetic instructions.
  *
- * @version $Id$
  */
 public abstract class ArithmeticInstruction extends Instruction implements TypedInstruction,
         StackProducer, StackConsumer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayInstruction.java
@@ -26,7 +26,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
 /**
  * Super class for instructions dealing with array access such as IALOAD.
  *
- * @version $Id$
  */
 public abstract class ArrayInstruction extends Instruction implements ExceptionThrower,
         TypedInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayType.java
@@ -25,7 +25,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * Denotes array type, such as int[][]
  *
- * @version $Id$
  */
 public final class ArrayType extends ReferenceType {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BALOAD.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * BALOAD - Load byte or boolean from array
  * <PRE>Stack: ..., arrayref, index -&gt; ..., value</PRE>
  *
- * @version $Id$
  */
 public class BALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BASTORE.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * BASTORE -  Store into byte or boolean array
  * <PRE>Stack: ..., arrayref, index, value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class BASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BIPUSH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BIPUSH.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  *
  * <PRE>Stack: ... -&gt; ..., value</PRE>
  *
- * @version $Id$
  */
 public class BIPUSH extends Instruction implements ConstantPushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BREAKPOINT.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BREAKPOINT.java
@@ -23,7 +23,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * BREAKPOINT, JVM dependent, ignored by default
  *
- * @version $Id$
  */
 public class BREAKPOINT extends Instruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BasicType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BasicType.java
@@ -25,7 +25,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * Denotes basic type such as int.
  *
- * @version $Id$
  */
 public final class BasicType extends Type {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BranchHandle.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BranchHandle.java
@@ -29,7 +29,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * @see InstructionHandle
  * @see Instruction
  * @see InstructionList
- * @version $Id$
  */
 public final class BranchHandle extends InstructionHandle {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BranchInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BranchInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CALOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * CALOAD - Load char from array
  * <PRE>Stack: ..., arrayref, index -&gt; ..., value</PRE>
  *
- * @version $Id$
  */
 public class CALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CASTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * CASTORE -  Store into char array
  * <PRE>Stack: ..., arrayref, index, value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class CASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CHECKCAST.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CHECKCAST.java
@@ -27,7 +27,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * CHECKCAST - Check whether object is of given type
  * <PRE>Stack: ..., objectref -&gt; ..., objectref</PRE>
  *
- * @version $Id$
  */
 public class CHECKCAST extends CPInstruction implements LoadClass, ExceptionThrower, StackProducer,
         StackConsumer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CPInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CPInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -35,8 +35,7 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  * @see LDC
  * @see INVOKEVIRTUAL
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class CPInstruction extends Instruction implements TypedInstruction,
         IndexedInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -42,8 +42,7 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * existing java class (file).
  *
  * @see JavaClass
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class ClassGen extends AccessFlags implements Cloneable {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassGenException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassGenException.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Thrown on internal errors. Extends RuntimeException so it hasn't to be declared
  * in the throws clause every time.
  *
- * @version $Id$
  */
 public class ClassGenException extends RuntimeException {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassObserver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassObserver.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Implement this interface if you're interested in changes to a ClassGen object
  * and register yourself with addObserver().
  *
- * @version $Id$
  */
 public interface ClassObserver {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CodeExceptionGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CodeExceptionGen.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.classfile.CodeException;
  * The end of the region is automatically mapped to be exclusive when calling
  * getCodeException(), i.e., there is no difference semantically.
  *
- * @version $Id$
  * @see     MethodGen
  * @see     CodeException
  * @see     InstructionHandle

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CompoundInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CompoundInstruction.java
@@ -32,7 +32,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * The interface provides the possibilty for the user to write
  * `templates' or `macros' for such reuseable code patterns.
  *
- * @version $Id$
  * @see PUSH
  * @see SWITCH
  */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConstantPoolGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConstantPoolGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -49,9 +49,8 @@ import com.sun.org.apache.bcel.internal.classfile.ConstantUtf8;
  * Constants.MAX_SHORT entries. Note that the first (0) is used by the
  * JVM and that Double and Long constants need two slots.
  *
- * @version $Id$
  * @see Constant
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class ConstantPoolGen {
 
@@ -181,6 +180,10 @@ public class ConstantPoolGen {
             } else if (c instanceof com.sun.org.apache.bcel.internal.classfile.ConstantMethodType) {
                 // TODO should this be handled somehow?
             } else if (c instanceof com.sun.org.apache.bcel.internal.classfile.ConstantMethodHandle) {
+                // TODO should this be handled somehow?
+            } else if (c instanceof com.sun.org.apache.bcel.internal.classfile.ConstantModule) {
+                // TODO should this be handled somehow?
+            } else if (c instanceof com.sun.org.apache.bcel.internal.classfile.ConstantPackage) {
                 // TODO should this be handled somehow?
             } else {
                 assert false : "Unexpected constant type: " + c.getClass().getName();

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConstantPushInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConstantPushInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denotes a push instruction that produces a literal on the stack
  * such as  SIPUSH, BIPUSH, ICONST, etc.
  *
- * @version $Id$
 
  * @see ICONST
  * @see SIPUSH

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConversionInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConversionInstruction.java
@@ -26,7 +26,6 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * Super class for the x2y family of instructions.
  *
- * @version $Id$
  */
 public abstract class ConversionInstruction extends Instruction implements TypedInstruction,
         StackProducer, StackConsumer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/D2F.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/D2F.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * D2F - Convert double to float
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class D2F extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/D2I.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/D2I.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * D2I - Convert double to int
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class D2I extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/D2L.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/D2L.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * D2L - Convert double to long
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class D2L extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DADD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DADD.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result1.word2
  *
- * @version $Id$
  */
 public class DADD extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DALOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DALOAD - Load double from array
  * <PRE>Stack: ..., arrayref, index -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class DALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DASTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DASTORE -  Store into double array
  * <PRE>Stack: ..., arrayref, index, value.word1, value.word2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class DASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DCMPG.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DCMPG.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DCMPG - Compare doubles: value1 &gt; value2
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class DCMPG extends Instruction implements TypedInstruction, StackProducer, StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DCMPL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DCMPL.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DCMPL - Compare doubles: value1 &lt; value2
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class DCMPL extends Instruction implements TypedInstruction, StackProducer, StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DCONST.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DCONST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,8 +25,7 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ... -&gt; ..., </PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class DCONST extends Instruction implements ConstantPushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DDIV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DDIV.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class DDIV extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DLOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DLOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DLOAD - Load double from local variable
  * <PRE>Stack ... -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class DLOAD extends LoadInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DMUL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DMUL.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class DMUL extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DNEG.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DNEG.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DNEG - Negate double
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class DNEG extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DREM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DREM.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class DREM extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DRETURN.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DRETURN.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DRETURN -  Return double from method
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; &lt;empty&gt;</PRE>
  *
- * @version $Id$
  */
 public class DRETURN extends ReturnInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DSTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DSTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DSTORE - Store double into local variable
  * <pre>Stack: ..., value.word1, value.word2 -&gt; ... </PRE>
  *
- * @version $Id$
  */
 public class DSTORE extends StoreInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DSUB.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DSUB.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class DSUB extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DUP - Duplicate top operand stack word
  * <PRE>Stack: ..., word -&gt; ..., word, word</PRE>
  *
- * @version $Id$
  */
 public class DUP extends StackInstruction implements PushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP2.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DUP2 - Duplicate two top operand stack words
  * <PRE>Stack: ..., word2, word1 -&gt; ..., word2, word1, word2, word1</PRE>
  *
- * @version $Id$
  */
 public class DUP2 extends StackInstruction implements PushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP2_X1.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP2_X1.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DUP2_X1 - Duplicate two top operand stack words and put three down
  * <PRE>Stack: ..., word3, word2, word1 -&gt; ..., word2, word1, word3, word2, word1</PRE>
  *
- * @version $Id$
  */
 public class DUP2_X1 extends StackInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP2_X2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP2_X2.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DUP2_X2 - Duplicate two top operand stack words and put four down
  * <PRE>Stack: ..., word4, word3, word2, word1 -&gt; ..., word2, word1, word4, word3, word2, word1</PRE>
  *
- * @version $Id$
  */
 public class DUP2_X2 extends StackInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP_X1.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP_X1.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DUP_X1 - Duplicate top operand stack word and put two down
  * <PRE>Stack: ..., word2, word1 -&gt; ..., word1, word2, word1</PRE>
  *
- * @version $Id$
  */
 public class DUP_X1 extends StackInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP_X2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/DUP_X2.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * DUP_X2 - Duplicate top operand stack word and put three down
  * <PRE>Stack: ..., word3, word2, word1 -&gt; ..., word1, word3, word2, word1</PRE>
  *
- * @version $Id$
  */
 public class DUP_X2 extends StackInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ElementValueGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ElementValueGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -34,7 +34,7 @@ import com.sun.org.apache.bcel.internal.classfile.SimpleElementValue;
 
 /**
  * @since 6.0
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class ElementValueGen
 {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/EmptyVisitor.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/EmptyVisitor.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Supplies empty method bodies to be overridden by subclasses.
  *
- * @version $Id$
  */
 public abstract class EmptyVisitor implements Visitor {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ExceptionThrower.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ExceptionThrower.java
@@ -38,7 +38,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * "Throwable" object; so this term is equally used for "Exception"
  * and "Error" objects.
  *
- * @version $Id$
  */
 public interface ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/F2D.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/F2D.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * F2D - Convert float to double
  * <PRE>Stack: ..., value -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class F2D extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/F2I.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/F2I.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * F2I - Convert float to int
  * <PRE>Stack: ..., value -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class F2I extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/F2L.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/F2L.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * F2L - Convert float to long
  * <PRE>Stack: ..., value -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class F2L extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FADD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FADD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FADD - Add floats
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class FADD extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FALOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FALOAD - Load float from array
  * <PRE>Stack: ..., arrayref, index -&gt; ..., value</PRE>
  *
- * @version $Id$
  */
 public class FALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FASTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FASTORE -  Store into float array
  * <PRE>Stack: ..., arrayref, index, value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class FASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FCMPG.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FCMPG.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FCMPG - Compare floats: value1 &gt; value2
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class FCMPG extends Instruction implements TypedInstruction, StackProducer, StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FCMPL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FCMPL.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FCMPL - Compare floats: value1 &lt; value2
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class FCMPL extends Instruction implements TypedInstruction, StackProducer, StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FCONST.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FCONST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,8 +25,7 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ... -&gt; ..., </PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class FCONST extends Instruction implements ConstantPushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FDIV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FDIV.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FDIV - Divide floats
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class FDIV extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FLOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FLOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FLOAD - Load float from local variable
  * <PRE>Stack ... -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class FLOAD extends LoadInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FMUL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FMUL.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FMUL - Multiply floats
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class FMUL extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FNEG.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FNEG.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FNEG - Negate float
  * <PRE>Stack: ..., value -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class FNEG extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FREM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FREM.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FREM - Remainder of floats
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class FREM extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FRETURN.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FRETURN.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FRETURN -  Return float from method
  * <PRE>Stack: ..., value -&gt; &lt;empty&gt;</PRE>
  *
- * @version $Id$
  */
 public class FRETURN extends ReturnInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FSTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FSTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FSTORE - Store float into local variable
  * <PRE>Stack: ..., value -&gt; ... </PRE>
  *
- * @version $Id$
  */
 public class FSTORE extends StoreInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FSUB.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FSUB.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * FSUB - Substract floats
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class FSUB extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -40,9 +40,8 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * one can do is to add a constant value attribute to a field (which must of
  * course be compatible with to the declared type).
  *
- * @version $Id$
  * @see Field
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class FieldGen extends FieldGenOrMethodGen {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGenOrMethodGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGenOrMethodGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,8 +30,7 @@ import com.sun.org.apache.bcel.internal.classfile.Attribute;
  * Super class for FieldGen and MethodGen objects, since they have
  * some methods in common!
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jun 2020
  */
 public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAndTyped, Cloneable {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldInstruction.java
@@ -26,7 +26,6 @@ import com.sun.org.apache.bcel.internal.classfile.ConstantPool;
 /**
  * Super class for the GET/PUTxxx family of instructions.
  *
- * @version $Id$
  */
 public abstract class FieldInstruction extends FieldOrMethod {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldObserver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldObserver.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Imnplement this interface if you're interested in changes to a FieldGen object
  * and register yourself with addObserver().
  *
- * @version $Id$
  */
 public interface FieldObserver {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldOrMethod.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldOrMethod.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.classfile.ConstantUtf8;
  * Super class for InvokeInstruction and FieldInstruction, since they have
  * some methods in common!
  *
- * @version $Id$
  */
 public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
 
@@ -40,6 +39,7 @@ public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
      * Not to be used otherwise.
      */
     FieldOrMethod() {
+        // no init
     }
 
 
@@ -53,7 +53,7 @@ public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
 
     /** @return signature of referenced method/field.
      */
-    public String getSignature( final ConstantPoolGen cpg ) {
+    public String getSignature(final ConstantPoolGen cpg) {
         final ConstantPool cp = cpg.getConstantPool();
         final ConstantCP cmr = (ConstantCP) cp.getConstant(super.getIndex());
         final ConstantNameAndType cnat = (ConstantNameAndType) cp.getConstant(cmr.getNameAndTypeIndex());
@@ -63,7 +63,7 @@ public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
 
     /** @return name of referenced method/field.
      */
-    public String getName( final ConstantPoolGen cpg ) {
+    public String getName(final ConstantPoolGen cpg) {
         final ConstantPool cp = cpg.getConstantPool();
         final ConstantCP cmr = (ConstantCP) cp.getConstant(super.getIndex());
         final ConstantNameAndType cnat = (ConstantNameAndType) cp.getConstant(cmr.getNameAndTypeIndex());
@@ -83,7 +83,7 @@ public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
      *
      */
     @Deprecated
-    public String getClassName( final ConstantPoolGen cpg ) {
+    public String getClassName(final ConstantPoolGen cpg) {
         final ConstantPool cp = cpg.getConstantPool();
         final ConstantCP cmr = (ConstantCP) cp.getConstant(super.getIndex());
         final String className = cp.getConstantString(cmr.getClassIndex(), Const.CONSTANT_Class);
@@ -101,20 +101,20 @@ public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
      *    getReferenceType() instead.
      */
     @Deprecated
-    public ObjectType getClassType( final ConstantPoolGen cpg ) {
+    public ObjectType getClassType(final ConstantPoolGen cpg) {
         return ObjectType.getInstance(getClassName(cpg));
     }
 
 
     /**
-     * Return the reference type representing the class, interface,
+     * Gets the reference type representing the class, interface,
      * or array class referenced by the instruction.
      * @param cpg the ConstantPoolGen used to create the instruction
      * @return an ObjectType (if the referenced class type is a class
      *   or interface), or an ArrayType (if the referenced class
      *   type is an array class)
      */
-    public ReferenceType getReferenceType( final ConstantPoolGen cpg ) {
+    public ReferenceType getReferenceType(final ConstantPoolGen cpg) {
         final ConstantPool cp = cpg.getConstantPool();
         final ConstantCP cmr = (ConstantCP) cp.getConstant(super.getIndex());
         String className = cp.getConstantString(cmr.getClassIndex(), Const.CONSTANT_Class);
@@ -127,17 +127,18 @@ public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
 
 
     /**
-     * Get the ObjectType of the method return or field.
+     * Gets the ObjectType of the method return or field.
      *
      * @return type of the referenced class/interface
      * @throws ClassGenException when the field is (or method returns) an array,
      */
     @Override
-    public ObjectType getLoadClassType( final ConstantPoolGen cpg ) {
+    public ObjectType getLoadClassType(final ConstantPoolGen cpg) {
         final ReferenceType rt = getReferenceType(cpg);
-        if(rt instanceof ObjectType) {
-            return (ObjectType)rt;
+        if (rt instanceof ObjectType) {
+            return (ObjectType) rt;
         }
-        throw new ClassGenException(rt.getSignature() + " does not represent an ObjectType");
+        throw new ClassGenException(rt.getClass().getCanonicalName() + " " +
+                rt.getSignature() + " does not represent an ObjectType");
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GETFIELD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GETFIELD.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * OR
  * <PRE>Stack: ..., objectref -&gt; ..., value.word1, value.word2</PRE>
  *
- * @version $Id$
  */
 public class GETFIELD extends FieldInstruction implements ExceptionThrower, StackConsumer,
         StackProducer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GETSTATIC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GETSTATIC.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * OR
  * <PRE>Stack: ..., -&gt; ..., value.word1, value.word2</PRE>
  *
- * @version $Id$
  */
 public class GETSTATIC extends FieldInstruction implements PushInstruction, ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GOTO.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GOTO.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 /**
  * GOTO - Branch always (to relative offset, not absolute address)
  *
- * @version $Id$
  */
 public class GOTO extends GotoInstruction implements VariableLengthInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GOTO_W.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GOTO_W.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * GOTO_W - Branch always (to relative offset, not absolute address)
  *
- * @version $Id$
  */
 public class GOTO_W extends GotoInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GotoInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/GotoInstruction.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Super class for GOTO
  *
- * @version $Id$
  */
 public abstract class GotoInstruction extends BranchInstruction implements UnconditionalBranch {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2B.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2B.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * I2B - Convert int to byte
  * <PRE>Stack: ..., value -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class I2B extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2C.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2C.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * I2C - Convert int to char
  * <PRE>Stack: ..., value -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class I2C extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2D.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2D.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * I2D - Convert int to double
  * <PRE>Stack: ..., value -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class I2D extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2F.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2F.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * I2F - Convert int to float
  * <PRE>Stack: ..., value -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class I2F extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2L.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2L.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * I2L - Convert int to long
  * <PRE>Stack: ..., value -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class I2L extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2S.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/I2S.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * I2S - Convert int to short
  * <PRE>Stack: ..., value -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class I2S extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IADD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IADD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IADD - Add ints
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class IADD extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IALOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IALOAD - Load int from array
  * <PRE>Stack: ..., arrayref, index -&gt; ..., value</PRE>
  *
- * @version $Id$
  */
 public class IALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IAND.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IAND.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IAND - Bitwise AND int
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class IAND extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IASTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IASTORE -  Store into int array
  * <PRE>Stack: ..., arrayref, index, value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ICONST.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ICONST.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ... -&gt; ..., </PRE>
  *
- * @version $Id$
  */
 public class ICONST extends Instruction implements ConstantPushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IDIV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IDIV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * IDIV - Divide ints
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class IDIV extends ArithmeticInstruction implements ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFEQ.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFEQ.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFEQ extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFGE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFGE.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFGE extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFGT.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFGT.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFGT extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFLE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFLE.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFLE extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFLT.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFLT.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFLT extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFNE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFNE.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFNE extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFNONNULL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFNONNULL.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., reference -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFNONNULL extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFNULL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IFNULL.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., reference -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IFNULL extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ACMPEQ.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ACMPEQ.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ACMPEQ extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ACMPNE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ACMPNE.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ACMPNE extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPEQ.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPEQ.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ICMPEQ extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPGE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPGE.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ICMPGE extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPGT.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPGT.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ICMPGT extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPLE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPLE.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ICMPLE extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPLT.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPLT.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ICMPLT extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPNE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IF_ICMPNE.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., value1, value2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class IF_ICMPNE extends IfInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IINC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IINC.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * IINC - Increment local variable by constant
  *
- * @version $Id$
  */
 public class IINC extends LocalVariableInstruction {
 
@@ -50,7 +49,7 @@ public class IINC extends LocalVariableInstruction {
      * @param c increment factor
      */
     public IINC(final int n, final int c) {
-        super(); // Default behaviour of LocalVariableInstruction causes error
+        super(); // Default behavior of LocalVariableInstruction causes error
         super.setOpcode(com.sun.org.apache.bcel.internal.Const.IINC);
         super.setLength((short) 3);
         setIndex(n); // May set wide as side effect

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ILOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ILOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * ILOAD - Load int from local variable onto stack
  * <PRE>Stack: ... -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class ILOAD extends LoadInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IMPDEP1.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IMPDEP1.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * IMPDEP1 - Implementation dependent
  *
- * @version $Id$
  */
 public class IMPDEP1 extends Instruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IMPDEP2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IMPDEP2.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * IMPDEP2 - Implementation dependent
  *
- * @version $Id$
  */
 public class IMPDEP2 extends Instruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IMUL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IMUL.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IMUL - Multiply ints
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class IMUL extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INEG.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INEG.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * INEG - Negate int
  * <PRE>Stack: ..., value -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class INEG extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INSTANCEOF.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INSTANCEOF.java
@@ -27,7 +27,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * INSTANCEOF - Determine if object is of given type
  * <PRE>Stack: ..., objectref -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class INSTANCEOF extends CPInstruction implements LoadClass, ExceptionThrower,
         StackProducer, StackConsumer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEDYNAMIC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEDYNAMIC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -35,12 +35,11 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  * expects to be able to get the class of the method. Ignores the bootstrap
  * mechanism entirely.
  *
- * @version $Id: InvokeInstruction.java 1152072 2011-07-29 01:54:05Z dbrosius $
  * @see
  * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic">
  * The invokedynamic instruction in The Java Virtual Machine Specification</a>
  * @since 6.0
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class INVOKEDYNAMIC extends InvokeInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEINTERFACE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEINTERFACE.java
@@ -33,7 +33,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  * INVOKEINTERFACE - Invoke interface method
  * <PRE>Stack: ..., objectref, [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
- * @version $Id$
  * @see
  * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokeinterface">
  * The invokeinterface instruction in The Java Virtual Machine Specification</a>

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESPECIAL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESPECIAL.java
@@ -33,7 +33,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  *
  * <PRE>Stack: ..., objectref, [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
- * @version $Id$
  * @see
  * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial">
  * The invokespecial instruction in The Java Virtual Machine Specification</a>

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESTATIC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESTATIC.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  *
  * <PRE>Stack: ..., [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
- * @version $Id$
  * @see
  * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokestatic">
  * The invokestatic instruction in The Java Virtual Machine Specification</a>

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEVIRTUAL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEVIRTUAL.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  *
  * <PRE>Stack: ..., objectref, [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
- * @version $Id$
  * @see
  * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokevirtual">
  * The invokevirtual instruction in The Java Virtual Machine Specification</a>

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IOR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IOR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IOR - Bitwise OR int
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class IOR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IREM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IREM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * IREM - Remainder of int
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class IREM extends ArithmeticInstruction implements ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IRETURN.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IRETURN.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IRETURN -  Return int from method
  * <PRE>Stack: ..., value -&gt; &lt;empty&gt;</PRE>
  *
- * @version $Id$
  */
 public class IRETURN extends ReturnInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISHL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISHL.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * ISHL - Arithmetic shift left int
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class ISHL extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISHR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISHR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * ISHR - Arithmetic shift right int
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class ISHR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * ISTORE - Store int from stack into local variable
  * <PRE>Stack: ..., value -&gt; ... </PRE>
  *
- * @version $Id$
  */
 public class ISTORE extends StoreInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISUB.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ISUB.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * ISUB - Substract ints
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
  */
 public class ISUB extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IUSHR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IUSHR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IUSHR - Logical shift right int
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class IUSHR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IXOR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IXOR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * IXOR - Bitwise XOR int
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class IXOR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IfInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IfInstruction.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Super class for the IFxxx family of instructions.
  *
- * @version $Id$
  */
 public abstract class IfInstruction extends BranchInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IndexedInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/IndexedInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denote entity that refers to an index, e.g. local variable instructions,
  * RET, CPInstruction, etc.
  *
- * @version $Id$
  */
 public interface IndexedInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Instruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Instruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionComparator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionComparator.java
@@ -25,40 +25,38 @@ package com.sun.org.apache.bcel.internal.generic;
  * Equality of instructions isn't clearly to be defined. You might
  * wish, for example, to compare whether instructions have the same
  * meaning. E.g., whether two INVOKEVIRTUALs describe the same
- * call.<br>The DEFAULT comparator however, considers two instructions
+ * call.
+ * <p>
+ * The DEFAULT comparator however, considers two instructions
  * to be equal if they have same opcode and point to the same indexes
  * (if any) in the constant pool or the same local variable index. Branch
  * instructions must have the same target.
+ * </p>
  *
  * @see Instruction
- * @version $Id$
  */
 public interface InstructionComparator {
 
-    InstructionComparator DEFAULT = new InstructionComparator() {
-
-        @Override
-        public boolean equals( final Instruction i1, final Instruction i2 ) {
-            if (i1.getOpcode() == i2.getOpcode()) {
-                if (i1 instanceof BranchInstruction) {
-                 // BIs are never equal to make targeters work correctly (BCEL-195)
-                    return false;
+    InstructionComparator DEFAULT = (i1, i2) -> {
+        if (i1.getOpcode() == i2.getOpcode()) {
+            if (i1 instanceof BranchInstruction) {
+             // BIs are never equal to make targeters work correctly (BCEL-195)
+                return false;
 //                } else if (i1 == i2) { TODO consider adding this shortcut
 //                    return true; // this must be AFTER the BI test
-                } else if (i1 instanceof ConstantPushInstruction) {
-                    return ((ConstantPushInstruction) i1).getValue().equals(
-                            ((ConstantPushInstruction) i2).getValue());
-                } else if (i1 instanceof IndexedInstruction) {
-                    return ((IndexedInstruction) i1).getIndex() == ((IndexedInstruction) i2)
-                            .getIndex();
-                } else if (i1 instanceof NEWARRAY) {
-                    return ((NEWARRAY) i1).getTypecode() == ((NEWARRAY) i2).getTypecode();
-                } else {
-                    return true;
-                }
+            } else if (i1 instanceof ConstantPushInstruction) {
+                return ((ConstantPushInstruction) i1).getValue().equals(
+                        ((ConstantPushInstruction) i2).getValue());
+            } else if (i1 instanceof IndexedInstruction) {
+                return ((IndexedInstruction) i1).getIndex() == ((IndexedInstruction) i2)
+                        .getIndex();
+            } else if (i1 instanceof NEWARRAY) {
+                return ((NEWARRAY) i1).getTypecode() == ((NEWARRAY) i2).getTypecode();
+            } else {
+                return true;
             }
-            return false;
         }
+        return false;
     };
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionConst.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionConst.java
@@ -37,7 +37,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * The Instructions can also accessed directly under their names, so
  * it's possible to write il.append(Instruction.ICONST_0);
  *
- * @version $Id: InstructionConstants.java 1695415 2015-08-12 01:02:39Z chas $
  */
 public final class InstructionConst {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,10 +30,9 @@ import com.sun.org.apache.bcel.internal.Const;
  * Note: The static createXXX methods return singleton instances
  * from the {@link InstructionConst} class.
  *
- * @version $Id$
  * @see Const
  * @see InstructionConst
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class InstructionFactory {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionHandle.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,10 +39,10 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  * can traverse the list via an Enumeration returned by
  * InstructionList.elements().
  *
- * @version $Id$
  * @see Instruction
  * @see BranchHandle
  * @see InstructionList
+ * @LastModified: Jan 2020
  */
 public class InstructionHandle {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionList.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
  /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -44,11 +44,10 @@ import java.util.NoSuchElementException;
  * A list is finally dumped to a byte code array with <a
  * href="#getByteCode()">getByteCode</a>.
  *
- * @version $Id$
  * @see Instruction
  * @see InstructionHandle
  * @see BranchHandle
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class InstructionList implements Iterable<InstructionHandle> {
 
@@ -66,7 +65,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Create instruction list containing one instruction.
      *
-     * @param i initial instruction
+     * @param i
+     *            initial instruction
      */
     public InstructionList(final Instruction i) {
         append(i);
@@ -75,7 +75,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Create instruction list containing one instruction.
      *
-     * @param i initial instruction
+     * @param i
+     *            initial instruction
      */
     public InstructionList(final BranchInstruction i) {
         append(i);
@@ -85,7 +86,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Initialize list with (nonnull) compound instruction. Consumes argument
      * list, i.e., it becomes empty.
      *
-     * @param c compound instruction (list)
+     * @param c
+     *            compound instruction (list)
      */
     public InstructionList(final CompoundInstruction c) {
         append(c.getInstructionList());
@@ -102,21 +104,25 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Find the target instruction (handle) that corresponds to the given target
      * position (byte code offset).
      *
-     * @param ihs array of instruction handles, i.e. il.getInstructionHandles()
-     * @param pos array of positions corresponding to ihs, i.e.
-     * il.getInstructionPositions()
-     * @param count length of arrays
-     * @param target target position to search for
+     * @param ihs
+     *            array of instruction handles, i.e. il.getInstructionHandles()
+     * @param pos
+     *            array of positions corresponding to ihs, i.e. il.getInstructionPositions()
+     * @param count
+     *            length of arrays
+     * @param target
+     *            target position to search for
      * @return target position's instruction handle if available
      */
-    public static InstructionHandle findHandle(final InstructionHandle[] ihs, final int[] pos, final int count, final int target) {
+    public static InstructionHandle findHandle(final InstructionHandle[] ihs,
+            final int[] pos, final int count, final int target) {
         int l = 0;
         int r = count - 1;
         /*
          * Do a binary search since the pos array is orderd.
          */
         do {
-            final int i = (l + r) / 2;
+            final int i = (l + r) >>> 1;
             final int j = pos[i];
             if (j == target) {
                 return ihs[i];
@@ -134,7 +140,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * only works properly, if the list is freshly initialized from a byte array
      * or setPositions() has been called before this method.
      *
-     * @param pos byte code position to search for
+     * @param pos
+     *            byte code position to search for
      * @return target position's instruction handle if available
      */
     public InstructionHandle findHandle(final int pos) {
@@ -152,7 +159,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Initialize instruction list from byte array.
      *
-     * @param code byte array containing the instructions
+     * @param code
+     *            byte array containing the instructions
      */
     public InstructionList(final byte[] code) {
         int count = 0; // Contains actual length
@@ -195,8 +203,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
                 final BranchInstruction bi = (BranchInstruction) ihs[i].getInstruction();
                 int target = bi.getPosition() + bi.getIndex();
                 /*
-                                                                * Byte code position: relative -> absolute.
-                 */
+                 * Byte code position: relative -> absolute.
+                */
                 // Search for target position
                 InstructionHandle ih = findHandle(ihs, pos, count, target);
                 if (ih == null) {
@@ -224,10 +232,11 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Append another list after instruction (handle) ih contained in this list.
      * Consumes argument list, i.e., it becomes empty.
      *
-     * @param ih where to append the instruction list
-     * @param il Instruction list to append to this one
-     * @return instruction handle pointing to the <B>first</B> appended
-     * instruction
+     * @param ih
+     *            where to append the instruction list
+     * @param il
+     *            Instruction list to append to this one
+     * @return instruction handle pointing to the <B>first</B> appended instruction
      */
     public InstructionHandle append(final InstructionHandle ih, final InstructionList il) {
         if (il == null) {
@@ -255,10 +264,11 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Append another list after instruction i contained in this list. Consumes
      * argument list, i.e., it becomes empty.
      *
-     * @param i where to append the instruction list
-     * @param il Instruction list to append to this one
-     * @return instruction handle pointing to the <B>first</B> appended
-     * instruction
+     * @param i
+     *            where to append the instruction list
+     * @param il
+     *            Instruction list to append to this one
+     * @return instruction handle pointing to the <B>first</B> appended instruction
      */
     public InstructionHandle append(final Instruction i, final InstructionList il) {
         InstructionHandle ih;
@@ -272,7 +282,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Append another list to this one. Consumes argument list, i.e., it becomes
      * empty.
      *
-     * @param il list to append to end of this list
+     * @param il
+     *            list to append to end of this list
      * @return instruction handle of the <B>first</B> appended instruction
      */
     public InstructionHandle append(final InstructionList il) {
@@ -295,7 +306,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Append an instruction to the end of this list.
      *
-     * @param ih instruction to append
+     * @param ih
+     *            instruction to append
      */
     private void append(final InstructionHandle ih) {
         if (isEmpty()) {
@@ -307,14 +319,14 @@ public class InstructionList implements Iterable<InstructionHandle> {
             ih.setNext(null);
             end = ih;
         }
-
         length++; // Update length
     }
 
     /**
      * Append an instruction to the end of this list.
      *
-     * @param i instruction to append
+     * @param i
+     *            instruction to append
      * @return instruction handle of the appended instruction
      */
     public InstructionHandle append(final Instruction i) {
@@ -326,7 +338,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Append a branch instruction to the end of this list.
      *
-     * @param i branch instruction to append
+     * @param i
+     *            branch instruction to append
      * @return branch instruction handle of the appended instruction
      */
     public BranchHandle append(final BranchInstruction i) {
@@ -339,8 +352,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Append a single instruction j after another instruction i, which must be
      * in this list of course!
      *
-     * @param i Instruction in list
-     * @param j Instruction to append after i in list
+     * @param i
+     *            Instruction in list
+     * @param j
+     *            Instruction to append after i in list
      * @return instruction handle of the first appended instruction
      */
     public InstructionHandle append(final Instruction i, final Instruction j) {
@@ -350,8 +365,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Append a compound instruction, after instruction i.
      *
-     * @param i Instruction in list
-     * @param c The composite instruction (containing an InstructionList)
+     * @param i
+     *            Instruction in list
+     * @param c
+     *            The composite instruction (containing an InstructionList)
      * @return instruction handle of the first appended instruction
      */
     public InstructionHandle append(final Instruction i, final CompoundInstruction c) {
@@ -361,7 +378,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Append a compound instruction.
      *
-     * @param c The composite instruction (containing an InstructionList)
+     * @param c
+     *            The composite instruction (containing an InstructionList)
      * @return instruction handle of the first appended instruction
      */
     public InstructionHandle append(final CompoundInstruction c) {
@@ -371,8 +389,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Append a compound instruction.
      *
-     * @param ih where to append the instruction list
-     * @param c The composite instruction (containing an InstructionList)
+     * @param ih
+     *            where to append the instruction list
+     * @param c
+     *            The composite instruction (containing an InstructionList)
      * @return instruction handle of the first appended instruction
      */
     public InstructionHandle append(final InstructionHandle ih, final CompoundInstruction c) {
@@ -380,26 +400,26 @@ public class InstructionList implements Iterable<InstructionHandle> {
     }
 
     /**
-     * Append an instruction after instruction (handle) ih contained in this
-     * list.
+     * Append an instruction after instruction (handle) ih contained in this list.
      *
-     * @param ih where to append the instruction list
-     * @param i Instruction to append
-     * @return instruction handle pointing to the <B>first</B> appended
-     * instruction
+     * @param ih
+     *            where to append the instruction list
+     * @param i
+     *            Instruction to append
+     * @return instruction handle pointing to the <B>first</B> appended instruction
      */
     public InstructionHandle append(final InstructionHandle ih, final Instruction i) {
         return append(ih, new InstructionList(i));
     }
 
     /**
-     * Append an instruction after instruction (handle) ih contained in this
-     * list.
+     * Append an instruction after instruction (handle) ih contained in this list.
      *
-     * @param ih where to append the instruction list
-     * @param i Instruction to append
-     * @return instruction handle pointing to the <B>first</B> appended
-     * instruction
+     * @param ih
+     *            where to append the instruction list
+     * @param i
+     *            Instruction to append
+     * @return instruction handle pointing to the <B>first</B> appended instruction
      */
     public BranchHandle append(final InstructionHandle ih, final BranchInstruction i) {
         final BranchHandle bh = BranchHandle.getBranchHandle(i);
@@ -413,8 +433,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Insert another list before Instruction handle ih contained in this list.
      * Consumes argument list, i.e., it becomes empty.
      *
-     * @param ih where to append the instruction list
-     * @param il Instruction list to insert
+     * @param ih
+     *            where to append the instruction list
+     * @param il
+     *            Instruction list to insert
      * @return instruction handle of the first inserted instruction
      */
     public InstructionHandle insert(final InstructionHandle ih, final InstructionList il) {
@@ -442,7 +464,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Insert another list.
      *
-     * @param il list to insert before start of this list
+     * @param il
+     *            list to insert before start of this list
      * @return instruction handle of the first inserted instruction
      */
     public InstructionHandle insert(final InstructionList il) {
@@ -456,7 +479,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Insert an instruction at start of this list.
      *
-     * @param ih instruction to insert
+     * @param ih
+     *            instruction to insert
      */
     private void insert(final InstructionHandle ih) {
         if (isEmpty()) {
@@ -475,10 +499,11 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Insert another list before Instruction i contained in this list. Consumes
      * argument list, i.e., it becomes empty.
      *
-     * @param i where to append the instruction list
-     * @param il Instruction list to insert
-     * @return instruction handle pointing to the first inserted instruction,
-     * i.e., il.getStart()
+     * @param i
+     *            where to append the instruction list
+     * @param il
+     *            Instruction list to insert
+     * @return instruction handle pointing to the first inserted instruction, i.e., il.getStart()
      */
     public InstructionHandle insert(final Instruction i, final InstructionList il) {
         InstructionHandle ih;
@@ -491,7 +516,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Insert an instruction at start of this list.
      *
-     * @param i instruction to insert
+     * @param i
+     *            instruction to insert
      * @return instruction handle of the inserted instruction
      */
     public InstructionHandle insert(final Instruction i) {
@@ -503,7 +529,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Insert a branch instruction at start of this list.
      *
-     * @param i branch instruction to insert
+     * @param i
+     *            branch instruction to insert
      * @return branch instruction handle of the appended instruction
      */
     public BranchHandle insert(final BranchInstruction i) {
@@ -516,8 +543,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Insert a single instruction j before another instruction i, which must be
      * in this list of course!
      *
-     * @param i Instruction in list
-     * @param j Instruction to insert before i in list
+     * @param i
+     *            Instruction in list
+     * @param j
+     *            Instruction to insert before i in list
      * @return instruction handle of the first inserted instruction
      */
     public InstructionHandle insert(final Instruction i, final Instruction j) {
@@ -527,8 +556,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Insert a compound instruction before instruction i.
      *
-     * @param i Instruction in list
-     * @param c The composite instruction (containing an InstructionList)
+     * @param i
+     *            Instruction in list
+     * @param c
+     *            The composite instruction (containing an InstructionList)
      * @return instruction handle of the first inserted instruction
      */
     public InstructionHandle insert(final Instruction i, final CompoundInstruction c) {
@@ -538,7 +569,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Insert a compound instruction.
      *
-     * @param c The composite instruction (containing an InstructionList)
+     * @param c
+     *            The composite instruction (containing an InstructionList)
      * @return instruction handle of the first inserted instruction
      */
     public InstructionHandle insert(final CompoundInstruction c) {
@@ -546,11 +578,12 @@ public class InstructionList implements Iterable<InstructionHandle> {
     }
 
     /**
-     * Insert an instruction before instruction (handle) ih contained in this
-     * list.
+     * Insert an instruction before instruction (handle) ih contained in this list.
      *
-     * @param ih where to insert to the instruction list
-     * @param i Instruction to insert
+     * @param ih
+     *            where to insert to the instruction list
+     * @param i
+     *            Instruction to insert
      * @return instruction handle of the first inserted instruction
      */
     public InstructionHandle insert(final InstructionHandle ih, final Instruction i) {
@@ -560,8 +593,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Insert a compound instruction.
      *
-     * @param ih where to insert the instruction list
-     * @param c The composite instruction (containing an InstructionList)
+     * @param ih
+     *            where to insert the instruction list
+     * @param c
+     *            The composite instruction (containing an InstructionList)
      * @return instruction handle of the first inserted instruction
      */
     public InstructionHandle insert(final InstructionHandle ih, final CompoundInstruction c) {
@@ -569,11 +604,12 @@ public class InstructionList implements Iterable<InstructionHandle> {
     }
 
     /**
-     * Insert an instruction before instruction (handle) ih contained in this
-     * list.
+     * Insert an instruction before instruction (handle) ih contained in this list.
      *
-     * @param ih where to insert to the instruction list
-     * @param i Instruction to insert
+     * @param ih
+     *            where to insert to the instruction list
+     * @param i
+     *            Instruction to insert
      * @return instruction handle of the first inserted instruction
      */
     public BranchHandle insert(final InstructionHandle ih, final BranchInstruction i) {
@@ -587,14 +623,18 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Take all instructions (handles) from "start" to "end" and append them
      * after the new location "target". Of course, "end" must be after "start"
-     * and target must not be located withing this range. If you want to move
-     * something to the start of the list use null as value for target.<br>
+     * and target must not be located within this range. If you want to move
+     * something to the start of the list use null as value for target.
+     * <p>
      * Any instruction targeters pointing to handles within the block, keep
      * their targets.
      *
-     * @param start of moved block
-     * @param end of moved block
-     * @param target of moved block
+     * @param start
+     *            of moved block
+     * @param end
+     *            of moved block
+     * @param target
+     *            of moved block
      */
     public void move(final InstructionHandle start, final InstructionHandle end, final InstructionHandle target) {
         // Step 1: Check constraints
@@ -648,8 +688,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Move a single instruction (handle) to a new location.
      *
-     * @param ih moved instruction
-     * @param target new location of moved instruction
+     * @param ih
+     *            moved instruction
+     * @param target
+     *            new location of moved instruction
      */
     public void move(final InstructionHandle ih, final InstructionHandle target) {
         move(ih, ih, target);
@@ -660,8 +702,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * this list. Throws TargetLostException when one of the removed instruction
      * handles is still being targeted.
      *
-     * @param prev where to start deleting (predecessor, exclusive)
-     * @param next where to end deleting (successor, exclusive)
+     * @param prev
+     *            where to start deleting (predecessor, exclusive)
+     * @param next
+     *            where to end deleting (successor, exclusive)
      */
     private void remove(final InstructionHandle prev, InstructionHandle next) throws TargetLostException {
         InstructionHandle first;
@@ -716,17 +760,18 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Remove instruction from this list. The corresponding Instruction handles
      * must not be reused!
      *
-     * @param ih instruction (handle) to remove
+     * @param ih
+     *            instruction (handle) to remove
      */
     public void delete(final InstructionHandle ih) throws TargetLostException {
         remove(ih.getPrev(), ih.getNext());
     }
 
     /**
-     * Remove instruction from this list. The corresponding Instruction handles
-     * must not be reused!
+     * Remove instruction from this list. The corresponding Instruction handles must not be reused!
      *
-     * @param i instruction to remove
+     * @param i
+     *            instruction to remove
      */
     public void delete(final Instruction i) throws TargetLostException {
         InstructionHandle ih;
@@ -742,8 +787,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * `to', or risk havoc. The corresponding Instruction handles must not be
      * reused!
      *
-     * @param from where to start deleting (inclusive)
-     * @param to where to end deleting (inclusive)
+     * @param from
+     *            where to start deleting (inclusive)
+     * @param to
+     *            where to end deleting (inclusive)
      */
     public void delete(final InstructionHandle from, final InstructionHandle to) throws TargetLostException {
         remove(from.getPrev(), to.getNext());
@@ -755,8 +802,10 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * `to', or risk havoc. The corresponding Instruction handles must not be
      * reused!
      *
-     * @param from where to start deleting (inclusive)
-     * @param to where to end deleting (inclusive)
+     * @param from
+     *            where to start deleting (inclusive)
+     * @param to
+     *            where to end deleting (inclusive)
      */
     public void delete(final Instruction from, final Instruction to) throws TargetLostException {
         InstructionHandle from_ih;
@@ -773,7 +822,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Search for given Instruction reference, start at beginning of list.
      *
-     * @param i instruction to search for
+     * @param i
+     *            instruction to search for
      * @return instruction found on success, null otherwise
      */
     private InstructionHandle findInstruction1(final Instruction i) {
@@ -788,7 +838,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Search for given Instruction reference, start at end of list
      *
-     * @param i instruction to search for
+     * @param i
+     *            instruction to search for
      * @return instruction found on success, null otherwise
      */
     private InstructionHandle findInstruction2(final Instruction i) {
@@ -824,8 +875,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Give all instructions their position number (offset in byte stream),
      * i.e., make the list ready to be dumped.
      *
-     * @param check Perform sanity checks, e.g. if all targeted instructions
-     * really belong to this list
+     * @param check
+     *            Perform sanity checks, e.g. if all targeted instructions really belong to this list
      */
     public void setPositions(final boolean check) { // called by code in other packages
         int max_additional_bytes = 0;
@@ -882,11 +933,11 @@ public class InstructionList implements Iterable<InstructionHandle> {
                 case Const.JSR:
                 case Const.GOTO:
                     max_additional_bytes += 2;
-                    break;
+                break;
                 case Const.TABLESWITCH:
                 case Const.LOOKUPSWITCH:
                     max_additional_bytes += 3;
-                    break;
+                break;
             }
             index += i.getLength();
         }
@@ -909,12 +960,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
             pos[count++] = index;
             index += i.getLength();
         }
-        if (length == count) {
-            byte_positions = pos;
-        } else {
-            byte_positions = new int[count]; // Trim to proper size
-            System.arraycopy(pos, 0, byte_positions, 0, count);
-        }
+        byte_positions = new int[count]; // Trim to proper size
+        System.arraycopy(pos, 0, byte_positions, 0, count);
     }
 
     /**
@@ -963,7 +1010,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     }
 
     /**
-     * @param verbose toggle output format
+     * @param verbose
+     *            toggle output format
      * @return String containing all instructions in this list.
      */
     public String toString(final boolean verbose) {
@@ -1145,11 +1193,12 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * Redirect all references from old_target to new_target, i.e., update
      * targets of branch instructions.
      *
-     * @param old_target the old target instruction handle
-     * @param new_target the new target instruction handle
+     * @param old_target
+     *            the old target instruction handle
+     * @param new_target
+     *            the new target instruction handle
      */
-    public void redirectBranches(final InstructionHandle old_target,
-            final InstructionHandle new_target) {
+    public void redirectBranches(final InstructionHandle old_target, final InstructionHandle new_target) {
         for (InstructionHandle ih = start; ih != null; ih = ih.getNext()) {
             final Instruction i = ih.getInstruction();
             if (i instanceof BranchInstruction) {
@@ -1173,13 +1222,15 @@ public class InstructionList implements Iterable<InstructionHandle> {
     /**
      * Redirect all references of local variables from old_target to new_target.
      *
-     * @param lg array of local variables
-     * @param old_target the old target instruction handle
-     * @param new_target the new target instruction handle
+     * @param lg
+     *            array of local variables
+     * @param old_target
+     *            the old target instruction handle
+     * @param new_target
+     *            the new target instruction handle
      * @see MethodGen
      */
-    public void redirectLocalVariables(final LocalVariableGen[] lg,
-            final InstructionHandle old_target, final InstructionHandle new_target) {
+    public void redirectLocalVariables(final LocalVariableGen[] lg, final InstructionHandle old_target, final InstructionHandle new_target) {
         for (final LocalVariableGen element : lg) {
             final InstructionHandle start = element.getStart();
             final InstructionHandle end = element.getEnd();
@@ -1193,12 +1244,14 @@ public class InstructionList implements Iterable<InstructionHandle> {
     }
 
     /**
-     * Redirect all references of exception handlers from old_target to
-     * new_target.
+     * Redirect all references of exception handlers from old_target to new_target.
      *
-     * @param exceptions array of exception handlers
-     * @param old_target the old target instruction handle
-     * @param new_target the new target instruction handle
+     * @param exceptions
+     *            array of exception handlers
+     * @param old_target
+     *            the old target instruction handle
+     * @param new_target
+     *            the new target instruction handle
      * @see MethodGen
      */
     public void redirectExceptionHandlers(final CodeExceptionGen[] exceptions,

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionListObserver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionListObserver.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Implement this interface if you're interested in changes to an InstructionList object
  * and register yourself with addObserver().
  *
- * @version $Id$
  */
 public interface InstructionListObserver {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionTargeter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionTargeter.java
@@ -28,7 +28,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * @see BranchHandle
  * @see LocalVariableGen
  * @see CodeExceptionGen
- * @version $Id$
  */
 public interface InstructionTargeter {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InvokeInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InvokeInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,8 +30,7 @@ import com.sun.org.apache.bcel.internal.classfile.ConstantPool;
 /**
  * Super class for the INVOKExxx family of instructions.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class InvokeInstruction extends FieldOrMethod implements ExceptionThrower,
         StackConsumer, StackProducer {
@@ -59,8 +58,19 @@ public abstract class InvokeInstruction extends FieldOrMethod implements Excepti
     public String toString( final ConstantPool cp ) {
         final Constant c = cp.getConstant(super.getIndex());
         final StringTokenizer tok = new StringTokenizer(cp.constantToString(c));
-        return Const.getOpcodeName(super.getOpcode()) + " " + tok.nextToken().replace('.', '/')
-                + tok.nextToken();
+
+        final String opcodeName = Const.getOpcodeName(super.getOpcode());
+
+        final StringBuilder sb = new StringBuilder(opcodeName);
+        if (tok.hasMoreTokens()) {
+            sb.append(" ");
+            sb.append(tok.nextToken().replace('.', '/'));
+            if (tok.hasMoreTokens()) {
+                sb.append(tok.nextToken());
+            }
+        }
+
+        return sb.toString();
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JSR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JSR.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 /**
  * JSR - Jump to subroutine
  *
- * @version $Id$
  */
 public class JSR extends JsrInstruction implements VariableLengthInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JSR_W.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JSR_W.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * JSR_W - Jump to subroutine
  *
- * @version $Id$
  */
 public class JSR_W extends JsrInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JsrInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JsrInstruction.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Super class for JSR - Jump to subroutine
  *
- * @version $Id$
  */
 public abstract class JsrInstruction extends BranchInstruction implements UnconditionalBranch,
         TypedInstruction, StackProducer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/L2D.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/L2D.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * L2D - Convert long to double
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class L2D extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/L2F.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/L2F.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * L2F - Convert long to float
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class L2F extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/L2I.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/L2I.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * L2I - Convert long to int
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class L2I extends ConversionInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LADD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LADD.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class LADD extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LALOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LALOAD - Load long from array
  * <PRE>Stack: ..., arrayref, index -&gt; ..., value1, value2</PRE>
  *
- * @version $Id$
  */
 public class LALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LAND.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LAND.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class LAND extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LASTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LASTORE -  Store into long array
  * <PRE>Stack: ..., arrayref, index, value.word1, value.word2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class LASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LCMP.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LCMP.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt; ..., result &lt;= -1, 0, 1&gt;</PRE>
  *
  *
- * @version $Id$
  */
 public class LCMP extends Instruction implements TypedInstruction, StackProducer, StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LCONST.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LCONST.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ... -&gt; ..., </PRE>
  *
- * @version $Id$
  */
 public class LCONST extends Instruction implements ConstantPushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,8 +31,7 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  *
  * <PRE>Stack: ... -&gt; ..., item</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class LDC extends CPInstruction implements PushInstruction, ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC2_W.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC2_W.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,8 +25,7 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ... -&gt; ..., item.word1, item.word2</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class LDC2_W extends CPInstruction implements PushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC_W.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC_W.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  *
  * <PRE>Stack: ... -&gt; ..., item.word1, item.word2</PRE>
  *
- * @version $Id$
  */
 public class LDC_W extends LDC {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDIV.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDIV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -27,8 +27,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class LDIV extends ArithmeticInstruction implements ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LLOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LLOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LLOAD - Load long from local variable
  *<PRE>Stack ... -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class LLOAD extends LoadInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LMUL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LMUL.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class LMUL extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LNEG.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LNEG.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LNEG - Negate long
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class LNEG extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LOOKUPSWITCH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LOOKUPSWITCH.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * LOOKUPSWITCH - Switch with unordered set of values
  *
- * @version $Id$
  * @see SWITCH
  */
 public class LOOKUPSWITCH extends Select {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LOR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LOR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LOR - Bitwise OR long
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class LOR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LREM.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LREM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * LREM - Remainder of long
  * <PRE>Stack: ..., value1, value2 -&gt; result</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class LREM extends ArithmeticInstruction implements ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LRETURN.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LRETURN.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LRETURN -  Return long from method
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; &lt;empty&gt;</PRE>
  *
- * @version $Id$
  */
 public class LRETURN extends ReturnInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSHL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSHL.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LSHL - Arithmetic shift left long
  * <PRE>Stack: ..., value1.word1, value1.word2, value2 -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class LSHL extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSHR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSHR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LSHR - Arithmetic shift right long
  * <PRE>Stack: ..., value1.word1, value1.word2, value2 -&gt; ..., result.word1, result.word2</PRE>
  *
- * @version $Id$
  */
 public class LSHR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LSTORE - Store long into local variable
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ... </PRE>
  *
- * @version $Id$
  */
 public class LSTORE extends StoreInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSUB.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LSUB.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * <PRE>Stack: ..., value1.word1, value1.word2, value2.word1, value2.word2 -&gt;</PRE>
  *        ..., result.word1, result.word2
  *
- * @version $Id$
  */
 public class LSUB extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LUSHR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LUSHR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LUSHR - Logical shift right long
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class LUSHR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LXOR.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LXOR.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * LXOR - Bitwise XOR long
  * <PRE>Stack: ..., value1, value2 -&gt; ..., result</PRE>
  *
- * @version $Id$
  */
 public class LXOR extends ArithmeticInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LineNumberGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LineNumberGen.java
@@ -27,7 +27,6 @@ import com.sun.org.apache.bcel.internal.classfile.LineNumber;
  * This class represents a line number within a method, i.e., give an instruction
  * a line number corresponding to the source code line.
  *
- * @version $Id$
  * @see     LineNumber
  * @see     MethodGen
  */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LoadClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LoadClass.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denotes that an instruction may start the process of loading and resolving
  * the referenced class in the Virtual Machine.
  *
- * @version $Id$
  */
 public interface LoadClass {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LoadInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LoadInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denotes an unparameterized instruction to load a value from a local
  * variable, e.g. ILOAD.
  *
- * @version $Id$
  */
 public abstract class LoadInstruction extends LocalVariableInstruction implements PushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableGen.java
@@ -24,12 +24,11 @@ import com.sun.org.apache.bcel.internal.Const;
 import com.sun.org.apache.bcel.internal.classfile.LocalVariable;
 
 /**
- * This class represents a local variable within a method. It contains its
+ * Represents a local variable within a method. It contains its
  * scope, name and type. The generated LocalVariable object can be obtained
  * with getLocalVariable which needs the instruction list and the constant
  * pool as parameters.
  *
- * @version $Id$
  * @see     LocalVariable
  * @see     MethodGen
  */
@@ -70,7 +69,7 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
 
 
     /**
-     * Generate a local variable that with index `index'. Note that double and long
+     * Generates a local variable that with index `index'. Note that double and long
      * variables need two indexs. Index indices have to be provided by the user.
      *
      * @param index index of local variable
@@ -88,7 +87,7 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
 
 
     /**
-     * Get LocalVariable object.
+     * Gets LocalVariable object.
      *
      * This relies on that the instruction list has already been dumped to byte code or
      * or that the `setPositions' methods has been called for the instruction list.

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -28,8 +28,7 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * Abstract super class for instructions dealing with local variables.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class LocalVariableInstruction extends Instruction implements TypedInstruction,
         IndexedInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MONITORENTER.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MONITORENTER.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * MONITORENTER - Enter monitor for object
  * <PRE>Stack: ..., objectref -&gt; ...</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class MONITORENTER extends Instruction implements ExceptionThrower, StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MONITOREXIT.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MONITOREXIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * MONITOREXIT - Exit monitor for object
  * <PRE>Stack: ..., objectref -&gt; ...</PRE>
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class MONITOREXIT extends Instruction implements ExceptionThrower, StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MULTIANEWARRAY.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MULTIANEWARRAY.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  * MULTIANEWARRAY - Create new mutidimensional array of references
  * <PRE>Stack: ..., count1, [count2, ...] -&gt; ..., arrayref</PRE>
  *
- * @version $Id$
  */
 public class MULTIANEWARRAY extends CPInstruction implements LoadClass, AllocationInstruction,
         ExceptionThrower {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MethodGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MethodGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,10 +39,10 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
 import com.sun.org.apache.bcel.internal.util.BCELComparator;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Stack;
 
 /**
@@ -55,10 +55,9 @@ import java.util.Stack;
  * use the `removeNOPs' method to get rid off them.
  * The resulting method object can be obtained via the `getMethod()' method.
  *
- * @version $Id$
  * @see     InstructionList
  * @see     Method
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class MethodGen extends FieldGenOrMethodGen {
 
@@ -86,8 +85,8 @@ public class MethodGen extends FieldGenOrMethodGen {
         public boolean equals( final Object o1, final Object o2 ) {
             final MethodGen THIS = (MethodGen) o1;
             final MethodGen THAT = (MethodGen) o2;
-            return THIS.getName().equals(THAT.getName())
-                    && THIS.getSignature().equals(THAT.getSignature());
+            return Objects.equals(THIS.getName(), THAT.getName())
+                    && Objects.equals(THIS.getSignature(), THAT.getSignature());
         }
 
 
@@ -357,12 +356,7 @@ public class MethodGen extends FieldGenOrMethodGen {
             }
         }
         if (size > 1) {
-            Arrays.sort(lg, new Comparator<LocalVariableGen>() {
-                @Override
-                public int compare(final LocalVariableGen o1, final LocalVariableGen o2) {
-                    return o1.getIndex() - o2.getIndex();
-                }
-            });
+            Arrays.sort(lg, (o1, o2) -> o1.getIndex() - o2.getIndex());
         }
         return lg;
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MethodObserver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MethodObserver.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Implement this interface if you're interested in changes to a MethodGen object
  * and register yourself with addObserver().
  *
- * @version $Id$
  */
 public interface MethodObserver {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NEW.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NEW.java
@@ -27,7 +27,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * NEW - Create new object
  * <PRE>Stack: ... -&gt; ..., objectref</PRE>
  *
- * @version $Id$
  */
 public class NEW extends CPInstruction implements LoadClass, AllocationInstruction,
         ExceptionThrower, StackProducer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NEWARRAY.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NEWARRAY.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,8 +31,7 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  * <PRE>Stack: ..., count -&gt; ..., arrayref</PRE>
  * type must be one of T_INT, T_SHORT, ...
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class NEWARRAY extends Instruction implements AllocationInstruction, ExceptionThrower,
         StackProducer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NOP.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NOP.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * NOP - Do nothing
  *
- * @version $Id$
  */
 public class NOP extends Instruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NameSignatureInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NameSignatureInstruction.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.classfile.ConstantUtf8;
  * Super class for FieldOrMethod and INVOKEDYNAMIC, since they both have
  * names and signatures
  *
- * @version $Id: FieldOrMethod.java 1481383 2013-05-11 17:34:32Z dbrosius $
  * @since 6.0
  */
 public abstract class NameSignatureInstruction extends CPInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NamedAndTyped.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/NamedAndTyped.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denote entity that has both name and type. This is true for local variables,
  * methods and fields.
  *
- * @version $Id$
  */
 public interface NamedAndTyped {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ObjectType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ObjectType.java
@@ -28,7 +28,6 @@ import com.sun.org.apache.bcel.internal.classfile.JavaClass;
 /**
  * Denotes reference such as java.lang.String.
  *
- * @version $Id$
  */
 public class ObjectType extends ReferenceType {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/POP.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/POP.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., word -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class POP extends StackInstruction implements PopInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/POP2.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/POP2.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ..., word2, word1 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class POP2 extends StackInstruction implements PopInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PUSH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PUSH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.Const;
  * Wrapper class for push operations, which are implemented either as BIPUSH,
  * LDC or xCONST_n instructions.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public final class PUSH implements CompoundInstruction, VariableLengthInstruction {
 
@@ -176,12 +175,12 @@ public final class PUSH implements CompoundInstruction, VariableLengthInstructio
 
 
     @Override
-    public final InstructionList getInstructionList() {
+    public InstructionList getInstructionList() {
         return new InstructionList(instruction);
     }
 
 
-    public final Instruction getInstruction() {
+    public Instruction getInstruction() {
         return instruction;
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PUTFIELD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PUTFIELD.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * OR
  * <PRE>Stack: ..., objectref, value.word1, value.word2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class PUTFIELD extends FieldInstruction implements PopInstruction, ExceptionThrower {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PUTSTATIC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PUTSTATIC.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * OR
  * <PRE>Stack: ..., value.word1, value.word2 -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class PUTSTATIC extends FieldInstruction implements ExceptionThrower, PopInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PopInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PopInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denotes an unparameterized instruction to pop a value on top from the stack,
  * such as ISTORE, POP, PUTSTATIC.
  *
- * @version $Id$
  * @see ISTORE
  * @see POP
  */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PushInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/PushInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denotes an unparameterized instruction to produce a value on top of the stack,
  * such as ILOAD, LDC, SIPUSH, DUP, ICONST, etc.
  *
- * @version $Id$
 
  * @see ILOAD
  * @see ICONST

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/RET.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/RET.java
@@ -31,7 +31,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  *
  * <PRE>Stack: ... -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class RET extends Instruction implements IndexedInstruction, TypedInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/RETURN.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/RETURN.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * RETURN -  Return from void method
  * <PRE>Stack: ... -&gt; &lt;empty&gt;</PRE>
  *
- * @version $Id$
  */
 public class RETURN extends ReturnInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ReferenceType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ReferenceType.java
@@ -27,7 +27,6 @@ import com.sun.org.apache.bcel.internal.classfile.JavaClass;
 /**
  * Super class for object and array types.
  *
- * @version $Id$
  */
 public abstract class ReferenceType extends Type {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ReturnInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ReturnInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,8 +26,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
 /**
  * Super class for the xRETURN family of instructions.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class ReturnInstruction extends Instruction implements ExceptionThrower,
         TypedInstruction, StackConsumer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ReturnaddressType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ReturnaddressType.java
@@ -27,7 +27,6 @@ import com.sun.org.apache.bcel.internal.Const;
  * Returnaddress, the type JSR or JSR_W instructions push upon the stack.
  *
  * see vmspec2 3.3.3
- * @version $Id$
  */
 public class ReturnaddressType extends Type {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SALOAD.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SALOAD.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * SALOAD - Load short from array
  * <PRE>Stack: ..., arrayref, index -&gt; ..., value</PRE>
  *
- * @version $Id$
  */
 public class SALOAD extends ArrayInstruction implements StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SASTORE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SASTORE.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * SASTORE - Store into short array
  * <PRE>Stack: ..., arrayref, index, value -&gt; ...</PRE>
  *
- * @version $Id$
  */
 public class SASTORE extends ArrayInstruction implements StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SIPUSH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SIPUSH.java
@@ -30,7 +30,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  *
  * <PRE>Stack: ... -&gt; ..., value</PRE>
  *
- * @version $Id$
  */
 public class SIPUSH extends Instruction implements ConstantPushInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SWAP.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SWAP.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * SWAP - Swa top operand stack word
  * <PRE>Stack: ..., word2, word1 -&gt; ..., word1, word2</PRE>
  *
- * @version $Id$
  */
 public class SWAP extends StackInstruction implements StackConsumer, StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SWITCH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SWITCH.java
@@ -26,7 +26,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * TABLESWITCH instruction, depending on whether the match values (int[]) can be
  * sorted with no gaps between the numbers.
  *
- * @version $Id$
  */
 public final class SWITCH implements CompoundInstruction {
 
@@ -106,7 +105,7 @@ public final class SWITCH implements CompoundInstruction {
         int i = l;
         int j = r;
         int h;
-        final int m = match[(l + r) / 2];
+        final int m = match[(l + r) >>> 1];
         InstructionHandle h2;
         do {
             while (match[i] < m) {
@@ -149,12 +148,12 @@ public final class SWITCH implements CompoundInstruction {
 
 
     @Override
-    public final InstructionList getInstructionList() {
+    public InstructionList getInstructionList() {
         return new InstructionList(instruction);
     }
 
 
-    public final Instruction getInstruction() {
+    public Instruction getInstruction() {
         return instruction;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Select.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Select.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -29,11 +29,10 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  *
  * <p>We use our super's <code>target</code> property as the default target.
  *
- * @version $Id$
  * @see LOOKUPSWITCH
  * @see TABLESWITCH
  * @see InstructionList
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class Select extends BranchInstruction implements VariableLengthInstruction,
         StackConsumer /* @since 6.0 */, StackProducer {
@@ -46,8 +45,8 @@ public abstract class Select extends BranchInstruction implements VariableLength
     private int padding = 0; // number of pad bytes for alignment TODO could be package-protected?
 
     /**
-     * Empty constructor needed for the Class.newInstance() statement in
-     * Instruction.readInstruction(). Not to be used otherwise.
+     * Empty constructor needed for Instruction.readInstruction.
+     * Not to be used otherwise.
      */
     Select() {
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StackConsumer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StackConsumer.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Denote an instruction that may consume a value from the stack.
  *
- * @version $Id$
  */
 public interface StackConsumer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StackInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StackInstruction.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Super class for stack operations like DUP and POP.
  *
- * @version $Id$
  */
 public abstract class StackInstruction extends Instruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StackProducer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StackProducer.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denote an instruction that may produce a value on top of the stack
  * (this excludes DUP_X1, e.g.)
  *
- * @version $Id$
  */
 public interface StackProducer {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StoreInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/StoreInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denotes an unparameterized instruction to store a value into a local variable,
  * e.g. ISTORE.
  *
- * @version $Id$
  */
 public abstract class StoreInstruction extends LocalVariableInstruction implements PopInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/TABLESWITCH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/TABLESWITCH.java
@@ -29,7 +29,6 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * TABLESWITCH - Switch within given range of values, i.e., low..high
  *
- * @version $Id$
  * @see SWITCH
  */
 public class TABLESWITCH extends Select {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/TargetLostException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/TargetLostException.java
@@ -47,7 +47,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * @see InstructionHandle
  * @see InstructionList
  * @see InstructionTargeter
- * @version $Id$
  */
 public final class TargetLostException extends Exception {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Type.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,8 +30,7 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  * Abstract super class for all possible java types, namely basic types
  * such as int, object types like String and array types, e.g. int[]
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public abstract class Type {
 
@@ -207,9 +206,8 @@ public abstract class Type {
             wrap(consumed_chars, _temp);
             return new ArrayType(t, dim);
         } else { // type == T_REFERENCE
-            // Utility.signatureToString understands how to parse
-            // generic types.
-            final String parsedSignature = Utility.signatureToString(signature, false);
+            // Utility.typeSignatureToString understands how to parse generic types.
+            final String parsedSignature = Utility.typeSignatureToString(signature, false);
             wrap(consumed_chars, parsedSignature.length() + 2); // "Lblabla;" `L' and `;' are removed
             return ObjectType.getInstance(parsedSignature.replace('/', '.'));
         }
@@ -242,11 +240,12 @@ public abstract class Type {
         final List<Type> vec = new ArrayList<>();
         int index;
         Type[] types;
-        try { // Read all declarations between for `(' and `)'
-            if (signature.charAt(0) != '(') {
+        try {
+            // Skip any type arguments to read argument declarations between `(' and `)'
+            index = signature.indexOf('(') + 1;
+            if (index <= 0) {
                 throw new ClassFormatException("Invalid method signature: " + signature);
             }
-            index = 1; // current string position
             while (signature.charAt(index) != ')') {
                 vec.add(getType(signature.substring(index)));
                 //corrected concurrent private static field acess
@@ -344,11 +343,12 @@ public abstract class Type {
     static int getArgumentTypesSize( final String signature ) {
         int res = 0;
         int index;
-        try { // Read all declarations between for `(' and `)'
-            if (signature.charAt(0) != '(') {
+        try {
+            // Skip any type arguments to read argument declarations between `(' and `)'
+            index = signature.indexOf('(') + 1;
+            if (index <= 0) {
                 throw new ClassFormatException("Invalid method signature: " + signature);
             }
-            index = 1; // current string position
             while (signature.charAt(index) != ')') {
                 final int coded = getTypeSize(signature.substring(index));
                 res += size(coded);

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/TypedInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/TypedInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Get the type associated with an instruction, int for ILOAD, or the type
  * of the field of a PUTFIELD instruction, e.g..
  *
- * @version $Id$
  */
 public interface TypedInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/UnconditionalBranch.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/UnconditionalBranch.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.generic;
 /**
  * Denotes an instruction to perform an unconditional branch, i.e., GOTO, JSR.
  *
- * @version $Id$
 
  * @see GOTO
  * @see JSR

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/VariableLengthInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/VariableLengthInstruction.java
@@ -25,7 +25,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * Denotes an instruction to be a variable length instruction, such as
  * GOTO, JSR, LOOKUPSWITCH and TABLESWITCH.
  *
- * @version $Id$
 
  * @see GOTO
  * @see JSR

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Visitor.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Visitor.java
@@ -27,7 +27,6 @@ package com.sun.org.apache.bcel.internal.generic;
  * instructions with the properly typed methods just by calling the accept()
  * method.
  *
- * @version $Id$
  */
 public interface Visitor {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/AttributeHTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/AttributeHTML.java
@@ -45,7 +45,6 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
 /**
  * Convert found attributes into HTML file.
  *
- * @version $Id$
  *
  */
 final class AttributeHTML {
@@ -73,18 +72,18 @@ final class AttributeHTML {
     }
 
 
-    final void close() {
+    void close() {
         file.println("</TABLE></BODY></HTML>");
         file.close();
     }
 
 
-    final void writeAttribute( final Attribute attribute, final String anchor ) {
+    void writeAttribute( final Attribute attribute, final String anchor ) {
         writeAttribute(attribute, anchor, 0);
     }
 
 
-    final void writeAttribute( final Attribute attribute, final String anchor, final int method_number ) {
+    void writeAttribute( final Attribute attribute, final String anchor, final int method_number ) {
         final byte tag = attribute.getTag();
         int index;
         if (tag == Const.ATTR_UNKNOWN) {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELComparator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELComparator.java
@@ -24,7 +24,6 @@ package com.sun.org.apache.bcel.internal.util;
 /**
  * Used for BCEL comparison strategy
  *
- * @version $Id$
  * @since 5.2
  */
 public interface BCELComparator {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -64,8 +64,7 @@ import com.sun.org.apache.bcel.internal.generic.Type;
  * A helper class for BCELifier.
  *
  * @see BCELifier
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 class BCELFactory extends EmptyVisitor {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELifier.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELifier.java
@@ -46,7 +46,6 @@ import com.sun.org.apache.bcel.internal.generic.Type;
  * are done with BCEL. It does not cover all features of BCEL,
  * but tries to mimic hand-written code as close as possible.
  *
- * @version $Id$
  */
 public class BCELifier extends com.sun.org.apache.bcel.internal.classfile.EmptyVisitor {
 
@@ -113,6 +112,8 @@ public class BCELifier extends com.sun.org.apache.bcel.internal.classfile.EmptyV
                 + "\", \"" + super_name + "\", " + "\"" + clazz.getSourceFileName() + "\", "
                 + printFlags(clazz.getAccessFlags(), FLAGS.CLASS) + ", "
                 + "new String[] { " + inter + " });");
+        _out.println("    _cg.setMajor(" + clazz.getMajor() +");");
+        _out.println("    _cg.setMinor(" + clazz.getMinor() +");");
         _out.println();
         _out.println("    _cp = _cg.getConstantPool();");
         _out.println("    _factory = new InstructionFactory(_cg, _cp);");
@@ -216,7 +217,7 @@ public class BCELifier extends com.sun.org.apache.bcel.internal.classfile.EmptyV
             return "0";
         }
         final StringBuilder buf = new StringBuilder();
-        for (int i = 0, pow = 1; pow <= Const.MAX_ACC_FLAG; i++) {
+        for (int i = 0, pow = 1; pow <= Const.MAX_ACC_FLAG_I; i++) {
             if ((flags & pow) != 0) {
                 if ((pow == Const.ACC_SYNCHRONIZED) && (location == FLAGS.CLASS)) {
                     buf.append(CONSTANT_PREFIX+"ACC_SUPER | ");

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ByteSequence.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ByteSequence.java
@@ -29,7 +29,6 @@ import java.io.DataInputStream;
  * via the `readByte()' method. This is used to implement a wrapper for the
  * Java byte code stream to gain some more readability.
  *
- * @version $Id$
  */
 public final class ByteSequence extends DataInputStream {
 
@@ -42,12 +41,12 @@ public final class ByteSequence extends DataInputStream {
     }
 
 
-    public final int getIndex() {
+    public int getIndex() {
         return byteStream.getPosition();
     }
 
 
-    final void unreadByte() {
+    void unreadByte() {
         byteStream.unreadByte();
     }
 
@@ -57,12 +56,12 @@ public final class ByteSequence extends DataInputStream {
             super(bytes);
         }
 
-        final int getPosition() {
+        int getPosition() {
             // pos is protected in ByteArrayInputStream
             return pos;
         }
 
-        final void unreadByte() {
+        void unreadByte() {
             if (pos > 0) {
                 pos--;
             }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/Class2HTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/Class2HTML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -53,8 +53,7 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  * method in the Method's frame will jump to the appropriate method in
  * the Code frame.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class Class2HTML {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ClassQueue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ClassQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -27,8 +27,7 @@ import com.sun.org.apache.bcel.internal.classfile.JavaClass;
  * Utility class implementing a (typesafe) queue of JavaClass
  * objects.
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class ClassQueue {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ClassSet.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ClassSet.java
@@ -32,7 +32,6 @@ import com.sun.org.apache.bcel.internal.classfile.JavaClass;
  * Since JavaClass has no equals() method, the name of the class is
  * used for comparison.
  *
- * @version $Id$
  * @see ClassStack
  */
 public class ClassSet {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ClassStack.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ClassStack.java
@@ -28,7 +28,6 @@ import com.sun.org.apache.bcel.internal.classfile.JavaClass;
 /**
  * Utility class implementing a (typesafe) stack of JavaClass objects.
  *
- * @version $Id$
  * @see Stack
  */
 public class ClassStack {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/CodeHTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/CodeHTML.java
@@ -44,7 +44,6 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
 /**
  * Convert code into HTML file.
  *
- * @version $Id$
  *
  */
 final class CodeHTML {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ConstantHTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ConstantHTML.java
@@ -40,7 +40,6 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
 /**
  * Convert constant pool into HTML file.
  *
- * @version $Id$
  *
  */
 final class ConstantHTML {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/InstructionFinder.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/InstructionFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -62,10 +62,9 @@ import java.util.regex.Pattern;
  *
  * </pre>
  *
- * @version $Id$
  * @see com.sun.org.apache.bcel.internal.generic.Instruction
  * @see InstructionList
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class InstructionFinder {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/MethodHTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/MethodHTML.java
@@ -37,7 +37,6 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
 /**
  * Convert methods and fields into HTML file.
  *
- * @version $Id$
  *
  */
 final class MethodHTML {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ModularRuntimeImage.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ModularRuntimeImage.java
@@ -87,12 +87,10 @@ public class ModularRuntimeImage implements Closeable {
     @Override
     public void close() throws IOException {
         if (classLoader != null) {
-            if (classLoader != null) {
-                classLoader.close();
-            }
-            if (fileSystem != null) {
-                fileSystem.close();
-            }
+            classLoader.close();
+        }
+        if (fileSystem != null) {
+            fileSystem.close();
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/Repository.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -27,42 +27,34 @@ import com.sun.org.apache.bcel.internal.classfile.JavaClass;
  * Repository.setRepository method.
  *
  * @see com.sun.org.apache.bcel.internal.Repository
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public interface Repository {
 
     /**
      * Stores the provided class under "clazz.getClassName()"
      */
-    void storeClass( JavaClass clazz );
-
+    void storeClass(JavaClass clazz);
 
     /**
      * Removes class from repository
      */
-    void removeClass( JavaClass clazz );
-
-
-    /**
-     * Finds the class with the name provided, if the class
-     * isn't there, return NULL.
-     */
-    JavaClass findClass( String className );
-
+    void removeClass(JavaClass clazz);
 
     /**
-     * Finds the class with the name provided, if the class
-     * isn't there, make an attempt to load it.
+     * Finds the class with the name provided, if the class isn't there, return NULL.
      */
-    JavaClass loadClass( String className ) throws java.lang.ClassNotFoundException;
+    JavaClass findClass(String className);
 
+    /**
+     * Finds the class with the name provided, if the class isn't there, make an attempt to load it.
+     */
+    JavaClass loadClass(String className) throws java.lang.ClassNotFoundException;
 
     /**
      * Finds the JavaClass instance for the given run-time class object
      */
-    JavaClass loadClass( Class<?> clazz ) throws java.lang.ClassNotFoundException;
-
+    JavaClass loadClass(Class<?> clazz) throws java.lang.ClassNotFoundException;
 
     /**
      * Clears all entries from cache.

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/SyntheticRepository.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/SyntheticRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,8 +39,7 @@ import java.util.Map;
  *
  * @see com.sun.org.apache.bcel.internal.Repository
  *
- * @version $Id$
- * @LastModified: Jun 2019
+ * @LastModified: Jan 2020
  */
 public class SyntheticRepository implements Repository {
 
@@ -79,7 +78,7 @@ public class SyntheticRepository implements Repository {
         final SoftReference<JavaClass> ref = loadedClasses.get(className);
         if (ref == null) {
             return null;
-}
+        }
         return ref.get();
     }
 
@@ -95,7 +94,7 @@ public class SyntheticRepository implements Repository {
     public JavaClass loadClass(String className) throws ClassNotFoundException {
         if ((className == null) || className.isEmpty()) {
             throw new IllegalArgumentException("Invalid class name " + className);
-        }
+    }
         className = className.replace('/', '.'); // Just in case, canonical form
         final JavaClass clazz = findClass(className);
         if (clazz != null) {
@@ -126,7 +125,7 @@ public class SyntheticRepository implements Repository {
         final JavaClass repositoryClass = findClass(className);
         if (repositoryClass != null) {
             return repositoryClass;
-        }
+    }
         String name = className;
         final int i = name.lastIndexOf('.');
         if (i > 0) {

--- a/src/java.xml/share/legal/bcel.md
+++ b/src/java.xml/share/legal/bcel.md
@@ -1,4 +1,4 @@
-## Apache Commons Byte Code Engineering Library (BCEL) Version 6.3.1
+## Apache Commons Byte Code Engineering Library (BCEL) Version 6.4.1
 
 ### Apache Commons BCEL Notice
 <pre>


### PR DESCRIPTION
8235368: Update BCEL to Version 6.4.1

Applies cleanly except @LastModified timestamps in two files below (due to JDK-8248348 with newer timestamps is already included in 13u)

src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/BranchInstruction.java
src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Instruction.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8235368](https://bugs.openjdk.java.net/browse/JDK-8235368): Update BCEL to Version 6.4.1


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/227/head:pull/227` \
`$ git checkout pull/227`

Update a local copy of the PR: \
`$ git checkout pull/227` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 227`

View PR using the GUI difftool: \
`$ git pr show -t 227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/227.diff">https://git.openjdk.java.net/jdk13u-dev/pull/227.diff</a>

</details>
