### PR TITLE
8280947: Adapt test/jdk/javax/xml/crypto/dsig/LogParameters.java for 13u

### DIFF
--- a/test/jdk/javax/xml/crypto/dsig/LogParameters.java
+++ b/test/jdk/javax/xml/crypto/dsig/LogParameters.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import jdk.test.lib.hexdump.HexPrinter;
 
 import java.io.ByteArrayOutputStream;
 import java.util.logging.*;
@@ -51,7 +50,6 @@ public class LogParameters {
         String s = new String(data);
         if (!s.contains("LogParameters main")
                 || !s.contains("FINE: I have 10 apples.")) {
-            HexPrinter.simple().format(data);
             throw new RuntimeException("Unexpected log output: " + s);
         }
     }


### PR DESCRIPTION
Original test depends on JDK-8243010. We have no plans so far to backport the enhancement.