### PR TITLE
8274293: Build failure on macOS with Xcode 13.0 as vfork is deprecated

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -430,8 +430,8 @@ static int copystrings(char *buf, int offset, const char * const *arg) {
 __attribute_noinline__
 #endif
 
-/* vfork(2) is deprecated on Solaris */
-#ifndef __solaris__
+/* vfork(2) is deprecated on Solaris and Darwin */
+#if !defined(__APPLE__) && !defined(__solaris__)
 static pid_t
 vforkChild(ChildStuff *c) {
     volatile pid_t resultPid;
@@ -561,8 +561,8 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
 static pid_t
 startChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) {
     switch (c->mode) {
-/* vfork(2) is deprecated on Solaris */
-#ifndef __solaris__
+/* vfork(2) is deprecated on Solaris and Darwin */
+#if !defined(__APPLE__) && !defined(__solaris__)
       case MODE_VFORK:
         return vforkChild(c);
 #endif


### PR DESCRIPTION
I'd like to backport JDK-8274293 to jdk13u for parity with jdk11u. 
The same issue is observed on macOS Monterey 12.0.1 while compiling with Xcode 13.0 (--disable-warnings-as-errors is used because it's not the only issue at the moment):

```
/Users/olgamikhaltsova/projects/jdk13u-dev-fork/src/java.base/unix/native/libjava/ProcessImpl_md.c:445:17: warning: 'vfork' is deprecated: Use posix_spawn or fork [-Wdeprecated-declarations]
    resultPid = vfork();
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/usr/include/unistd.h:604:1: note: 'vfork' has been explicitly marked deprecated here
__deprecated_msg("Use posix_spawn or fork")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/usr/include/sys/cdefs.h:208:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
```

The original patch applied partially and manually because os_posix.cpp doesn't need any fixes due to JDK-8262955 is not included to jdk13u. This patch is absolutely identical to that one applied to jdk11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274293](https://bugs.openjdk.java.net/browse/JDK-8274293): Build failure on macOS with Xcode 13.0 as vfork is deprecated


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/292/head:pull/292` \
`$ git checkout pull/292`

Update a local copy of the PR: \
`$ git checkout pull/292` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 292`

View PR using the GUI difftool: \
`$ git pr show -t 292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/292.diff">https://git.openjdk.java.net/jdk13u-dev/pull/292.diff</a>

</details>
