### PR TITLE
8258471: "search codecache" clhsdb command does not work

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1425,6 +1425,7 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   declare_type(BufferBlob,               RuntimeBlob)                     \
   declare_type(AdapterBlob,              BufferBlob)                      \
   declare_type(MethodHandlesAdapterBlob, BufferBlob)                      \
+  declare_type(VtableBlob,               BufferBlob)                      \
   declare_type(CompiledMethod,           CodeBlob)                        \
   declare_type(nmethod,                  CompiledMethod)                  \
   declare_type(RuntimeStub,              RuntimeBlob)                     \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
@@ -62,6 +62,7 @@ public class CodeCache {
     virtualConstructor.addMapping("RuntimeStub", RuntimeStub.class);
     virtualConstructor.addMapping("AdapterBlob", AdapterBlob.class);
     virtualConstructor.addMapping("MethodHandlesAdapterBlob", MethodHandlesAdapterBlob.class);
+    virtualConstructor.addMapping("VtableBlob", VtableBlob.class);
     virtualConstructor.addMapping("SafepointBlob", SafepointBlob.class);
     virtualConstructor.addMapping("DeoptimizationBlob", DeoptimizationBlob.class);
     if (VM.getVM().isServerCompiler()) {
@@ -163,7 +164,7 @@ public class CodeCache {
     }
     catch (Exception e) {
       String message = "Unable to deduce type of CodeBlob from address " + codeBlobAddr +
-                       " (expected type nmethod, RuntimeStub, ";
+                       " (expected type nmethod, RuntimeStub, VtableBlob, ";
       if (VM.getVM().isClientCompiler()) {
         message = message + " or ";
       }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/VtableBlob.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/VtableBlob.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, NTT DATA.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.code;
+
+import sun.jvm.hotspot.debugger.Address;
+
+public class VtableBlob extends BufferBlob {
+
+    public VtableBlob(Address addr) {
+        super(addr);
+    }
+
+    public boolean isVtableBlob() {
+        return true;
+    }
+
+    public String getName() {
+        return "VtableBlob: " + super.getName();
+    }
+
+}


### PR DESCRIPTION
Clean backport of a useful SA fix. First series of tests run OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258471](https://bugs.openjdk.java.net/browse/JDK-8258471): "search codecache" clhsdb command does not work


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/351/head:pull/351` \
`$ git checkout pull/351`

Update a local copy of the PR: \
`$ git checkout pull/351` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 351`

View PR using the GUI difftool: \
`$ git pr show -t 351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/351.diff">https://git.openjdk.java.net/jdk13u-dev/pull/351.diff</a>

</details>
