### PR TITLE
8273575: memory leak in appendBootClassPath(), paths must be deallocated

### DIFF
--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -981,4 +981,5 @@ appendBootClassPath( JPLISAgent* agent,
     if (haveBasePath && parent != canonicalPath) {
         free(parent);
     }
+    free(paths);
 }


### PR DESCRIPTION
I'd like to backport JDK-8273575 to jdk13u.
The original patch applied cleanly.
The patch fixes a memory leak that should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273575](https://bugs.openjdk.java.net/browse/JDK-8273575): memory leak in appendBootClassPath(), paths must be deallocated


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/270/head:pull/270` \
`$ git checkout pull/270`

Update a local copy of the PR: \
`$ git checkout pull/270` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 270`

View PR using the GUI difftool: \
`$ git pr show -t 270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/270.diff">https://git.openjdk.java.net/jdk13u-dev/pull/270.diff</a>

</details>
