### PR TITLE
8266545: 8261169 broke Harfbuzz build with gcc 7 and 8

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -575,7 +575,7 @@ else
 
   HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-       maybe-uninitialized class-memaccess unused-result
+       maybe-uninitialized class-memaccess unused-result extra
   HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
        tautological-constant-out-of-range-compare int-to-pointer-cast \
        undef missing-field-initializers range-loop-analysis


### PR DESCRIPTION
I'd like to backport JDK-8266545 to jdk13u as a follow-up to JDK-8261169.

The original patch applied manually because the patched file is in another directory:
make/lib/Awt2dLibraries.gmk instead of make/modules/java.desktop/lib/Awt2dLibraries.gmk.

All regular tests passed (tested on Windows x86/x86_64 (VS 2017), Linux x86/x86_64 (gcc 8.3.0), Mac OS X x86_64 (XCode/Clang 11.0), Linux aarch64 (gcc 9.3.0)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266545](https://bugs.openjdk.java.net/browse/JDK-8266545): 8261169 broke Harfbuzz build with gcc 7 and 8


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/307/head:pull/307` \
`$ git checkout pull/307`

Update a local copy of the PR: \
`$ git checkout pull/307` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 307`

View PR using the GUI difftool: \
`$ git pr show -t 307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/307.diff">https://git.openjdk.java.net/jdk13u-dev/pull/307.diff</a>

</details>
