### PR TITLE
8276657: XSLT compiler tries to define a class with empty name

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/XSLTC.java
@@ -58,7 +58,7 @@ import org.xml.sax.XMLReader;
  * @author G. Todd Miller
  * @author Morten Jorgensen
  * @author John Howard (johnh@schemasoft.com)
- * @LastModified: Oct 2017
+ * @LastModified: Nov 2021
  */
 public final class XSLTC {
 
@@ -460,8 +460,11 @@ public final class XSLTC {
                 if (name != null) {
                     setClassName(name);
                 }
-                else if (systemId != null && !systemId.equals("")) {
-                    setClassName(Util.baseName(systemId));
+                else if (systemId != null && !systemId.isEmpty()) {
+                    String clsName = Util.baseName(systemId);
+                    if (clsName != null && !clsName.isEmpty()) {
+                        setClassName(clsName);
+                    }
                 }
 
                 // Ensure we have a non-empty class name at this point


### PR DESCRIPTION
I'd like to backport JDK-8276657 to jdk13u for parity with jdk11u.
The original patch applied cleanly. It's simple and low risk.
The arguments sound reasonable https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-November/083135.html
All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276657](https://bugs.openjdk.java.net/browse/JDK-8276657): XSLT compiler tries to define a class with empty name


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/339/head:pull/339` \
`$ git checkout pull/339`

Update a local copy of the PR: \
`$ git checkout pull/339` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 339`

View PR using the GUI difftool: \
`$ git pr show -t 339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/339.diff">https://git.openjdk.java.net/jdk13u-dev/pull/339.diff</a>

</details>
