### PR TITLE
8255790: GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -537,22 +537,18 @@ endif
 
 ###########################################################################
 
-ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
-  LIBHARFBUZZ_LIBS := $(HARFBUZZ_LIBS)
-else
-  HARFBUZZ_CFLAGS := -DHAVE_OT -DHAVE_FALLBACK -DHAVE_UCDN -DHAVE_ROUND
 
-  # This is better than adding EXPORT_ALL_SYMBOLS
-  ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__attribute__\(\(visibility\(\"default\"\)\)\)
-  else ifeq ($(TOOLCHAIN_TYPE), microsoft)
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__declspec\(dllexport\)
-  endif
+ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
+  LIBFONTMANAGER_EXTRA_SRC =
+  BUILD_LIBFONTMANAGER_FONTLIB += $(HARFBUZZ_LIBS)
+else
+  LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
+  HARFBUZZ_CFLAGS := -DHAVE_OT -DHAVE_FALLBACK -DHAVE_UCDN -DHAVE_ROUND
 
   ifeq ($(call isTargetOs, windows), false)
     HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
-                      -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
-                      -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
+                       -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
+                       -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
   endif
   ifeq ($(call isTargetOs, solaris), true)
     HARFBUZZ_CFLAGS += -DHAVE_SOLARIS_ATOMIC_OPS
@@ -563,68 +559,42 @@ else
   ifeq ($(call isTargetOs, macosx), true)
     HARFBUZZ_CFLAGS += -DHAVE_CORETEXT
   endif
+
+  # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
+  # when building libharfbuzz
+  ifeq ($(call isTargetOs, aix), true)
+    HARFBUZZ_CFLAGS += -qdebug=necan
+  endif
+
   ifeq ($(call isTargetOs, macosx), false)
-    LIBHARFBUZZ_EXCLUDE_FILES += harfbuzz/hb-coretext.cc
+    LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-coretext.cc
   endif
   # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-  LIBHARFBUZZ_EXCLUDE_FILES += harfbuzz/hb-ft.cc
+  LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
-  LIBHARFBUZZ_CFLAGS += $(HARFBUZZ_CFLAGS)
+  HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
+  HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
+       maybe-uninitialized class-memaccess
+  HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
+       tautological-constant-out-of-range-compare int-to-pointer-cast \
+       undef missing-field-initializers
+  HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138
+  HARFBUZZ_DISABLED_WARNINGS_C_solstudio := \
+        E_INTEGER_OVERFLOW_DETECTED \
+        E_ARG_INCOMPATIBLE_WITH_ARG_L \
+        E_ENUM_VAL_OVERFLOWS_INT_MAX
+  HARFBUZZ_DISABLED_WARNINGS_CXX_solstudio := \
+        truncwarn wvarhidenmem wvarhidemem wbadlkginit identexpected \
+        hidevf w_novirtualdescr arrowrtn2 unknownpragma
 
-  # For use by libfontmanager:
-  ifeq ($(call isTargetOs, windows), true)
-    LIBHARFBUZZ_LIBS := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libharfbuzz/harfbuzz.lib
-  else
-    LIBHARFBUZZ_LIBS := -lharfbuzz
-  endif
-
-  LIBHARFBUZZ_EXTRA_HEADER_DIRS := \
-    libharfbuzz/hb-ucdn \
-    #
-
-  LIBHARFBUZZ_OPTIMIZATION := HIGH
-
-  LIBHARFBUZZ_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
-
-  $(eval $(call SetupJdkLibrary, BUILD_LIBHARFBUZZ, \
-      NAME := harfbuzz, \
-      EXCLUDE_FILES := $(LIBHARFBUZZ_EXCLUDE_FILES), \
-      TOOLCHAIN := TOOLCHAIN_LINK_CXX, \
-      CFLAGS := $(CFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      OPTIMIZATION := $(LIBHARFBUZZ_OPTIMIZATION), \
-      CFLAGS_windows = -DCC_NOEX, \
-      EXTRA_HEADER_DIRS := $(LIBHARFBUZZ_EXTRA_HEADER_DIRS), \
-      WARNINGS_AS_ERRORS_xlc := false, \
-      DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing, \
-      DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-        maybe-uninitialized class-memaccess, \
-      DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
-        tautological-constant-out-of-range-compare int-to-pointer-cast \
-        undef missing-field-initializers, \
-      DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138, \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-        $(call SET_SHARED_LIBRARY_ORIGIN), \
-      LDFLAGS_unix := -L$(INSTALL_LIBRARIES_HERE), \
-      LDFLAGS_aix := -Wl$(COMMA)-berok, \
-      LIBS := $(BUILD_LIBHARFBUZZ), \
-      LIBS_unix := $(LIBM) $(LIBCXX), \
-      LIBS_macosx := -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
-      LIBS_windows := user32.lib, \
-  ))
-
-  ifeq ($(FREETYPE_TO_USE), bundled)
-    $(BUILD_LIBHARFBUZZ): $(BUILD_LIBFREETYPE)
-  endif
-
-  TARGETS += $(BUILD_LIBHARFBUZZ)
+  LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 
 endif
 
-###########################################################################
 
 LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libharfbuzz \
+    libharfbuzz/hb-ucdn \
     common/awt \
     common/font \
     libawt/java2d \
@@ -632,10 +602,10 @@ LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libawt/java2d/loops \
     #
 
-LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS) $(HARFBUZZ_FLAGS)
-BUILD_LIBFONTMANAGER_FONTLIB += $(LIBHARFBUZZ_LIBS) $(LIBFREETYPE_LIBS)
+LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS)
+BUILD_LIBFONTMANAGER_FONTLIB +=  $(LIBFREETYPE_LIBS)
 
-LIBFONTMANAGER_OPTIMIZATION := HIGH
+LIBFONTMANAGER_OPTIMIZATION := HIGHEST
 
 ifeq ($(call isTargetOs, windows), true)
   LIBFONTMANAGER_EXCLUDE_FILES += X11FontScaler.c \
@@ -673,17 +643,14 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     OPTIMIZATION := $(LIBFONTMANAGER_OPTIMIZATION), \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
+    EXTRA_SRC := $(LIBFONTMANAGER_EXTRA_SRC), \
     WARNINGS_AS_ERRORS_xlc := false, \
-    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast, \
-    DISABLED_WARNINGS_clang := sign-compare, \
-    DISABLED_WARNINGS_microsoft := 4018 4146 4244 4996, \
-    DISABLED_WARNINGS_C_solstudio = \
-        E_INTEGER_OVERFLOW_DETECTED \
-        E_ARG_INCOMPATIBLE_WITH_ARG_L \
-        E_ENUM_VAL_OVERFLOWS_INT_MAX, \
-    DISABLED_WARNINGS_CXX_solstudio := \
-        truncwarn wvarhidenmem wvarhidemem wbadlkginit identexpected \
-        hidevf w_novirtualdescr arrowrtn2 refmemnoconstr_aggr unknownpragma, \
+    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast $(HARFBUZZ_DISABLED_WARNINGS_gcc), \
+    DISABLED_WARNINGS_CXX_gcc := $(HARFBUZZ_DISABLED_WARNINGS_CXX_gcc), \
+    DISABLED_WARNINGS_clang := sign-compare $(HARFBUZZ_DISABLED_WARNINGS_clang), \
+    DISABLED_WARNINGS_C_solstudio := $(HARFBUZZ_DISABLED_WARNINGS_C_solstudio), \
+    DISABLED_WARNINGS_CXX_solstudio := $(HARFBUZZ_DISABLED_WARNINGS_CXX_solstudio), \
+    DISABLED_WARNINGS_microsoft := 4018 4996 $(HARFBUZZ_DISABLED_WARNINGS_microsoft), \
     LDFLAGS := $(subst -Xlinker -z -Xlinker defs,, \
         $(subst -Wl$(COMMA)-z$(COMMA)defs,,$(LDFLAGS_JDKLIB))) $(LDFLAGS_CXX_JDK) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
@@ -691,16 +658,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     LIBS := $(BUILD_LIBFONTMANAGER_FONTLIB), \
     LIBS_unix := -lawt -ljava -ljvm $(LIBM) $(LIBCXX), \
-    LIBS_macosx := -lawt_lwawt, \
+    LIBS_macosx := -lawt_lwawt -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
     LIBS_windows := $(WIN_JAVA_LIB) advapi32.lib user32.lib gdi32.lib \
         $(WIN_AWT_LIB), \
 ))
 
 $(BUILD_LIBFONTMANAGER): $(BUILD_LIBAWT)
-
-ifeq ($(USE_EXTERNAL_HARFBUZZ), false)
-  $(BUILD_LIBFONTMANAGER): $(BUILD_LIBHARFBUZZ)
-endif
 
 ifeq ($(call isTargetOs, macosx), true)
   $(BUILD_LIBFONTMANAGER): $(call FindLib, $(MODULE), awt_lwawt)


### PR DESCRIPTION
I'd like to backport JDK-8255790 to jdk13u for parity with jdk11u. It's a follow-up for JDK-8249821.

The backport for
`JDK-8272332: --with-harfbuzz=system doesn't add -lharfbuzz after JDK-8255790`
was included as a part of this patch.

The original patch applied manually because the file has another location: 
`make/lib/Awt2dLibraries.gmk instead of make/modules/java.desktop/lib/Awt2dLibraries.gmk.`
This patch is very similar to those ones applied to jdk11u and jdk15u.

The crash was reproduced on Fedora Linux 35 with a test app from JDK-8272149. After applying this patch it is fixed.
(the build was with --with-freetype=system)

All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8255790](https://bugs.openjdk.java.net/browse/JDK-8255790): GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux
 * [JDK-8272332](https://bugs.openjdk.java.net/browse/JDK-8272332): --with-harfbuzz=system doesn't add -lharfbuzz after JDK-8255790


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.java.net/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/304/head:pull/304` \
`$ git checkout pull/304`

Update a local copy of the PR: \
`$ git checkout pull/304` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 304`

View PR using the GUI difftool: \
`$ git pr show -t 304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/304.diff">https://git.openjdk.java.net/jdk13u-dev/pull/304.diff</a>

</details>
