### PR TITLE
8241888: Mirror jdk.security.allowNonCaAnchor system property with a security one

### DIFF
--- a/src/java.base/share/classes/sun/security/validator/PKIXValidator.java
+++ b/src/java.base/share/classes/sun/security/validator/PKIXValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,9 @@ import java.security.cert.*;
 
 import javax.security.auth.x500.X500Principal;
 import sun.security.action.GetBooleanAction;
-import sun.security.action.GetPropertyAction;
 import sun.security.provider.certpath.AlgorithmChecker;
 import sun.security.provider.certpath.PKIXExtendedParameters;
+import sun.security.util.SecurityProperties;
 
 /**
  * Validator implementation built on the PKIX CertPath API. This
@@ -62,14 +62,14 @@ public final class PKIXValidator extends Validator {
             .privilegedGetProperty("com.sun.net.ssl.checkRevocation");
 
     /**
-     * System property that if set (or set to "true"), allows trust anchor
-     * certificates to be used if they do not have the proper CA extensions.
-     * Set to false if prop is not set, or set to any other value.
+     * System or security property that if set (or set to "true"), allows trust
+     * anchor certificates to be used if they do not have the proper CA
+     * extensions. Set to false if prop is not set, or set to any other value.
      */
     private static final boolean ALLOW_NON_CA_ANCHOR = allowNonCaAnchor();
     private static boolean allowNonCaAnchor() {
-        String prop = GetPropertyAction
-            .privilegedGetProperty("jdk.security.allowNonCaAnchor");
+        String prop = SecurityProperties
+                .privilegedGetOverridable("jdk.security.allowNonCaAnchor");
         return prop != null && (prop.isEmpty() || prop.equalsIgnoreCase("true"));
     }
 

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1312,6 +1312,19 @@ jdk.io.permissionsUseCanonicalPath=false
 #jdk.security.krb5.default.initiate.credential=always-impersonate
 
 #
+# Trust Anchor Certificates - CA Basic Constraint check
+#
+# X.509 v3 certificates used as Trust Anchors (to validate signed code or TLS
+# connections) must have the cA Basic Constraint field set to 'true'. Also, if
+# they include a Key Usage extension, the keyCertSign bit must be set. These
+# checks, enabled by default, can be disabled for backward-compatibility
+# purposes with the jdk.security.allowNonCaAnchor System and Security
+# properties. In the case that both properties are simultaneously set, the
+# System value prevails. The default value of the property is "false".
+#
+#jdk.security.allowNonCaAnchor=true
+
+#
 # JNDI Object Factories Filter
 #
 # This filter is used by the JNDI runtime to control the set of object factory classes


### PR DESCRIPTION
The original patch applies almost clean: trivial fix in java.security because of jdk.jndi.object.factoriesFilter property already backported into 13u
Tests in jdk/sun/security/validator passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241888](https://bugs.openjdk.java.net/browse/JDK-8241888): Mirror jdk.security.allowNonCaAnchor system property with a security one


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/249.diff">https://git.openjdk.java.net/jdk13u-dev/pull/249.diff</a>

</details>
