### PR TITLE
8250605: Linux x86_32 builds fail after JDK-8249821

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -669,7 +669,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
     WARNINGS_AS_ERRORS_xlc := false, \
-    DISABLED_WARNINGS_gcc := sign-compare unused-function, \
+    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast, \
     DISABLED_WARNINGS_clang := sign-compare, \
     DISABLED_WARNINGS_microsoft := 4018 4146 4244 4996, \
     DISABLED_WARNINGS_C_solstudio = \


### PR DESCRIPTION
I'd like to backport JDK-8250605 to jdk13u for parity with jdk11u.
The patch applied manually because the patched file is in another directory: make/lib/Awt2dLibraries.gmk instead of make/modules/java.desktop/lib/Awt2dLibraries.gmk.
I observed the same cast warnings (not errors due to --disable-warnings-as-errors) at the compile time on the Linux 32 bits platform. 
```
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/java.desktop/share/native/libfontmanager/DrawGlyphList.c: In function 'setupBlitVector':
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/java.desktop/share/native/libfontmanager/DrawGlyphList.c:108:21: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
             ginfo = (GlyphInfo*)imagePtrs[g];
                     ^
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/java.desktop/share/native/libfontmanager/DrawGlyphList.c:121:21: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
             ginfo = (GlyphInfo*)imagePtrs[g];
                     ^
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/java.desktop/share/native/libfontmanager/DrawGlyphList.c: In function 'setupLCDBlitVector':
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/java.desktop/share/native/libfontmanager/DrawGlyphList.c:534:17: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
         ginfo = (GlyphInfo*)imagePtrs[0];
                 ^
/home/ec2-user/workspace/zulu13-build-linux32/zulu-src.git/src/java.desktop/share/native/libfontmanager/DrawGlyphList.c:569:21: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
             ginfo = (GlyphInfo*)imagePtrs[g];
                     ^
...
```                     
After applying this patch they were fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250605](https://bugs.openjdk.java.net/browse/JDK-8250605): Linux x86_32 builds fail after JDK-8249821


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/302/head:pull/302` \
`$ git checkout pull/302`

Update a local copy of the PR: \
`$ git checkout pull/302` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 302`

View PR using the GUI difftool: \
`$ git pr show -t 302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/302.diff">https://git.openjdk.java.net/jdk13u-dev/pull/302.diff</a>

</details>
