### PR TITLE
8272541: Incorrect overflow test in Toom-Cook branch of BigInteger multiplication

### DIFF
--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -1653,8 +1653,8 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
                     // are only considering the magnitudes as non-negative. The
                     // Toom-Cook multiplication algorithm determines the sign
                     // at its end from the two signum values.
-                    if (bitLength(mag, mag.length) +
-                        bitLength(val.mag, val.mag.length) >
+                    if ((long)bitLength(mag, mag.length) +
+                        (long)bitLength(val.mag, val.mag.length) >
                         32L*MAX_MAG_LENGTH) {
                         reportOverflow();
                     }

--- a/test/jdk/java/math/BigInteger/BitLengthOverflow.java
+++ b/test/jdk/java/math/BigInteger/BitLengthOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,28 +23,43 @@
 
 /*
  * @test
- * @bug 6910473
+ * @bug 6910473 8272541
  * @summary Test that bitLength() is not negative
  * @author Dmitry Nadezhin
  */
 import java.math.BigInteger;
+import java.util.function.Supplier;
 
 public class BitLengthOverflow {
-
-    public static void main(String[] args) {
+    private static void test(Supplier<BigInteger> s) {
         try {
-            BigInteger x = BigInteger.ONE.shiftLeft(Integer.MAX_VALUE); // x = pow(2,Integer.MAX_VALUE)
-            if (x.bitLength() != (1L << 31)) {
-                throw new RuntimeException("Incorrect bitLength() " + x.bitLength());
-            }
-            System.out.println("Surprisingly passed with correct bitLength() " + x.bitLength());
+            BigInteger x = s.get();
+            System.out.println("Surprisingly passed with correct bitLength() " +
+                               x.bitLength());
         } catch (ArithmeticException e) {
             // expected
-            System.out.println("Overflow is reported by ArithmeticException, as expected");
+            System.out.println("Overflow reported by ArithmeticException, as expected");
         } catch (OutOfMemoryError e) {
             // possible
             System.err.println("BitLengthOverflow skipped: OutOfMemoryError");
             System.err.println("Run jtreg with -javaoption:-Xmx8g");
         }
+    }
+
+    public static void main(String[] args) {
+        test(() -> {
+            // x = pow(2,Integer.MAX_VALUE)
+            BigInteger x = BigInteger.ONE.shiftLeft(Integer.MAX_VALUE);
+            if (x.bitLength() != (1L << 31)) {
+                throw new RuntimeException("Incorrect bitLength() " +
+                                           x.bitLength());
+            }
+            return x;
+        });
+        test(() -> {
+            BigInteger a = BigInteger.ONE.shiftLeft(1073742825);
+            BigInteger b = BigInteger.ONE.shiftLeft(1073742825);
+            return a.multiply(b);
+        });
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d1aeca11](https://github.com/openjdk/jdk/commit/d1aeca117ccc4334d67b2692ff087a9f8d808a59) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Brian Burkhalter on 27 Aug 2021 and was reviewed by Joe Darcy.
It has already been backported to [jdk17u-dev](https://git.openjdk.java.net/jdk17u-dev/commit/8207e69aa076ba848b8496c4ea0bcbea952aae2a).

This is a clean backport to 11u. As @shipilev notes on the bug, the original code (JDK-8200659) was backported to all active branches in the January 2019 security update, so we should update the test everywhere as well.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272541](https://bugs.openjdk.java.net/browse/JDK-8272541): Incorrect overflow test in Toom-Cook branch of BigInteger multiplication


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/327/head:pull/327` \
`$ git checkout pull/327`

Update a local copy of the PR: \
`$ git checkout pull/327` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 327`

View PR using the GUI difftool: \
`$ git pr show -t 327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/327.diff">https://git.openjdk.java.net/jdk13u-dev/pull/327.diff</a>

</details>
