### PR TITLE
8270216: [macOS] Update named used for Java run loop mode

### DIFF
--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
@@ -33,7 +33,7 @@
 JavaVM *jvm = NULL;
 static JNIEnv *appKitEnv = NULL;
 static jobject appkitThreadGroup = NULL;
-static NSString* JavaRunLoopMode = @"javaRunLoopMode";
+static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
 static NSArray<NSString*> *javaModes = nil;
 
 static inline void attachCurrentThread(void** env) {


### PR DESCRIPTION
Simple fix, clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270216](https://bugs.openjdk.java.net/browse/JDK-8270216): [macOS] Update named used for Java run loop mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/255/head:pull/255` \
`$ git checkout pull/255`

Update a local copy of the PR: \
`$ git checkout pull/255` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 255`

View PR using the GUI difftool: \
`$ git pr show -t 255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/255.diff">https://git.openjdk.java.net/jdk13u-dev/pull/255.diff</a>

</details>
