### PR TITLE
8257794: Zero: assert(istate->_stack_limit == istate->_thread->last_Java_sp() + 1) failed: wrong on Linux/x86_32

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
@@ -482,7 +482,6 @@ BytecodeInterpreter::run(interpreterState istate) {
 #ifdef ASSERT
   if (istate->_msg != initialize) {
     assert(labs(istate->_stack_base - istate->_stack_limit) == (istate->_method->max_stack() + 1), "bad stack limit");
-    IA32_ONLY(assert(istate->_stack_limit == istate->_thread->last_Java_sp() + 1, "wrong"));
   }
   // Verify linkages.
   interpreterState l = istate;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [df55ecd8](https://github.com/openjdk/jdk/commit/df55ecd83c70e8962e9037671cd13b104d3e5620) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Jie Fu on 9 Dec 2020 and was reviewed by Aleksey Shipilev.

The fix has already been backported to 11u so it makes sense to also fix it in 13u. This unbreaks the slowdebug Zero build on x86_32.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257794](https://bugs.openjdk.java.net/browse/JDK-8257794): Zero: assert(istate->_stack_limit == istate->_thread->last_Java_sp() + 1) failed: wrong on Linux/x86_32


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/340/head:pull/340` \
`$ git checkout pull/340`

Update a local copy of the PR: \
`$ git checkout pull/340` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 340`

View PR using the GUI difftool: \
`$ git pr show -t 340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/340.diff">https://git.openjdk.java.net/jdk13u-dev/pull/340.diff</a>

</details>
