### PR TITLE
8238932: Invalid tier1_gc_1 test group definition

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -190,7 +190,6 @@ tier1_gc_1 = \
   :gc_epsilon \
   gc/g1/ \
   -gc/g1/ihop/TestIHOPErgo.java
-  -gc/g1/TestTimelyCompaction.java
 
 tier1_gc_2 = \
   gc/ \


### PR DESCRIPTION
TEST.group cleanup fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238932](https://bugs.openjdk.java.net/browse/JDK-8238932): Invalid tier1_gc_1 test group definition


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/271.diff">https://git.openjdk.java.net/jdk13u-dev/pull/271.diff</a>

</details>
