### PR TITLE
8247964: All log0() in com/sun/org/slf4j/internal/Logger.java should be private

### DIFF
--- a/src/java.xml.crypto/share/classes/com/sun/org/slf4j/internal/Logger.java
+++ b/src/java.xml.crypto/share/classes/com/sun/org/slf4j/internal/Logger.java
@@ -103,14 +103,14 @@ public class Logger {
         }
     }
 
-    public void log0(Level level, String s, Throwable e) {
+    private void log0(Level level, String s, Throwable e) {
         if (impl.isLoggable(level)) {
             var sf = WALKER.walk(f -> f.skip(2).findFirst()).get();
             impl.logp(Level.FINE, sf.getClassName(), sf.getMethodName(), s, e);
         }
     }
 
-    public void log0(Level level, String s, Object... o) {
+    private void log0(Level level, String s, Object... o) {
         if (impl.isLoggable(level)) {
             var sf = WALKER.walk(f -> f.skip(2).findFirst()).get();
             impl.logp(Level.FINE, sf.getClassName(), sf.getMethodName(),


### PR DESCRIPTION
Second backport related to logging. Clean patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247964](https://bugs.openjdk.java.net/browse/JDK-8247964): All log0() in com/sun/org/slf4j/internal/Logger.java should be private


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/317/head:pull/317` \
`$ git checkout pull/317`

Update a local copy of the PR: \
`$ git checkout pull/317` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 317`

View PR using the GUI difftool: \
`$ git pr show -t 317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/317.diff">https://git.openjdk.java.net/jdk13u-dev/pull/317.diff</a>

</details>
