### PR TITLE
8266949: Check possibility to disable OperationTimedOut on Unix

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1408,15 +1408,6 @@ public abstract class SunToolkit extends Toolkit
     }
 
     @SuppressWarnings("serial")
-    public static class OperationTimedOut extends RuntimeException {
-        public OperationTimedOut(String msg) {
-            super(msg);
-        }
-        public OperationTimedOut() {
-        }
-    }
-
-    @SuppressWarnings("serial")
     public static class IllegalThreadException extends RuntimeException {
         public IllegalThreadException(String msg) {
             super(msg);
@@ -1433,7 +1424,7 @@ public abstract class SunToolkit extends Toolkit
     /**
      * Parameterless version of realsync which uses default timout (see DEFAUL_WAIT_TIME).
      */
-    public void realSync() throws OperationTimedOut {
+    public void realSync() {
         realSync(DEFAULT_WAIT_TIME);
     }
 
@@ -1482,7 +1473,7 @@ public abstract class SunToolkit extends Toolkit
      *
      * @param timeout the maximum time to wait in milliseconds, negative means "forever".
      */
-    public void realSync(final long timeout) throws OperationTimedOut {
+    public void realSync(final long timeout) {
         if (EventQueue.isDispatchThread()) {
             throw new IllegalThreadException("The SunToolkit.realSync() method cannot be used on the event dispatch thread (EDT).");
         }
@@ -1538,7 +1529,7 @@ public abstract class SunToolkit extends Toolkit
                 && bigLoop < MAX_ITERS);
     }
 
-    private long timeout(long end){
+    protected long timeout(long end){
         return end - TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
     }
 
@@ -1568,6 +1559,9 @@ public abstract class SunToolkit extends Toolkit
      */
     @SuppressWarnings("serial")
     private final boolean waitForIdle(final long end) {
+        if (timeout(end) <= 0) {
+            return false;
+        }
         flushPendingEvents();
         final boolean queueWasEmpty;
         final AtomicBoolean queueEmpty = new AtomicBoolean();

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -126,6 +126,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.Vector;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.LookAndFeel;
 import javax.swing.UIDefaults;
@@ -2587,7 +2588,7 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
      * @inheritDoc
      */
     @Override
-    protected boolean syncNativeQueue(final long timeout) {
+    protected boolean syncNativeQueue(long timeout) {
         if (timeout <= 0) {
             return false;
         }
@@ -2612,30 +2613,32 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
 
             oops_updated = false;
             long event_number = getEventNumber();
-            // Generate OOPS ConfigureNotify event
-            XlibWrapper.XMoveWindow(getDisplay(), win.getWindow(),
-                                    win.scaleUp(++oops_position), 0);
             // Change win position each time to avoid system optimization
+            oops_position += 5;
             if (oops_position > 50) {
                 oops_position = 0;
             }
+            // Generate OOPS ConfigureNotify event
+            XlibWrapper.XMoveWindow(getDisplay(), win.getWindow(),
+                                    oops_position, 0);
 
             XSync();
 
             eventLog.finer("Generated OOPS ConfigureNotify event");
 
-            long start = System.currentTimeMillis();
+            long end = TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) + timeout;
+            // This "while" is a protection from spurious wake-ups.
+            // However, we shouldn't wait for too long.
             while (!oops_updated) {
+                timeout = timeout(end);
+                if (timeout <= 0) {
+                    break;
+                }
                 try {
                     // Wait for OOPS ConfigureNotify event
                     awtLockWait(timeout);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
-                }
-                // This "while" is a protection from spurious
-                // wake-ups.  However, we shouldn't wait for too long
-                if ((System.currentTimeMillis() - start > timeout) && timeout >= 0) {
-                    throw new OperationTimedOut(Long.toString(System.currentTimeMillis() - start));
                 }
             }
             // Don't take into account OOPS ConfigureNotify event


### PR DESCRIPTION
I'd like to backport this fix for consistency. The patch applies cleanly after 8196100 in both repositories, some obvious related tests do pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266949](https://bugs.openjdk.java.net/browse/JDK-8266949): Check possibility to disable OperationTimedOut on Unix


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/289/head:pull/289` \
`$ git checkout pull/289`

Update a local copy of the PR: \
`$ git checkout pull/289` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 289`

View PR using the GUI difftool: \
`$ git pr show -t 289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/289.diff">https://git.openjdk.java.net/jdk13u-dev/pull/289.diff</a>

</details>
