### PR TITLE
8269934: RunThese24H.java failed with EXCEPTION_ACCESS_VIOLATION in java_lang_Thread::get_thread_status

### DIFF
--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -861,7 +861,10 @@ void ThreadSnapshot::initialize(ThreadsList * t_list, JavaThread* thread) {
   _sleep_ticks = stat->sleep_ticks();
   _sleep_count = stat->sleep_count();
 
-  _thread_status = java_lang_Thread::get_thread_status(_threadObj);
+  // If thread is still attaching then threadObj will be NULL.
+  _thread_status = _threadObj == NULL ? java_lang_Thread::NEW
+                                     : java_lang_Thread::get_thread_status(_threadObj);
+
   _is_ext_suspended = thread->is_being_ext_suspended();
   _is_in_native = (thread->thread_state() == _thread_in_native);
 


### PR DESCRIPTION
Clean backport from 15u ( reviewed by Paul Hohensee ). Not clean backport from jdk/jdk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269934](https://bugs.openjdk.java.net/browse/JDK-8269934): RunThese24H.java failed with EXCEPTION_ACCESS_VIOLATION in java_lang_Thread::get_thread_status


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/254/head:pull/254` \
`$ git checkout pull/254`

Update a local copy of the PR: \
`$ git checkout pull/254` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 254`

View PR using the GUI difftool: \
`$ git pr show -t 254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/254.diff">https://git.openjdk.java.net/jdk13u-dev/pull/254.diff</a>

</details>
