### PR TITLE
8278416: Crash during execution of ClassInitBarrier test

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -709,6 +709,7 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   address c2i_entry = __ pc();
 
   // Class initialization barrier for static methods
+  address c2i_no_clinit_check_entry = NULL;
   if (VM_Version::supports_fast_class_init_checks()) {
     Label L_skip_barrier;
 
@@ -722,12 +723,13 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
     __ clinit_barrier(rscratch2, rscratch1, &L_skip_barrier);
     __ far_jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub()));
     __ bind(L_skip_barrier);
+    c2i_no_clinit_check_entry = __ pc();
   }
 
   gen_c2i_adapter(masm, total_args_passed, comp_args_on_stack, sig_bt, regs, skip_fixup);
 
   __ flush();
-  return AdapterHandlerLibrary::new_entry(fingerprint, i2c_entry, c2i_entry, c2i_unverified_entry);
+  return AdapterHandlerLibrary::new_entry(fingerprint, i2c_entry, c2i_entry, c2i_unverified_entry, c2i_no_clinit_check_entry);
 }
 
 int SharedRuntime::c_calling_convention(const BasicType *sig_bt,


### PR DESCRIPTION
This is missed aarch64 part of JDK-8227260 (JNI upcalls should bypass class initialization barrier in c2i adapter). It was not implemented in time due to lack of link between 8227260 and 8223173 (Implement fast class initialization checks on AARCH64). 

The code is taken from jdk15 and verified with tier1 and ClassInitBarrier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278416](https://bugs.openjdk.java.net/browse/JDK-8278416): Crash during execution of ClassInitBarrier test


### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - no project role)
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/300/head:pull/300` \
`$ git checkout pull/300`

Update a local copy of the PR: \
`$ git checkout pull/300` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 300`

View PR using the GUI difftool: \
`$ git pr show -t 300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/300.diff">https://git.openjdk.java.net/jdk13u-dev/pull/300.diff</a>

</details>
