### PR TITLE
8273026: Slow LoginContext.login() on multi threading application

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/login/LoginContext.java
+++ b/src/java.base/share/classes/javax/security/auth/login/LoginContext.java
@@ -40,6 +40,10 @@ import java.util.ServiceLoader;
 import sun.security.util.PendingException;
 import sun.security.util.ResourcesMgr;
 
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.stream.*;
+import java.util.ServiceLoader.Provider;
 /**
  * <p> The {@code LoginContext} class describes the basic methods used
  * to authenticate Subjects and provides a way to develop an
@@ -221,6 +225,8 @@ public class LoginContext {
 
     private static final sun.security.util.Debug debug =
         sun.security.util.Debug.getInstance("logincontext", "\t[LoginContext]");
+    private static final WeakHashMap<ClassLoader, Set<Provider<LoginModule>>> providersCache =
+        new WeakHashMap<>();
 
     private void init(String name) throws LoginException {
 
@@ -286,6 +292,7 @@ public class LoginContext {
                     return loader;
                 }
         });
+
     }
 
     private void loadDefaultCallbackHandler() throws LoginException {
@@ -684,20 +691,35 @@ public class LoginContext {
                     // locate and instantiate the LoginModule
                     //
                     String name = moduleStack[i].entry.getLoginModuleName();
-                    ServiceLoader<LoginModule> sc = AccessController.doPrivileged(
-                            (PrivilegedAction<ServiceLoader<LoginModule>>)
-                                    () -> ServiceLoader.load(
-                                        LoginModule.class, contextClassLoader));
-                    for (LoginModule m: sc) {
-                        if (m.getClass().getName().equals(name)) {
-                            moduleStack[i].module = m;
+                    Set<Provider<LoginModule>> lmProviders;
+                    synchronized(providersCache){
+                        lmProviders = providersCache.get(contextClassLoader);
+                        if (lmProviders == null){
+                            if (debug != null){
+                                debug.println("Build ServiceProviders cache for ClassLoader: " + contextClassLoader.getName());
+                            }
+                            @SuppressWarnings("removal")
+                            ServiceLoader<LoginModule> sc = AccessController.doPrivileged(
+                                    (PrivilegedAction<ServiceLoader<LoginModule>>)
+                                            () -> java.util.ServiceLoader.load(
+                                                LoginModule.class, contextClassLoader));
+                            lmProviders = sc.stream().collect(Collectors.toSet());
+                                if (debug != null){
+                                    debug.println("Discovered ServiceProviders for ClassLoader: " + contextClassLoader.getName());
+                                    lmProviders.forEach(System.err::println);
+                                }
+                            providersCache.put(contextClassLoader,lmProviders);
+                        }
+                    }
+                    for (Provider<LoginModule> lm: lmProviders){
+                        if (lm.type().getName().equals(name)){
+                            moduleStack[i].module = lm.get();
                             if (debug != null) {
                                 debug.println(name + " loaded as a service");
                             }
                             break;
                         }
                     }
-
                     if (moduleStack[i].module == null) {
                         try {
                             @SuppressWarnings("deprecation")

--- a/test/jdk/javax/security/auth/spi/Loader.java
+++ b/test/jdk/javax/security/auth/spi/Loader.java
@@ -26,9 +26,13 @@ import java.io.File;
 
 /*
  * @test
- * @bug 8047789
+ * @bug 8047789 8273026
  * @summary auth.login.LoginContext needs to be updated to work with modules
- * @build FirstLoginModule SecondLoginModule
+ * @comment shows that the SecondLoginModule is still needed even if it's not in the JAAS login config file
+ * @build FirstLoginModule
+ * @clean SecondLoginModule
+ * @run main/othervm/fail Loader
+ * @build SecondLoginModule
  * @run main/othervm Loader
  */
 public class Loader {
@@ -39,18 +43,7 @@ public class Loader {
                 new File(System.getProperty("test.src"), "sl.conf").toString());
         LoginContext lc = new LoginContext("me");
 
-        if (SecondLoginModule.isLoaded) {
-            throw new Exception();
-        }
-
         lc.login();
 
-        // Although only FirstLoginModule is specified in the JAAS login
-        // config file, LoginContext will first create all LoginModule
-        // implementations that are registered as services, which include
-        // SecondLoginModule.
-        if (!SecondLoginModule.isLoaded) {
-            throw new Exception();
-        }
     }
 }

--- a/test/jdk/javax/security/auth/spi/SecondLoginModule.java
+++ b/test/jdk/javax/security/auth/spi/SecondLoginModule.java
@@ -29,11 +29,6 @@ import java.util.Map;
 
 public class SecondLoginModule implements LoginModule {
 
-    public static boolean isLoaded;
-
-    public SecondLoginModule() {
-        isLoaded = true;
-    }
 
     @Override
     public void initialize(Subject subject, CallbackHandler callbackHandler,


### PR DESCRIPTION
Backport the fix  8273026 that added cache of Service Loaders to LoginContext. Fix was not applied cleanly. Tested with tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273026](https://bugs.openjdk.java.net/browse/JDK-8273026): Slow LoginContext.login() on multi threading application


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/291/head:pull/291` \
`$ git checkout pull/291`

Update a local copy of the PR: \
`$ git checkout pull/291` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 291`

View PR using the GUI difftool: \
`$ git pr show -t 291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/291.diff">https://git.openjdk.java.net/jdk13u-dev/pull/291.diff</a>

</details>
