### PR TITLE
8257620: Do not use objc_msgSend_stret to get macOS version

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -236,11 +236,16 @@ void setOSNameAndVersion(java_props_t *sprops) {
 
     char* osVersionCStr = NULL;
     // Mac OS 10.9 includes the [NSProcessInfo operatingSystemVersion] function,
-    // but it's not in the 10.9 SDK.  So, call it via objc_msgSend_stret.
+    // but it's not in the 10.9 SDK.  So, call it via NSInvocation.
     if ([[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)]) {
-        OSVerStruct (*procInfoFn)(id rec, SEL sel) = (OSVerStruct(*)(id, SEL))objc_msgSend_stret;
-        OSVerStruct osVer = procInfoFn([NSProcessInfo processInfo],
-                                       @selector(operatingSystemVersion));
+        OSVerStruct osVer;
+        NSMethodSignature *sig = [[NSProcessInfo processInfo] methodSignatureForSelector:
+                @selector(operatingSystemVersion)];
+        NSInvocation *invoke = [NSInvocation invocationWithMethodSignature:sig];
+        invoke.selector = @selector(operatingSystemVersion);
+        [invoke invokeWithTarget:[NSProcessInfo processInfo]];
+        [invoke getReturnValue:&osVer];
+
         NSString *nsVerStr;
         if (osVer.patchVersion == 0) { // Omit trailing ".0"
             nsVerStr = [NSString stringWithFormat:@"%ld.%ld",


### PR DESCRIPTION
Applies cleanly, patch needed for zero+mac+aarch64 config

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257620](https://bugs.openjdk.java.net/browse/JDK-8257620): Do not use objc_msgSend_stret to get macOS version


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/241/head:pull/241` \
`$ git checkout pull/241`

Update a local copy of the PR: \
`$ git checkout pull/241` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 241`

View PR using the GUI difftool: \
`$ git pr show -t 241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/241.diff">https://git.openjdk.java.net/jdk13u-dev/pull/241.diff</a>

</details>
