### PR TITLE
8185005: Improve performance of ThreadMXBean.getThreadInfo(long ids[], int maxDepth)

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -148,6 +148,7 @@ Monitor* CodeHeapStateAnalytics_lock  = NULL;
 Mutex*   MetaspaceExpand_lock         = NULL;
 Mutex*   ClassLoaderDataGraph_lock    = NULL;
 Monitor* ThreadsSMRDelete_lock        = NULL;
+Mutex*   ThreadIdTableCreate_lock     = NULL;
 Mutex*   SharedDecoder_lock           = NULL;
 Mutex*   DCmdFactory_lock             = NULL;
 #if INCLUDE_NMT
@@ -349,6 +350,7 @@ void mutex_init() {
   def(CodeHeapStateAnalytics_lock  , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_never);
   def(NMethodSweeperStats_lock     , PaddedMutex  , special,     true,  Monitor::_safepoint_check_never);
   def(ThreadsSMRDelete_lock        , PaddedMonitor, special,     false, Monitor::_safepoint_check_never);
+  def(ThreadIdTableCreate_lock     , PaddedMutex  , leaf,        false, Monitor::_safepoint_check_always)
   def(SharedDecoder_lock           , PaddedMutex  , native,      false, Monitor::_safepoint_check_never);
   def(DCmdFactory_lock             , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_never);
 #if INCLUDE_NMT

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -127,6 +127,7 @@ extern Monitor* Service_lock;                    // a lock used for service thre
 extern Monitor* PeriodicTask_lock;               // protects the periodic task structure
 extern Monitor* RedefineClasses_lock;            // locks classes from parallel redefinition
 extern Monitor* ThreadsSMRDelete_lock;           // Used by ThreadsSMRSupport to take pressure off the Threads_lock
+extern Mutex*   ThreadIdTableCreate_lock;        // Used by ThreadIdTable to lazily create the thread id table
 extern Mutex*   SharedDecoder_lock;              // serializes access to the decoder during normal (not error reporting) use
 extern Mutex*   DCmdFactory_lock;                // serialize access to DCmdFactory information
 #if INCLUDE_NMT

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -1,0 +1,238 @@
+
+/*
+* Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*
+*/
+
+#include "precompiled.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/thread.hpp"
+#include "runtime/threadSMR.hpp"
+#include "runtime/timerTrace.hpp"
+#include "services/threadIdTable.hpp"
+#include "utilities/concurrentHashTable.inline.hpp"
+#include "utilities/concurrentHashTableTasks.inline.hpp"
+
+
+typedef ConcurrentHashTable<ThreadIdTableConfig, mtInternal> ThreadIdTableHash;
+
+// 2^24 is max size
+static const size_t END_SIZE = 24;
+// Default initial size 256
+static const size_t DEFAULT_TABLE_SIZE_LOG = 8;
+// Prefer short chains of avg 2
+static const double PREF_AVG_LIST_LEN = 2.0;
+static ThreadIdTableHash* volatile _local_table = NULL;
+static volatile size_t _current_size = 0;
+static volatile size_t _items_count = 0;
+
+volatile bool ThreadIdTable::_is_initialized = false;
+
+class ThreadIdTableEntry : public CHeapObj<mtInternal> {
+private:
+  jlong _tid;
+  JavaThread* _java_thread;
+public:
+  ThreadIdTableEntry(jlong tid, JavaThread* java_thread) :
+    _tid(tid), _java_thread(java_thread) {}
+
+  jlong tid() const { return _tid; }
+  JavaThread* thread() const { return _java_thread; }
+};
+
+class ThreadIdTableConfig : public AllStatic {
+  public:
+    typedef ThreadIdTableEntry* Value;
+
+    static uintx get_hash(Value const& value, bool* is_dead) {
+      jlong tid = value->tid();
+      return primitive_hash(tid);
+    }
+    static void* allocate_node(size_t size, Value const& value) {
+      ThreadIdTable::item_added();
+      return AllocateHeap(size, mtInternal);
+    }
+    static void free_node(void* memory, Value const& value) {
+      delete value;
+      FreeHeap(memory);
+      ThreadIdTable::item_removed();
+    }
+};
+
+static size_t ceil_log2(size_t val) {
+  size_t ret;
+  for (ret = 1; ((size_t)1 << ret) < val; ++ret);
+  return ret;
+}
+
+// Lazily creates the table and populates it with the given
+// thread list
+void ThreadIdTable::lazy_initialize(const ThreadsList *threads) {
+  if (!_is_initialized) {
+    {
+      // There is no obvious benefits in allowing the thread table
+      // to be concurently populated during the initalization.
+      MutexLocker ml(ThreadIdTableCreate_lock);
+      if (_is_initialized) {
+        return;
+      }
+      create_table(threads->length());
+      _is_initialized = true;
+    }
+    for (uint i = 0; i < threads->length(); i++) {
+      JavaThread* thread = threads->thread_at(i);
+      oop tobj = thread->threadObj();
+      if (tobj != NULL) {
+        jlong java_tid = java_lang_Thread::thread_id(tobj);
+        MutexLocker ml(Threads_lock);
+        if (!thread->is_exiting()) {
+          // Must be inside the lock to ensure that we don't add a thread to the table
+          // that has just passed the removal point in ThreadsSMRSupport::remove_thread()
+          add_thread(java_tid, thread);
+        }
+      }
+    }
+  }
+}
+
+void ThreadIdTable::create_table(size_t size) {
+  assert(_local_table == NULL, "Thread table is already created");
+  size_t size_log = ceil_log2(size);
+  size_t start_size_log =
+      size_log > DEFAULT_TABLE_SIZE_LOG ? size_log : DEFAULT_TABLE_SIZE_LOG;
+  _current_size = (size_t)1 << start_size_log;
+  _local_table = new ThreadIdTableHash(start_size_log, END_SIZE);
+}
+
+void ThreadIdTable::item_added() {
+  Atomic::inc(&_items_count);
+  log_trace(thread, table) ("Thread entry added");
+}
+
+void ThreadIdTable::item_removed() {
+  Atomic::dec(&_items_count);
+  log_trace(thread, table) ("Thread entry removed");
+}
+
+double ThreadIdTable::get_load_factor() {
+  return ((double)_items_count) / _current_size;
+}
+
+size_t ThreadIdTable::table_size() {
+  return (size_t)1 << _local_table->get_size_log2(Thread::current());
+}
+
+void ThreadIdTable::grow(JavaThread* jt) {
+  ThreadIdTableHash::GrowTask gt(_local_table);
+  if (!gt.prepare(jt)) {
+    return;
+  }
+  log_trace(thread, table)("Started to grow");
+  TraceTime timer("Grow", TRACETIME_LOG(Debug, membername, table, perf));
+  while (gt.do_task(jt)) {
+    gt.pause(jt);
+    {
+      ThreadBlockInVM tbivm(jt);
+    }
+    gt.cont(jt);
+  }
+  gt.done(jt);
+  _current_size = table_size();
+  log_info(thread, table)("Grown to size:" SIZE_FORMAT, _current_size);
+}
+
+class ThreadIdTableLookup : public StackObj {
+private:
+  jlong _tid;
+  uintx _hash;
+public:
+  ThreadIdTableLookup(jlong tid)
+    : _tid(tid), _hash(primitive_hash(tid)) {}
+  uintx get_hash() const {
+    return _hash;
+  }
+  bool equals(ThreadIdTableEntry** value, bool* is_dead) {
+    bool equals = primitive_equals(_tid, (*value)->tid());
+    if (!equals) {
+      return false;
+    }
+    return true;
+  }
+};
+
+class ThreadGet : public StackObj {
+private:
+  JavaThread* _return;
+public:
+  ThreadGet(): _return(NULL) {}
+  void operator()(ThreadIdTableEntry** val) {
+    _return = (*val)->thread();
+  }
+  JavaThread* get_res_thread() {
+    return _return;
+  }
+};
+
+void ThreadIdTable::grow_if_required() {
+  assert(Thread::current()->is_Java_thread(),"Must be Java thread");
+  assert(_is_initialized, "Thread table is not initialized");
+  double load_factor = get_load_factor();
+  log_debug(thread, table)("Concurrent work, load factor: %g", load_factor);
+  if (load_factor > PREF_AVG_LIST_LEN && !_local_table->is_max_size_reached()) {
+    grow(JavaThread::current());
+  }
+}
+
+JavaThread* ThreadIdTable::add_thread(jlong tid, JavaThread* java_thread) {
+  assert(_is_initialized, "Thread table is not initialized");
+  Thread* thread = Thread::current();
+  ThreadIdTableLookup lookup(tid);
+  ThreadGet tg;
+  while (true) {
+    if (_local_table->get(thread, lookup, tg)) {
+      return tg.get_res_thread();
+    }
+    ThreadIdTableEntry* entry = new ThreadIdTableEntry(tid, java_thread);
+    // The hash table takes ownership of the ThreadTableEntry,
+    // even if it's not inserted.
+    if (_local_table->insert(thread, lookup, entry)) {
+      grow_if_required();
+      return java_thread;
+    }
+  }
+}
+
+JavaThread* ThreadIdTable::find_thread_by_tid(jlong tid) {
+  assert(_is_initialized, "Thread table is not initialized");
+  Thread* thread = Thread::current();
+  ThreadIdTableLookup lookup(tid);
+  ThreadGet tg;
+  _local_table->get(thread, lookup, tg);
+  return tg.get_res_thread();
+}
+
+bool ThreadIdTable::remove_thread(jlong tid) {
+  assert(_is_initialized, "Thread table is not initialized");
+  Thread* thread = Thread::current();
+  ThreadIdTableLookup lookup(tid);
+  return _local_table->remove(thread, lookup);
+}

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -32,6 +32,22 @@
 #include "utilities/concurrentHashTable.inline.hpp"
 #include "utilities/concurrentHashTableTasks.inline.hpp"
 
+class ThreadIdTableEntry;
+
+typedef ConcurrentHashTable<ThreadIdTableEntry*, ThreadIdTableConfig, mtInternal> ThreadIdTableHash;
+
+// 2^24 is max size
+static const size_t END_SIZE = 24;
+// Default initial size 256
+static const size_t DEFAULT_TABLE_SIZE_LOG = 8;
+// Prefer short chains of avg 2
+static const double PREF_AVG_LIST_LEN = 2.0;
+static ThreadIdTableHash* volatile _local_table = NULL;
+static volatile size_t _current_size = 0;
+static volatile size_t _items_count = 0;
+
+volatile bool ThreadIdTable::_is_initialized = false;
+
 class ThreadIdTableEntry : public CHeapObj<mtInternal> {
 private:
   jlong _tid;
@@ -62,20 +78,6 @@ class ThreadIdTableConfig : public AllStatic {
       ThreadIdTable::item_removed();
     }
 };
-
-typedef ConcurrentHashTable<ThreadIdTableConfig::Value, ThreadIdTableConfig, mtInternal> ThreadIdTableHash;
-
-// 2^24 is max size
-static const size_t END_SIZE = 24;
-// Default initial size 256
-static const size_t DEFAULT_TABLE_SIZE_LOG = 8;
-// Prefer short chains of avg 2
-static const double PREF_AVG_LIST_LEN = 2.0;
-static ThreadIdTableHash* volatile _local_table = NULL;
-static volatile size_t _current_size = 0;
-static volatile size_t _items_count = 0;
-
-volatile bool ThreadIdTable::_is_initialized = false;
 
 static size_t ceil_log2(size_t val) {
   size_t ret;

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -32,21 +32,6 @@
 #include "utilities/concurrentHashTable.inline.hpp"
 #include "utilities/concurrentHashTableTasks.inline.hpp"
 
-
-typedef ConcurrentHashTable<ThreadIdTableConfig, mtInternal> ThreadIdTableHash;
-
-// 2^24 is max size
-static const size_t END_SIZE = 24;
-// Default initial size 256
-static const size_t DEFAULT_TABLE_SIZE_LOG = 8;
-// Prefer short chains of avg 2
-static const double PREF_AVG_LIST_LEN = 2.0;
-static ThreadIdTableHash* volatile _local_table = NULL;
-static volatile size_t _current_size = 0;
-static volatile size_t _items_count = 0;
-
-volatile bool ThreadIdTable::_is_initialized = false;
-
 class ThreadIdTableEntry : public CHeapObj<mtInternal> {
 private:
   jlong _tid;
@@ -77,6 +62,20 @@ class ThreadIdTableConfig : public AllStatic {
       ThreadIdTable::item_removed();
     }
 };
+
+typedef ConcurrentHashTable<ThreadIdTableConfig::Value, ThreadIdTableConfig, mtInternal> ThreadIdTableHash;
+
+// 2^24 is max size
+static const size_t END_SIZE = 24;
+// Default initial size 256
+static const size_t DEFAULT_TABLE_SIZE_LOG = 8;
+// Prefer short chains of avg 2
+static const double PREF_AVG_LIST_LEN = 2.0;
+static ThreadIdTableHash* volatile _local_table = NULL;
+static volatile size_t _current_size = 0;
+static volatile size_t _items_count = 0;
+
+volatile bool ThreadIdTable::_is_initialized = false;
 
 static size_t ceil_log2(size_t val) {
   size_t ret;

--- a/src/hotspot/share/services/threadIdTable.hpp
+++ b/src/hotspot/share/services/threadIdTable.hpp
@@ -1,0 +1,62 @@
+
+/*
+* Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*
+*/
+
+#ifndef SHARE_SERVICES_THREADIDTABLE_HPP
+#define SHARE_SERVICES_THREADIDTABLE_HPP
+
+#include "memory/allocation.hpp"
+
+class JavaThread;
+class ThreadsList;
+class ThreadIdTableConfig;
+
+class ThreadIdTable : public AllStatic {
+  friend class ThreadIdTableConfig;
+
+  static volatile bool _is_initialized;
+
+public:
+  // Initialization
+  static void lazy_initialize(const ThreadsList* threads);
+  static bool is_initialized() { return _is_initialized; }
+
+  // Lookup and list management
+  static JavaThread* find_thread_by_tid(jlong tid);
+  static JavaThread* add_thread(jlong tid, JavaThread* thread);
+  static bool remove_thread(jlong tid);
+
+private:
+  static void create_table(size_t size);
+
+  static size_t table_size();
+  static double get_load_factor();
+  static void grow_if_required();
+  static void grow(JavaThread* jt);
+
+  static void item_added();
+  static void item_removed();
+};
+
+#endif // SHARE_SERVICES_THREADIDTABLE_HPP


### PR DESCRIPTION
I'd like to backport this case for parity with jdk11. The patch need some fixes similar to described here http://mail.openjdk.java.net/pipermail/jdk-updates-dev/2020-January/002377.html, except move of primitive_hash is not necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8185005](https://bugs.openjdk.java.net/browse/JDK-8185005): Improve performance of ThreadMXBean.getThreadInfo(long ids[], int maxDepth)


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/266.diff">https://git.openjdk.java.net/jdk13u-dev/pull/266.diff</a>

</details>
