### PR TITLE
8238448: RSASSA-PSS signature verification fail when using certain odd key sizes

### DIFF
--- a/test/jdk/sun/security/rsa/pss/SignatureTest2.java
+++ b/test/jdk/sun/security/rsa/pss/SignatureTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,15 @@ import static javax.crypto.Cipher.PUBLIC_KEY;
 
 /**
  * @test
- * @bug 8146293
- * @summary Create a signature for RSA and get its signed data. re-initiate
- *          the signature with the public key. The signature can be verified
- *          by acquired signed data.
+ * @bug 8146293 8238448
+ * @summary Create a signature for RSASSA-PSS and get its signed data.
+ *          re-initiate the signature with the public key. The signature
+ *          can be verified by acquired signed data.
  * @run main SignatureTest2 768
  * @run main SignatureTest2 1024
+ * @run main SignatureTest2 1025
  * @run main SignatureTest2 2048
+ * @run main SignatureTest2 2049
  * @run main/timeout=240 SignatureTest2 4096
  */
 public class SignatureTest2 {

--- a/test/jdk/sun/security/rsa/pss/SignatureTestPSS.java
+++ b/test/jdk/sun/security/rsa/pss/SignatureTestPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,16 +32,18 @@ import static javax.crypto.Cipher.PUBLIC_KEY;
 
 /**
  * @test
- * @bug 8146293
- * @summary Create a signature for RSA and get its signed data. re-initiate
- *          the signature with the public key. The signature can be verified
- *          by acquired signed data.
+ * @bug 8146293 8238448
+ * @summary Create a signature for RSASSA-PSS and get its signed data.
+ *          re-initiate the signature with the public key. The signature
+ *          can be verified by acquired signed data.
  * @library /test/lib
  * @build jdk.test.lib.SigTestUtil
  * @run main SignatureTestPSS 512
  * @run main SignatureTestPSS 768
  * @run main SignatureTestPSS 1024
+ * @run main SignatureTestPSS 1025
  * @run main SignatureTestPSS 2048
+ * @run main SignatureTestPSS 2049
  * @run main/timeout=240 SignatureTestPSS 4096
  * @run main/timeout=240 SignatureTestPSS 5120
  * @run main/timeout=480 SignatureTestPSS 6144


### PR DESCRIPTION
Clean backport. All relevant tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238448](https://bugs.openjdk.java.net/browse/JDK-8238448): RSASSA-PSS signature verification fail when using certain odd key sizes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/296/head:pull/296` \
`$ git checkout pull/296`

Update a local copy of the PR: \
`$ git checkout pull/296` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 296`

View PR using the GUI difftool: \
`$ git pr show -t 296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/296.diff">https://git.openjdk.java.net/jdk13u-dev/pull/296.diff</a>

</details>
