### PR TITLE
8254270: linux 32 bit build doesn't compile libjdwp/log_messages.c

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,12 @@ get_time_stamp(char *tbuf, size_t ltbuf)
                 "%d.%m.%Y %T", localtime(&t));
     (void)strftime(timestamp_timezone, TZ_SIZE,
                 "%Z", localtime(&t));
-    (void)snprintf(tbuf, ltbuf,
-                   "%s.%.3d %s", timestamp_date_time,
-                   (int)(millisecs), timestamp_timezone);
+
+    // Truncate milliseconds in buffer large enough to hold the
+    // value which is always < 1000 (and so a maximum of 3 digits for "%.3d")
+    char tmp[20];
+    snprintf(tmp, sizeof(tmp), "%.3d", millisecs);
+    snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
 }
 
 /* Get basename of filename */


### PR DESCRIPTION
I'd like to backport JDK-8254270 to jdk13u for parity with jdk11u.
The same issue was observed while compiling for the Linux 32 bits platform (compiled with --disable-warnings-as-errors):
```
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c:82:29: warning: '%s' directive output may be truncated writing up to 56 bytes into a region of size between 52 and 76 [-Wformat-truncation=]
                    "%s.%.3d %s", timestamp_date_time,
                             ^~
                    (int)(millisecs), timestamp_timezone);
                                      ~~~~~~~~~~~~~~~~~~
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c:81:11: note: 'snprintf' output between 6 and 86 bytes into a destination of size 81
     (void)snprintf(tbuf, ltbuf,
           ^~~~~~~~~~~~~~~~~~~~~
                    "%s.%.3d %s", timestamp_date_time,
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                    (int)(millisecs), timestamp_timezone);
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
After applying this patch the problem has gone. The original patch applied cleanly. All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254270](https://bugs.openjdk.java.net/browse/JDK-8254270): linux 32 bit build doesn't compile libjdwp/log_messages.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/299/head:pull/299` \
`$ git checkout pull/299`

Update a local copy of the PR: \
`$ git checkout pull/299` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 299`

View PR using the GUI difftool: \
`$ git pr show -t 299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/299.diff">https://git.openjdk.java.net/jdk13u-dev/pull/299.diff</a>

</details>
