### PR TITLE
8241087: Build failure with VS 2019 (16.5.0) due to C2039 and C2873

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_DCHolder.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DCHolder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
  * questions.
  */
 
-#include "awt.h"
 #include "awt_ole.h"
 #include "awt_DCHolder.h"       // main symbols
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,18 +23,16 @@
  * questions.
  */
 
-#include "awt.h"
 #include <shlwapi.h>
 #include <shellapi.h>
 #include <memory.h>
 
 #include "awt_DataTransferer.h"
-#include "awt_Toolkit.h"
 #include "java_awt_dnd_DnDConstants.h"
 #include "sun_awt_windows_WDropTargetContextPeer.h"
 #include "awt_Container.h"
-#include "alloc.h"
 #include "awt_ole.h"
+#include "awt_Toolkit.h"
 #include "awt_DnDDT.h"
 #include "awt_DnDDS.h"
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_ole.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_ole.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,10 @@
 #ifndef AWT_OLE_H
 #define AWT_OLE_H
 
-#include "awt.h"
 #include <ole2.h>
 #include <comdef.h>
 #include <comutil.h>
+#include "awt.h"
 
 #ifdef _DEBUG
     #define _SUN_DEBUG


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [54564388](https://github.com/openjdk/jdk/commit/545643880c5bf00de850317b4b8c6f85074a2942) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Yasumasa Suenaga on 23 Mar 2020 and was reviewed by Sergey Bylokhov.

This change tweaks the code to support building using VS2019 which is already supported by the jdk11u.
I can confirm that the build failed before the fix and passed after, but it would be good if existing maintainers of 13u will confirm that the change did not break their environment.u.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8241087](https://bugs.openjdk.java.net/browse/JDK-8241087): Build failure with VS 2019 (16.5.0) due to C2039 and C2873


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/298/head:pull/298` \
`$ git checkout pull/298`

Update a local copy of the PR: \
`$ git checkout pull/298` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 298`

View PR using the GUI difftool: \
`$ git pr show -t 298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/298.diff">https://git.openjdk.java.net/jdk13u-dev/pull/298.diff</a>

</details>
