### PR TITLE
8261109: [macOS] Remove disabled warning for JNF in make/autoconf/flags-cflags.m4

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -208,11 +208,6 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
 
       DISABLED_WARNINGS="unknown-warning-option unused-parameter unused"
 
-      if test "x$OPENJDK_TARGET_OS" = xmacosx; then
-        # missing-method-return-type triggers in JavaNativeFoundation framework
-        DISABLED_WARNINGS="$DISABLED_WARNINGS missing-method-return-type"
-      fi
-
       ;;
 
     xlc)

--- a/make/lib/Lib-java.base.gmk
+++ b/make/lib/Lib-java.base.gmk
@@ -100,8 +100,6 @@ $(BUILD_LIBNIO): $(BUILD_LIBNET)
 # Create the macosx security library
 
 ifeq ($(call isTargetOs, macosx), true)
-  # JavaNativeFoundation framework not supported in static builds
-  ifneq ($(STATIC_BUILD), true)
 
     $(eval $(call SetupJdkLibrary, BUILD_LIBOSXSECURITY, \
         NAME := osxsecurity, \
@@ -124,7 +122,6 @@ ifeq ($(call isTargetOs, macosx), true)
 
     TARGETS += $(BUILD_LIBOSXSECURITY)
 
-  endif
 endif
 
 ################################################################################


### PR DESCRIPTION
Almost clean backport to jdk13u-dev. only different filename for gmk file in jdk13 mde it not apply clean ootb.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261109](https://bugs.openjdk.java.net/browse/JDK-8261109): [macOS] Remove disabled warning for JNF in make/autoconf/flags-cflags.m4


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/235.diff">https://git.openjdk.java.net/jdk13u-dev/pull/235.diff</a>

</details>
