### PR TITLE
8247907: XMLDsig logging does not work

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -79,6 +79,8 @@ grant codeBase "jrt:/java.sql.rowset" {
 
 grant codeBase "jrt:/java.xml.crypto" {
     permission java.lang.RuntimePermission
+                   "getStackWalkerWithClassReference";
+    permission java.lang.RuntimePermission
                    "accessClassInPackage.sun.security.util";
     permission java.util.PropertyPermission "*", "read";
     permission java.security.SecurityPermission "putProviderProperty.XMLDSig";

--- a/src/java.xml.crypto/share/classes/com/sun/org/slf4j/internal/Logger.java
+++ b/src/java.xml.crypto/share/classes/com/sun/org/slf4j/internal/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,27 @@
  */
 package com.sun.org.slf4j.internal;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.logging.Level;
+
 // Bridge to java.util.logging.
 public class Logger {
+
+    /**
+     * StackWalker to find out the caller of this class so that it can be
+     * shown in the log output. The multiple private log0() methods below
+     * skip exactly 2 frames -- one log0() itself, the other one of the
+     * public debug()/warn()/error()/trace() methods in this class --
+     * to find the caller.
+     */
+    private static final StackWalker WALKER;
+    static {
+        final PrivilegedAction<StackWalker> action =
+                () -> StackWalker.getInstance(StackWalker.Option
+                        .RETAIN_CLASS_REFERENCE);
+        WALKER = AccessController.doPrivileged(action);
+    }
 
     private final java.util.logging.Logger impl;
 
@@ -34,46 +53,92 @@ public class Logger {
     }
 
     public boolean isDebugEnabled() {
-        return impl.isLoggable(java.util.logging.Level.FINE);
+        return impl.isLoggable(Level.FINE);
     }
 
     public boolean isTraceEnabled() {
-        return impl.isLoggable(java.util.logging.Level.FINE);
+        return impl.isLoggable(Level.FINE);
     }
 
     public void debug(String s) {
-        impl.log(java.util.logging.Level.FINE, s);
+        log0(Level.FINE, s);
     }
 
     public void debug(String s, Throwable e) {
-        impl.log(java.util.logging.Level.FINE, s, e);
+        log0(Level.FINE, s, e);
     }
 
     public void debug(String s, Object... o) {
-        impl.log(java.util.logging.Level.FINE, s, o);
+        log0(Level.FINE, s, o);
     }
 
     public void trace(String s) {
-        impl.log(java.util.logging.Level.FINE, s);
+        log0(Level.FINE, s);
     }
 
     public void error(String s) {
-        impl.log(java.util.logging.Level.SEVERE, s);
+        log0(Level.SEVERE, s);
     }
 
     public void error(String s, Throwable e) {
-        impl.log(java.util.logging.Level.SEVERE, s, e);
+        log0(Level.SEVERE, s, e);
     }
 
     public void error(String s, Object... o) {
-        impl.log(java.util.logging.Level.SEVERE, s, o);
+        log0(Level.SEVERE, s, o);
     }
 
     public void warn(String s) {
-        impl.log(java.util.logging.Level.WARNING, s);
+        log0(Level.WARNING, s);
     }
 
     public void warn(String s, Throwable e) {
-        impl.log(java.util.logging.Level.WARNING, s, e);
+        log0(Level.WARNING, s, e);
+    }
+
+    private void log0(Level level, String s) {
+        if (impl.isLoggable(level)) {
+            var sf = WALKER.walk(f -> f.skip(2).findFirst()).get();
+            impl.logp(Level.FINE, sf.getClassName(), sf.getMethodName(), s);
+        }
+    }
+
+    public void log0(Level level, String s, Throwable e) {
+        if (impl.isLoggable(level)) {
+            var sf = WALKER.walk(f -> f.skip(2).findFirst()).get();
+            impl.logp(Level.FINE, sf.getClassName(), sf.getMethodName(), s, e);
+        }
+    }
+
+    public void log0(Level level, String s, Object... o) {
+        if (impl.isLoggable(level)) {
+            var sf = WALKER.walk(f -> f.skip(2).findFirst()).get();
+            impl.logp(Level.FINE, sf.getClassName(), sf.getMethodName(),
+                    addIndex(s), o);
+        }
+    }
+
+    /**
+     * Translate the log4j message format "Hello {}, {}" to the
+     * java.util.logging format "Hello {0}, {1}".
+     */
+    private static String addIndex(String s) {
+        int start = 0;
+        int index = 0;
+        StringBuilder sb = new StringBuilder();
+        while (true) {
+            int pos = s.indexOf("{}", start);
+            if (pos < 0) {
+                break;
+            }
+            sb.append(s, start, pos + 1).append(index++);
+            start = pos + 1;
+        }
+        if (index == 0) {
+            return s;
+        } else {
+            sb.append(s, start, s.length());
+            return sb.toString();
+        }
     }
 }

--- a/test/jdk/javax/xml/crypto/dsig/LogParameters.java
+++ b/test/jdk/javax/xml/crypto/dsig/LogParameters.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.hexdump.HexPrinter;
+
+import java.io.ByteArrayOutputStream;
+import java.util.logging.*;
+
+/**
+ * @test
+ * @bug 8247907
+ * @library /test/lib
+ * @modules java.xml.crypto/com.sun.org.slf4j.internal
+ */
+public class LogParameters {
+    public static void main(String[] args) {
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        Logger.getLogger(String.class.getName()).setLevel(Level.ALL);
+        Handler h = new StreamHandler(bout, new SimpleFormatter());
+        h.setLevel(Level.ALL);
+        Logger.getLogger(String.class.getName()).addHandler(h);
+
+        com.sun.org.slf4j.internal.Logger log =
+                com.sun.org.slf4j.internal.LoggerFactory.getLogger(String.class);
+        log.debug("I have {} {}s.", 10, "apple");
+
+        h.flush();
+
+        byte[] data = bout.toByteArray();
+        String s = new String(data);
+        if (!s.contains("LogParameters main")
+                || !s.contains("FINE: I have 10 apples.")) {
+            HexPrinter.simple().format(data);
+            throw new RuntimeException("Unexpected log output: " + s);
+        }
+    }
+}


### PR DESCRIPTION
Need to backport this fix and following 8247964 to make Santuario backports easier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247907](https://bugs.openjdk.java.net/browse/JDK-8247907): XMLDsig logging does not work


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/316/head:pull/316` \
`$ git checkout pull/316`

Update a local copy of the PR: \
`$ git checkout pull/316` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 316`

View PR using the GUI difftool: \
`$ git pr show -t 316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/316.diff">https://git.openjdk.java.net/jdk13u-dev/pull/316.diff</a>

</details>
