### PR TITLE
8257999: Parallel GC crash in gc/parallel/TestDynShrinkHeap.java: new region is not in covered_region

### DIFF
--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -37,6 +37,7 @@
 #include "logging/log.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/java.hpp"
+#include "runtime/orderAccess.hpp"
 #include "utilities/align.hpp"
 
 inline const char* PSOldGen::select_name() {
@@ -402,7 +403,9 @@ void PSOldGen::post_resize() {
   start_array()->set_covered_region(new_memregion);
   ParallelScavengeHeap::heap()->card_table()->resize_covered_region(new_memregion);
 
-  // ALWAYS do this last!!
+  // Ensure the space bounds are updated and made visible to other
+  // threads after the other data structures have been resized.
+  OrderAccess::storestore();
   object_space()->initialize(new_memregion,
                              SpaceDecorator::DontClear,
                              SpaceDecorator::DontMangle);


### PR DESCRIPTION
I'd like to backport JDK-8257999 to jdk13u for parity with jdk11u.
The original patch applied manually due to the slight context changes. This patch is absolutely identical to the same one applied to jdk11u.
All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257999](https://bugs.openjdk.java.net/browse/JDK-8257999): Parallel GC crash in gc/parallel/TestDynShrinkHeap.java: new region is not in covered_region


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/261.diff">https://git.openjdk.java.net/jdk13u-dev/pull/261.diff</a>

</details>
