### PR TITLE
8215712: Parsing extension failure may alert decode_error

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertSignAlgsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertSignAlgsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,9 +56,10 @@ final class CertSignAlgsExtension {
     private static final
             class CertSignatureSchemesStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new SignatureSchemesSpec(buffer)).toString();
+                return (new SignatureSchemesSpec(hc, buffer))
+                        .toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -150,12 +151,7 @@ final class CertSignAlgsExtension {
             }
 
             // Parse the extension.
-            SignatureSchemesSpec spec;
-            try {
-                spec = new SignatureSchemesSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            SignatureSchemesSpec spec = new SignatureSchemesSpec(shc, buffer);
 
             // Update the context.
             shc.handshakeExtensions.put(
@@ -295,12 +291,7 @@ final class CertSignAlgsExtension {
             }
 
             // Parse the extension.
-            SignatureSchemesSpec spec;
-            try {
-                spec = new SignatureSchemesSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            SignatureSchemesSpec spec = new SignatureSchemesSpec(chc, buffer);
 
             // Update the context.
             chc.handshakeExtensions.put(

--- a/src/java.base/share/classes/sun/security/ssl/CertStatusExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertStatusExtension.java
@@ -121,7 +121,8 @@ final class CertStatusExtension {
             this.statusRequest = statusRequest;
         }
 
-        private CertStatusRequestSpec(ByteBuffer buffer) throws IOException {
+        private CertStatusRequestSpec(HandshakeContext hc,
+                ByteBuffer buffer) throws IOException {
             // Is it a empty extension_data?
             if (buffer.remaining() == 0) {
                 // server response
@@ -130,8 +131,9 @@ final class CertStatusExtension {
             }
 
             if (buffer.remaining() < 1) {
-                throw new SSLProtocolException(
-                    "Invalid status_request extension: insufficient data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid status_request extension: insufficient data"));
             }
 
             byte statusType = (byte)Record.getInt8(buffer);
@@ -178,10 +180,12 @@ final class CertStatusExtension {
             this.statusResponse = resp;
         }
 
-        private CertStatusResponseSpec(ByteBuffer buffer) throws IOException {
+        private CertStatusResponseSpec(HandshakeContext hc,
+                ByteBuffer buffer) throws IOException {
             if (buffer.remaining() < 2) {
-                throw new SSLProtocolException(
-                    "Invalid status_request extension: insufficient data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid status_request extension: insufficient data"));
             }
 
             // Get the status type (1 byte) and response data (vector)
@@ -212,9 +216,9 @@ final class CertStatusExtension {
     private static final
             class CertStatusRequestStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new CertStatusRequestSpec(buffer)).toString();
+                return (new CertStatusRequestSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -225,9 +229,9 @@ final class CertStatusExtension {
     private static final
             class CertStatusRespStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new CertStatusResponseSpec(buffer)).toString();
+                return (new CertStatusResponseSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                  // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -599,12 +603,7 @@ final class CertStatusExtension {
             }
 
             // Parse the extension.
-            CertStatusRequestSpec spec;
-            try {
-                spec = new CertStatusRequestSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            CertStatusRequestSpec spec = new CertStatusRequestSpec(shc, buffer);
 
             // Update the context.
             shc.handshakeExtensions.put(SSLExtension.CH_STATUS_REQUEST, spec);
@@ -776,7 +775,8 @@ final class CertStatusExtension {
             this.certStatusRequests = certStatusRequests;
         }
 
-        private CertStatusRequestV2Spec(ByteBuffer message) throws IOException {
+        private CertStatusRequestV2Spec(HandshakeContext hc,
+                ByteBuffer message) throws IOException {
             // Is it a empty extension_data?
             if (message.remaining() == 0) {
                 // server response
@@ -787,15 +787,17 @@ final class CertStatusExtension {
             if (message.remaining() < 5) {  //  2: certificate_status_req_list
                                             // +1: status_type
                                             // +2: request_length
-                throw new SSLProtocolException(
-                    "Invalid status_request_v2 extension: insufficient data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid status_request_v2 extension: insufficient data"));
             }
 
             int listLen = Record.getInt16(message);
             if (listLen <= 0) {
-                throw new SSLProtocolException(
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "certificate_status_req_list length must be positive " +
-                    "(received length: " + listLen + ")");
+                    "(received length: " + listLen + ")"));
             }
 
             int remaining = listLen;
@@ -805,10 +807,12 @@ final class CertStatusExtension {
                 int requestLen = Record.getInt16(message);
 
                 if (message.remaining() < requestLen) {
-                    throw new SSLProtocolException(
+                        throw hc.conContext.fatal(
+                                Alert.DECODE_ERROR,
+                                new SSLProtocolException(
                             "Invalid status_request_v2 extension: " +
                             "insufficient data (request_length=" + requestLen +
-                            ", remining=" + message.remaining() + ")");
+                            ", remining=" + message.remaining() + ")"));
                 }
 
                 byte[] encoded = new byte[requestLen];
@@ -823,9 +827,11 @@ final class CertStatusExtension {
                     if (encoded.length < 4) {
                                         //  2: length of responder_id_list
                                         // +2: length of request_extensions
-                        throw new SSLProtocolException(
+                        throw hc.conContext.fatal(
+                                Alert.DECODE_ERROR,
+                                new SSLProtocolException(
                             "Invalid status_request_v2 extension: " +
-                            "insufficient data");
+                            "insufficient data"));
                     }
                     statusRequests.add(
                             new OCSPStatusRequest(statusType, encoded));
@@ -874,9 +880,9 @@ final class CertStatusExtension {
     private static final
             class CertStatusRequestsStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new CertStatusRequestV2Spec(buffer)).toString();
+                return (new CertStatusRequestV2Spec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -957,12 +963,7 @@ final class CertStatusExtension {
             }
 
             // Parse the extension.
-            CertStatusRequestV2Spec spec;
-            try {
-                spec = new CertStatusRequestV2Spec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            CertStatusRequestV2Spec spec = new CertStatusRequestV2Spec(shc, buffer);
 
             // Update the context.
             shc.handshakeExtensions.put(SSLExtension.CH_STATUS_REQUEST_V2,
@@ -1185,12 +1186,7 @@ final class CertStatusExtension {
             ClientHandshakeContext chc = (ClientHandshakeContext)context;
 
             // Parse the extension.
-            CertStatusResponseSpec spec;
-            try {
-                spec = new CertStatusResponseSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.DECODE_ERROR, ioe);
-            }
+            CertStatusResponseSpec spec = new CertStatusResponseSpec(chc, buffer);
 
             if (chc.sslContext.isStaplingEnabled(true)) {
                 // Activate stapling

--- a/src/java.base/share/classes/sun/security/ssl/KeyShareExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/KeyShareExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,21 +139,24 @@ final class KeyShareExtension {
             this.clientShares = clientShares;
         }
 
-        private CHKeyShareSpec(ByteBuffer buffer) throws IOException {
+        private CHKeyShareSpec(HandshakeContext handshakeContext,
+                ByteBuffer buffer) throws IOException {
             // struct {
             //      KeyShareEntry client_shares<0..2^16-1>;
             // } KeyShareClientHello;
             if (buffer.remaining() < 2) {
-                throw new SSLProtocolException(
+                throw handshakeContext.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "Invalid key_share extension: " +
-                    "insufficient data (length=" + buffer.remaining() + ")");
+                    "insufficient data (length=" + buffer.remaining() + ")"));
             }
 
             int listLen = Record.getInt16(buffer);
             if (listLen != buffer.remaining()) {
-                throw new SSLProtocolException(
+                throw handshakeContext.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "Invalid key_share extension: " +
-                    "incorrect list length (length=" + listLen + ")");
+                    "incorrect list length (length=" + listLen + ")"));
             }
 
             List<KeyShareEntry> keyShares = new LinkedList<>();
@@ -161,8 +164,9 @@ final class KeyShareExtension {
                 int namedGroupId = Record.getInt16(buffer);
                 byte[] keyExchange = Record.getBytes16(buffer);
                 if (keyExchange.length == 0) {
-                    throw new SSLProtocolException(
-                        "Invalid key_share extension: empty key_exchange");
+                    throw handshakeContext.conContext.fatal(Alert.DECODE_ERROR,
+                            new SSLProtocolException(
+                        "Invalid key_share extension: empty key_exchange"));
                 }
 
                 keyShares.add(new KeyShareEntry(namedGroupId, keyExchange));
@@ -191,9 +195,10 @@ final class KeyShareExtension {
 
     private static final class CHKeyShareStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(
+                HandshakeContext handshakeContext, ByteBuffer buffer) {
             try {
-                return (new CHKeyShareSpec(buffer)).toString();
+                return (new CHKeyShareSpec(handshakeContext, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -326,13 +331,7 @@ final class KeyShareExtension {
             }
 
             // Parse the extension
-            CHKeyShareSpec spec;
-            try {
-                spec = new CHKeyShareSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
+            CHKeyShareSpec spec = new CHKeyShareSpec(shc, buffer);
             List<SSLCredentials> credentials = new LinkedList<>();
             for (KeyShareEntry entry : spec.clientShares) {
                 NamedGroup ng = NamedGroup.valueOf(entry.namedGroupId);
@@ -415,22 +414,25 @@ final class KeyShareExtension {
             this.serverShare = serverShare;
         }
 
-        private SHKeyShareSpec(ByteBuffer buffer) throws IOException {
+        private SHKeyShareSpec(HandshakeContext handshakeContext,
+                ByteBuffer buffer) throws IOException {
             // struct {
             //      KeyShareEntry server_share;
             // } KeyShareServerHello;
             if (buffer.remaining() < 5) {       // 5: minimal server_share
-                throw new SSLProtocolException(
+                throw handshakeContext.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "Invalid key_share extension: " +
-                    "insufficient data (length=" + buffer.remaining() + ")");
+                    "insufficient data (length=" + buffer.remaining() + ")"));
             }
 
             int namedGroupId = Record.getInt16(buffer);
             byte[] keyExchange = Record.getBytes16(buffer);
 
             if (buffer.hasRemaining()) {
-                throw new SSLProtocolException(
-                    "Invalid key_share extension: unknown extra data");
+                throw handshakeContext.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid key_share extension: unknown extra data"));
             }
 
             this.serverShare = new KeyShareEntry(namedGroupId, keyExchange);
@@ -459,9 +461,10 @@ final class KeyShareExtension {
 
     private static final class SHKeyShareStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext handshakeContext,
+                ByteBuffer buffer) {
             try {
-                return (new SHKeyShareSpec(buffer)).toString();
+                return (new SHKeyShareSpec(handshakeContext, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -613,13 +616,7 @@ final class KeyShareExtension {
             }
 
             // Parse the extension
-            SHKeyShareSpec spec;
-            try {
-                spec = new SHKeyShareSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
+            SHKeyShareSpec spec = new SHKeyShareSpec(chc, buffer);
             KeyShareEntry keyShare = spec.serverShare;
             NamedGroup ng = NamedGroup.valueOf(keyShare.namedGroupId);
             if (ng == null || !SupportedGroups.isActivatable(
@@ -692,14 +689,16 @@ final class KeyShareExtension {
             this.selectedGroup = serverGroup.id;
         }
 
-        private HRRKeyShareSpec(ByteBuffer buffer) throws IOException {
+        private HRRKeyShareSpec(HandshakeContext handshakeContext,
+                ByteBuffer buffer) throws IOException {
             // struct {
             //     NamedGroup selected_group;
             // } KeyShareHelloRetryRequest;
             if (buffer.remaining() != 2) {
-                throw new SSLProtocolException(
+                throw handshakeContext.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "Invalid key_share extension: " +
-                    "improper data (length=" + buffer.remaining() + ")");
+                    "improper data (length=" + buffer.remaining() + ")"));
             }
 
             this.selectedGroup = Record.getInt16(buffer);
@@ -719,9 +718,10 @@ final class KeyShareExtension {
 
     private static final class HRRKeyShareStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext handshakeContext,
+                ByteBuffer buffer) {
             try {
-                return (new HRRKeyShareSpec(buffer)).toString();
+                return (new HRRKeyShareSpec(handshakeContext, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -865,22 +865,16 @@ final class KeyShareExtension {
             }
 
             // Parse the extension
-            HRRKeyShareSpec spec;
-            try {
-                spec = new HRRKeyShareSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
+            HRRKeyShareSpec spec = new HRRKeyShareSpec(chc, buffer);
             NamedGroup serverGroup = NamedGroup.valueOf(spec.selectedGroup);
             if (serverGroup == null) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE,
+                throw chc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                         "Unsupported HelloRetryRequest selected group: " +
                                 NamedGroup.nameOf(spec.selectedGroup));
             }
 
             if (!chc.clientRequestedNamedGroups.contains(serverGroup)) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE,
+                throw chc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                         "Unexpected HelloRetryRequest selected group: " +
                                 serverGroup.name);
             }

--- a/src/java.base/share/classes/sun/security/ssl/MaxFragExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/MaxFragExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,10 +71,12 @@ final class MaxFragExtension {
             this.id = id;
         }
 
-        private MaxFragLenSpec(ByteBuffer buffer) throws IOException {
+        private MaxFragLenSpec(HandshakeContext hc,
+                ByteBuffer buffer) throws IOException {
             if (buffer.remaining() != 1) {
-                throw new SSLProtocolException(
-                    "Invalid max_fragment_length extension data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid max_fragment_length extension data"));
             }
 
             this.id = buffer.get();
@@ -88,9 +90,9 @@ final class MaxFragExtension {
 
     private static final class MaxFragLenStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new MaxFragLenSpec(buffer)).toString();
+                return (new MaxFragLenSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -249,13 +251,7 @@ final class MaxFragExtension {
             }
 
             // Parse the extension.
-            MaxFragLenSpec spec;
-            try {
-                spec = new MaxFragLenSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
+            MaxFragLenSpec spec = new MaxFragLenSpec(shc, buffer);
             MaxFragLenEnum mfle = MaxFragLenEnum.valueOf(spec.id);
             if (mfle == null) {
                 throw shc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
@@ -363,13 +359,7 @@ final class MaxFragExtension {
             }
 
             // Parse the extension.
-            MaxFragLenSpec spec;
-            try {
-                spec = new MaxFragLenSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
+            MaxFragLenSpec spec = new MaxFragLenSpec(chc, buffer);
             if (spec.id != requestedSpec.id) {
                 throw chc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                     "The maximum fragment length response is not requested");
@@ -535,13 +525,7 @@ final class MaxFragExtension {
             }
 
             // Parse the extension.
-            MaxFragLenSpec spec;
-            try {
-                spec = new MaxFragLenSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
+            MaxFragLenSpec spec = new MaxFragLenSpec(chc, buffer);
             if (spec.id != requestedSpec.id) {
                 throw chc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
                     "The maximum fragment length response is not requested");

--- a/src/java.base/share/classes/sun/security/ssl/PreSharedKeyExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/PreSharedKeyExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.util.Collection;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLProtocolException;
 import static sun.security.ssl.ClientAuthType.CLIENT_AUTH_REQUIRED;
 import sun.security.ssl.ClientHello.ClientHelloMessage;
 import sun.security.ssl.SSLExtension.ExtensionConsumer;
@@ -107,23 +108,25 @@ final class PreSharedKeyExtension {
             this.binders = binders;
         }
 
-        CHPreSharedKeySpec(HandshakeContext context,
+        CHPreSharedKeySpec(HandshakeContext hc,
                 ByteBuffer m) throws IOException {
             // struct {
             //     PskIdentity identities<7..2^16-1>;
             //     PskBinderEntry binders<33..2^16-1>;
             // } OfferedPsks;
             if (m.remaining() < 44) {
-                throw context.conContext.fatal(Alert.ILLEGAL_PARAMETER,
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "Invalid pre_shared_key extension: " +
-                    "insufficient data (length=" + m.remaining() + ")");
+                    "insufficient data (length=" + m.remaining() + ")"));
             }
 
             int idEncodedLength = Record.getInt16(m);
             if (idEncodedLength < 7) {
-                throw context.conContext.fatal(Alert.ILLEGAL_PARAMETER,
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "Invalid pre_shared_key extension: " +
-                    "insufficient identities (length=" + idEncodedLength + ")");
+                    "insufficient identities (length=" + idEncodedLength + ")"));
             }
 
             identities = new ArrayList<>();
@@ -131,9 +134,10 @@ final class PreSharedKeyExtension {
             while (idReadLength < idEncodedLength) {
                 byte[] id = Record.getBytes16(m);
                 if (id.length < 1) {
-                    throw context.conContext.fatal(Alert.ILLEGAL_PARAMETER,
+                    throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                            new SSLProtocolException(
                         "Invalid pre_shared_key extension: " +
-                        "insufficient identity (length=" + id.length + ")");
+                        "insufficient identity (length=" + id.length + ")"));
                 }
                 int obfuscatedTicketAge = Record.getInt32(m);
 
@@ -143,18 +147,20 @@ final class PreSharedKeyExtension {
             }
 
             if (m.remaining() < 35) {
-                throw context.conContext.fatal(Alert.ILLEGAL_PARAMETER,
-                        "Invalid pre_shared_key extension: " +
-                        "insufficient binders data (length=" +
-                        m.remaining() + ")");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid pre_shared_key extension: " +
+                    "insufficient binders data (length=" +
+                    m.remaining() + ")"));
             }
 
             int bindersEncodedLen = Record.getInt16(m);
             if (bindersEncodedLen < 33) {
-                throw context.conContext.fatal(Alert.ILLEGAL_PARAMETER,
-                        "Invalid pre_shared_key extension: " +
-                        "insufficient binders (length=" +
-                        bindersEncodedLen + ")");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid pre_shared_key extension: " +
+                    "insufficient binders (length=" +
+                    bindersEncodedLen + ")"));
             }
 
             binders = new ArrayList<>();
@@ -162,10 +168,11 @@ final class PreSharedKeyExtension {
             while (bindersReadLength < bindersEncodedLen) {
                 byte[] binder = Record.getBytes8(m);
                 if (binder.length < 32) {
-                    throw context.conContext.fatal(Alert.ILLEGAL_PARAMETER,
-                            "Invalid pre_shared_key extension: " +
-                            "insufficient binder entry (length=" +
-                            binder.length + ")");
+                    throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                            new SSLProtocolException(
+                        "Invalid pre_shared_key extension: " +
+                        "insufficient binder entry (length=" +
+                        binder.length + ")"));
                 }
                 binders.add(binder);
                 bindersReadLength += 1 + binder.length;
@@ -253,15 +260,9 @@ final class PreSharedKeyExtension {
     private static final
             class CHPreSharedKeyStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                // As the HandshakeContext parameter of CHPreSharedKeySpec
-                // constructor is used for fatal alert only, we can use
-                // null HandshakeContext here as we don't care about exception.
-                //
-                // Please take care of this code if the CHPreSharedKeySpec
-                // constructor is updated in the future.
-                return (new CHPreSharedKeySpec(null, buffer)).toString();
+                return (new CHPreSharedKeySpec(hc, buffer)).toString();
             } catch (Exception ex) {
                 // For debug logging only, so please swallow exceptions.
                 return ex.getMessage();
@@ -277,13 +278,14 @@ final class PreSharedKeyExtension {
             this.selectedIdentity = selectedIdentity;
         }
 
-        SHPreSharedKeySpec(HandshakeContext context,
+        SHPreSharedKeySpec(HandshakeContext hc,
                 ByteBuffer m) throws IOException {
             if (m.remaining() < 2) {
-                throw context.conContext.fatal(Alert.ILLEGAL_PARAMETER,
-                        "Invalid pre_shared_key extension: " +
-                        "insufficient selected_identity (length=" +
-                        m.remaining() + ")");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid pre_shared_key extension: " +
+                    "insufficient selected_identity (length=" +
+                    m.remaining() + ")"));
             }
             this.selectedIdentity = Record.getInt16(m);
         }
@@ -314,15 +316,9 @@ final class PreSharedKeyExtension {
     private static final
             class SHPreSharedKeyStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                // As the HandshakeContext parameter of SHPreSharedKeySpec
-                // constructor is used for fatal alert only, we can use
-                // null HandshakeContext here as we don't care about exception.
-                //
-                // Please take care of this code if the SHPreSharedKeySpec
-                // constructor is updated in the future.
-                return (new SHPreSharedKeySpec(null, buffer)).toString();
+                return (new SHPreSharedKeySpec(hc, buffer)).toString();
             } catch (Exception ex) {
                 // For debug logging only, so please swallow exceptions.
                 return ex.getMessage();
@@ -353,12 +349,7 @@ final class PreSharedKeyExtension {
             }
 
             // Parse the extension.
-            CHPreSharedKeySpec pskSpec = null;
-            try {
-                pskSpec = new CHPreSharedKeySpec(shc, buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            CHPreSharedKeySpec pskSpec = new CHPreSharedKeySpec(shc, buffer);
 
             // The "psk_key_exchange_modes" extension should have been loaded.
             if (!shc.handshakeExtensions.containsKey(
@@ -392,7 +383,7 @@ final class PreSharedKeyExtension {
                             requestedId.identity.length > SessionId.MAX_LENGTH &&
                             sessionCache.statelessEnabled()) {
                         ByteBuffer b =
-                                new SessionTicketSpec(requestedId.identity).
+                            new SessionTicketSpec(shc, requestedId.identity).
                                         decrypt(shc);
                         if (b != null) {
                             try {

--- a/src/java.base/share/classes/sun/security/ssl/RenegoInfoExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/RenegoInfoExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,12 +74,14 @@ final class RenegoInfoExtension {
                     renegotiatedConnection, renegotiatedConnection.length);
         }
 
-        private RenegotiationInfoSpec(ByteBuffer m) throws IOException {
+        private RenegotiationInfoSpec(HandshakeContext hc,
+                ByteBuffer m) throws IOException {
             // Parse the extension.
             if (!m.hasRemaining() || m.remaining() < 1) {
-                throw new SSLProtocolException(
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
                     "Invalid renegotiation_info extension data: " +
-                    "insufficient data");
+                    "insufficient data"));
             }
             this.renegotiatedConnection = Record.getBytes8(m);
         }
@@ -105,9 +107,9 @@ final class RenegoInfoExtension {
     private static final
             class RenegotiationInfoStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new RenegotiationInfoSpec(buffer)).toString();
+                return (new RenegotiationInfoSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -220,13 +222,7 @@ final class RenegoInfoExtension {
             }
 
             // Parse the extension.
-            RenegotiationInfoSpec spec;
-            try {
-                spec = new RenegotiationInfoSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
+            RenegotiationInfoSpec spec = new RenegotiationInfoSpec(shc, buffer);
             if (!shc.conContext.isNegotiated) {
                 // initial handshaking.
                 if (spec.renegotiatedConnection.length != 0) {
@@ -433,14 +429,7 @@ final class RenegoInfoExtension {
             }
 
             // Parse the extension.
-            RenegotiationInfoSpec spec;
-            try {
-                spec = new RenegotiationInfoSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
-
-
+            RenegotiationInfoSpec spec = new RenegotiationInfoSpec(chc, buffer);
             if (!chc.conContext.isNegotiated) {     // initial handshake
                 // If the extension is present, set the secure_renegotiation
                 // flag to TRUE.  The client MUST then verify that the

--- a/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
@@ -643,7 +643,8 @@ enum SSLExtension implements SSLStringizer {
     }
 
     @Override
-    public String toString(ByteBuffer byteBuffer) {
+    public String toString(
+            HandshakeContext handshakeContext, ByteBuffer byteBuffer) {
         MessageFormat messageFormat = new MessageFormat(
             "\"{0} ({1})\": '{'\n" +
             "{2}\n" +
@@ -656,7 +657,7 @@ enum SSLExtension implements SSLStringizer {
             String encoded = hexEncoder.encode(byteBuffer.duplicate());
             extData = encoded;
         } else {
-            extData = stringizer.toString(byteBuffer);
+            extData = stringizer.toString(handshakeContext, byteBuffer);
         }
 
         Object[] messageFields = {

--- a/src/java.base/share/classes/sun/security/ssl/SSLExtensions.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLExtensions.java
@@ -346,7 +346,8 @@ final class SSLExtensions {
                     }
                     if (ext != null) {
                         builder.append(
-                                ext.toString(ByteBuffer.wrap(en.getValue())));
+                            ext.toString(handshakeMessage.handshakeContext,
+                                    ByteBuffer.wrap(en.getValue())));
                     } else {
                         builder.append(toString(en.getKey(), en.getValue()));
                     }
@@ -359,7 +360,8 @@ final class SSLExtensions {
                         builder.append(",\n");
                     }
                     builder.append(
-                        en.getKey().toString(ByteBuffer.wrap(en.getValue())));
+                        en.getKey().toString(handshakeMessage.handshakeContext,
+                                ByteBuffer.wrap(en.getValue())));
                 }
 
                 return builder.toString();

--- a/src/java.base/share/classes/sun/security/ssl/SSLStringizer.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLStringizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,5 +37,5 @@ interface SSLStringizer {
      * Note that the implementation MUST not change the internal status of
      * the {@code buffer}.
      */
-    String toString(ByteBuffer buffer);
+    String toString(HandshakeContext handshakeContext, ByteBuffer buffer);
 }

--- a/src/java.base/share/classes/sun/security/ssl/ServerHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerHello.java
@@ -47,8 +47,6 @@ import sun.security.ssl.SSLCipher.SSLWriteCipher;
 import sun.security.ssl.SSLHandshake.HandshakeMessage;
 import sun.security.ssl.SupportedVersionsExtension.SHSupportedVersionsSpec;
 
-import static sun.security.ssl.SSLExtension.SH_SESSION_TICKET;
-
 /**
  * Pack of the ServerHello/HelloRetryRequest handshake message.
  */

--- a/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/ServerNameExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,16 +93,19 @@ final class ServerNameExtension {
                     new ArrayList<>(serverNames));
         }
 
-        private CHServerNamesSpec(ByteBuffer buffer) throws IOException {
+        private CHServerNamesSpec(HandshakeContext hc,
+                ByteBuffer buffer) throws IOException {
             if (buffer.remaining() < 2) {
-                throw new SSLProtocolException(
-                    "Invalid server_name extension: insufficient data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid server_name extension: insufficient data"));
             }
 
             int sniLen = Record.getInt16(buffer);
             if ((sniLen == 0) || sniLen != buffer.remaining()) {
-                throw new SSLProtocolException(
-                    "Invalid server_name extension: incomplete data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid server_name extension: incomplete data"));
             }
 
             Map<Integer, SNIServerName> sniMap = new LinkedHashMap<>();
@@ -121,8 +124,9 @@ final class ServerNameExtension {
                 byte[] encoded = Record.getBytes16(buffer);
                 if (nameType == StandardConstants.SNI_HOST_NAME) {
                     if (encoded.length == 0) {
-                        throw new SSLProtocolException(
-                            "Empty HostName in server_name extension");
+                        throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                                new SSLProtocolException(
+                            "Empty HostName in server_name extension"));
                     }
 
                     try {
@@ -134,7 +138,8 @@ final class ServerNameExtension {
                             (new String(encoded, StandardCharsets.UTF_8)) +
                             ", value={" +
                             Utilities.toHexString(encoded) + "}");
-                        throw (SSLProtocolException)spe.initCause(iae);
+                        throw hc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
+                                (SSLProtocolException)spe.initCause(iae));
                     }
                 } else {
                     try {
@@ -144,15 +149,17 @@ final class ServerNameExtension {
                             "Illegal server name, type=(" + nameType +
                             "), value={" +
                             Utilities.toHexString(encoded) + "}");
-                        throw (SSLProtocolException)spe.initCause(iae);
+                        throw hc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
+                                (SSLProtocolException)spe.initCause(iae));
                     }
                 }
 
                 // check for duplicated server name type
                 if (sniMap.put(serverName.getType(), serverName) != null) {
-                    throw new SSLProtocolException(
+                        throw hc.conContext.fatal(Alert.ILLEGAL_PARAMETER,
+                                new SSLProtocolException(
                             "Duplicated server name of type " +
-                            serverName.getType());
+                            serverName.getType()));
                 }
             }
 
@@ -183,9 +190,9 @@ final class ServerNameExtension {
 
     private static final class CHServerNamesStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new CHServerNamesSpec(buffer)).toString();
+                return (new CHServerNamesSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -291,12 +298,7 @@ final class ServerNameExtension {
             }
 
             // Parse the extension.
-            CHServerNamesSpec spec;
-            try {
-                spec = new CHServerNamesSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            CHServerNamesSpec spec = new CHServerNamesSpec(shc, buffer);
 
             // Update the context.
             shc.handshakeExtensions.put(CH_SERVER_NAME, spec);
@@ -390,10 +392,12 @@ final class ServerNameExtension {
             // blank
         }
 
-        private SHServerNamesSpec(ByteBuffer buffer) throws IOException {
+        private SHServerNamesSpec(HandshakeContext hc,
+                ByteBuffer buffer) throws IOException {
             if (buffer.remaining() != 0) {
-                throw new SSLProtocolException(
-                    "Invalid ServerHello server_name extension: not empty");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid ServerHello server_name extension: not empty"));
             }
         }
 
@@ -405,9 +409,9 @@ final class ServerNameExtension {
 
     private static final class SHServerNamesStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new SHServerNamesSpec(buffer)).toString();
+                return (new SHServerNamesSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();

--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,18 +237,21 @@ final class SessionTicketExtension {
             data = zero;
         }
 
-        SessionTicketSpec(byte[] b) throws IOException {
-            this(ByteBuffer.wrap(b));
+        SessionTicketSpec(HandshakeContext hc, byte[] b) throws IOException {
+            this(hc, ByteBuffer.wrap(b));
         }
 
-        SessionTicketSpec(ByteBuffer buf) throws IOException {
+        SessionTicketSpec(HandshakeContext hc,
+                ByteBuffer buf) throws IOException {
             if (buf == null) {
-                throw new SSLProtocolException(
-                        "SessionTicket buffer too small");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "SessionTicket buffer too small"));
             }
             if (buf.remaining() > 65536) {
-                throw new SSLProtocolException(
-                        "SessionTicket buffer too large. " + buf.remaining());
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "SessionTicket buffer too large. " + buf.remaining()));
             }
 
             data = buf;
@@ -366,12 +369,10 @@ final class SessionTicketExtension {
     }
 
     static final class SessionTicketStringizer implements SSLStringizer {
-        SessionTicketStringizer() {}
-
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return new SessionTicketSpec(buffer).toString();
+                return new SessionTicketSpec(hc, buffer).toString();
             } catch (IOException e) {
                 return e.getMessage();
             }
@@ -456,16 +457,7 @@ final class SessionTicketExtension {
             }
 
             // Parse the extension.
-            SessionTicketSpec spec;
-            try {
-                 spec = new SessionTicketSpec(buffer);
-            } catch (IOException | RuntimeException e) {
-                if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                    SSLLogger.fine("SessionTicket data invalid. Doing full " +
-                            "handshake.");
-                }
-                return;
-            }
+            SessionTicketSpec spec = new SessionTicketSpec(shc, buffer);
             ByteBuffer b = spec.decrypt(shc);
             if (b != null) {
                 shc.resumingSession = new SSLSessionImpl(shc, b);
@@ -532,14 +524,8 @@ final class SessionTicketExtension {
                 return;
             }
 
-            try {
-                if (new SessionTicketSpec(buffer) == null) {
-                    return;
-                }
-                chc.statelessResumption = true;
-            } catch (IOException e) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, e);
-            }
+            SessionTicketSpec spec = new SessionTicketSpec(chc, buffer);
+            chc.statelessResumption = true;
         }
     }
 }

--- a/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,21 +82,25 @@ final class SignatureAlgorithmsExtension {
             }
         }
 
-        SignatureSchemesSpec(ByteBuffer buffer) throws IOException {
+        SignatureSchemesSpec(HandshakeContext hc,
+                ByteBuffer buffer) throws IOException {
             if (buffer.remaining() < 2) {      // 2: the length of the list
-                throw new SSLProtocolException(
-                    "Invalid signature_algorithms: insufficient data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid signature_algorithms: insufficient data"));
             }
 
             byte[] algs = Record.getBytes16(buffer);
             if (buffer.hasRemaining()) {
-                throw new SSLProtocolException(
-                    "Invalid signature_algorithms: unknown extra data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid signature_algorithms: unknown extra data"));
             }
 
             if (algs == null || algs.length == 0 || (algs.length & 0x01) != 0) {
-                throw new SSLProtocolException(
-                    "Invalid signature_algorithms: incomplete data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid signature_algorithms: incomplete data"));
             }
 
             int[] schemes = new int[algs.length / 2];
@@ -144,9 +148,9 @@ final class SignatureAlgorithmsExtension {
     private static final
             class SignatureSchemesStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new SignatureSchemesSpec(buffer)).toString();
+                return (new SignatureSchemesSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -235,12 +239,7 @@ final class SignatureAlgorithmsExtension {
             }
 
             // Parse the extension.
-            SignatureSchemesSpec spec;
-            try {
-                spec = new SignatureSchemesSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            SignatureSchemesSpec spec = new SignatureSchemesSpec(shc, buffer);
 
             // Update the context.
             shc.handshakeExtensions.put(
@@ -461,12 +460,7 @@ final class SignatureAlgorithmsExtension {
             }
 
             // Parse the extension.
-            SignatureSchemesSpec spec;
-            try {
-                spec = new SignatureSchemesSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            SignatureSchemesSpec spec = new SignatureSchemesSpec(chc, buffer);
 
             List<SignatureScheme> knownSignatureSchemes = new LinkedList<>();
             for (int id : spec.signatureSchemes) {

--- a/src/java.base/share/classes/sun/security/ssl/SupportedGroupsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SupportedGroupsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,21 +80,25 @@ final class SupportedGroupsExtension {
             }
         }
 
-        private SupportedGroupsSpec(ByteBuffer m) throws IOException  {
+        private SupportedGroupsSpec(HandshakeContext hc,
+                ByteBuffer m) throws IOException  {
             if (m.remaining() < 2) {      // 2: the length of the list
-                throw new SSLProtocolException(
-                    "Invalid supported_groups extension: insufficient data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid supported_groups extension: insufficient data"));
             }
 
             byte[] ngs = Record.getBytes16(m);
             if (m.hasRemaining()) {
-                throw new SSLProtocolException(
-                    "Invalid supported_groups extension: unknown extra data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid supported_groups extension: unknown extra data"));
             }
 
             if ((ngs == null) || (ngs.length == 0) || (ngs.length % 2 != 0)) {
-                throw new SSLProtocolException(
-                    "Invalid supported_groups extension: incomplete data");
+                throw hc.conContext.fatal(Alert.DECODE_ERROR,
+                        new SSLProtocolException(
+                    "Invalid supported_groups extension: incomplete data"));
             }
 
             int[] ids = new int[ngs.length / 2];
@@ -140,9 +144,9 @@ final class SupportedGroupsExtension {
     private static final
             class SupportedGroupsStringizer implements SSLStringizer {
         @Override
-        public String toString(ByteBuffer buffer) {
+        public String toString(HandshakeContext hc, ByteBuffer buffer) {
             try {
-                return (new SupportedGroupsSpec(buffer)).toString();
+                return (new SupportedGroupsSpec(hc, buffer)).toString();
             } catch (IOException ioe) {
                 // For debug logging only, so please swallow exceptions.
                 return ioe.getMessage();
@@ -416,12 +420,7 @@ final class SupportedGroupsExtension {
             }
 
             // Parse the extension.
-            SupportedGroupsSpec spec;
-            try {
-                spec = new SupportedGroupsSpec(buffer);
-            } catch (IOException ioe) {
-                throw shc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            SupportedGroupsSpec spec = new SupportedGroupsSpec(shc, buffer);
 
             // Update the context.
             List<NamedGroup> knownNamedGroups = new LinkedList<>();
@@ -566,12 +565,7 @@ final class SupportedGroupsExtension {
             }
 
             // Parse the extension.
-            SupportedGroupsSpec spec;
-            try {
-                spec = new SupportedGroupsSpec(buffer);
-            } catch (IOException ioe) {
-                throw chc.conContext.fatal(Alert.UNEXPECTED_MESSAGE, ioe);
-            }
+            SupportedGroupsSpec spec = new SupportedGroupsSpec(chc, buffer);
 
             // Update the context.
             List<NamedGroup> knownNamedGroups =

--- a/src/java.base/share/classes/sun/security/ssl/TransportContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/TransportContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import javax.net.ssl.SSLSocket;
 /**
  * SSL/(D)TLS transportation context.
  */
-class TransportContext implements ConnectionContext {
+final class TransportContext implements ConnectionContext {
     final SSLTransport              transport;
 
     // registered plaintext consumers


### PR DESCRIPTION
The original patch applies clean.
sun/security/ssl and javax/net/ssl tests passed

This patch is also required for clean backport of JDK-8206925

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8215712](https://bugs.openjdk.java.net/browse/JDK-8215712): Parsing extension failure may alert decode_error


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/251/head:pull/251` \
`$ git checkout pull/251`

Update a local copy of the PR: \
`$ git checkout pull/251` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 251`

View PR using the GUI difftool: \
`$ git pr show -t 251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/251.diff">https://git.openjdk.java.net/jdk13u-dev/pull/251.diff</a>

</details>
