### PR TITLE
8226871: invalid use of incomplete type class MacroAssembler when building minimal after JDK-8191278

### DIFF
--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "asm/codeBuffer.hpp"
+#include "asm/macroAssembler.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"


### PR DESCRIPTION
This is follow-up for https://github.com/openjdk/jdk13u-dev/pull/240 and required to build arm32/aarch64 binaries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226871](https://bugs.openjdk.java.net/browse/JDK-8226871): invalid use of incomplete type class MacroAssembler when building minimal after JDK-8191278


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/242.diff">https://git.openjdk.java.net/jdk13u-dev/pull/242.diff</a>

</details>
