### PR TITLE
8273358: macOS Monterey does not have the font Times needed by Serif

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CFontManager.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFontManager.java
@@ -223,7 +223,7 @@ public final class CFontManager extends SunFontManager {
             String defaultFallback = "Lucida Grande";
 
             setupLogicalFonts("Dialog", defaultFont, defaultFallback);
-            setupLogicalFonts("Serif", "Times", "Times");
+            setupLogicalFonts("Serif", "Times", "Times New Roman");
             setupLogicalFonts("SansSerif", defaultFont, defaultFallback);
             setupLogicalFonts("Monospaced", "Menlo", "Courier");
             setupLogicalFonts("DialogInput", defaultFont, defaultFallback);
@@ -249,7 +249,13 @@ public final class CFontManager extends SunFontManager {
         family = getFontFamily(realName, fallbackName);
         if (family != null) return family;
 
-        System.err.println("Warning: the fonts \"" + realName + "\" and \"" + fallbackName + "\" are not available for the Java logical font \"" + logicalName + "\", which may have unexpected appearance or behavior. Re-enable the \""+ realName +"\" font to remove this warning.");
+        if (FontUtilities.debugFonts()) {
+            FontUtilities.getLogger().severe(
+                "The fonts \"" + realName + "\" and \"" + fallbackName +
+                "\" are not available for the Java logical font \"" + logicalName +
+                "\", which may have unexpected appearance or behavior. Re-enable the \""+
+                realName +"\" font to remove this warning.");
+        }
         return null;
     }
 
@@ -259,7 +265,12 @@ public final class CFontManager extends SunFontManager {
 
         family = FontFamily.getFamily(fallbackName);
         if (family != null){
-            System.err.println("Warning: the font \"" + realName + "\" is not available, so \"" + fallbackName + "\" has been substituted, but may have unexpected appearance or behavor. Re-enable the \""+ realName +"\" font to remove this warning.");
+            if (FontUtilities.debugFonts()) {
+                FontUtilities.getLogger().warning(
+                    "The font \"" + realName + "\" is not available, so \"" + fallbackName +
+                    "\" has been substituted, but may have unexpected appearance or behavor. Re-enable the \"" +
+                    realName +"\" font to remove this warning.");
+             }
             return family;
         }
 

--- a/test/jdk/java/awt/FontClass/LogicalFontsTest.java
+++ b/test/jdk/java/awt/FontClass/LogicalFontsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273358
+ * @summary Verify logical fonts are as expected.
+ * @run main/othervm LogicalFontsTest
+ */
+
+import java.awt.Font;
+
+public class LogicalFontsTest {
+
+    public static void main(String[] args) {
+        test(Font.SANS_SERIF);
+        test(Font.SERIF);
+        test(Font.MONOSPACED);
+        test(Font.DIALOG);
+        test(Font.DIALOG_INPUT);
+     }
+
+     static void test(String fontName) {
+         System.out.println("name="+fontName);
+         Font font = new Font(fontName, Font.PLAIN, 12);
+         System.out.println("font = " + font);
+         if (!fontName.equalsIgnoreCase(font.getFamily())) {
+             throw new RuntimeException("Requested " + fontName + " but got " + font);
+         }
+     }
+}


### PR DESCRIPTION
I'd like to backport JDK-8273358 to jdk13u for parity with jdk11u.
The original patch applies cleanly but 2 logging methods were replaced as in jdk11u because they are not available in jdk13u as well (the replaced methods were added with JDK-8248802 to jdk16u only). The patch is absolutely identical to that one applied to jdk11u.
Tested with the test added in this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273358](https://bugs.openjdk.java.net/browse/JDK-8273358): macOS Monterey does not have the font Times needed by Serif


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/268/head:pull/268` \
`$ git checkout pull/268`

Update a local copy of the PR: \
`$ git checkout pull/268` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 268`

View PR using the GUI difftool: \
`$ git pr show -t 268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/268.diff">https://git.openjdk.java.net/jdk13u-dev/pull/268.diff</a>

</details>
