### PR TITLE
Backport bf3438c5dc993b96d089cabb5318bfc64a6904a3

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/DSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -357,7 +357,8 @@ abstract class DSA extends SignatureSpi {
             s = new BigInteger(1, s.toByteArray());
         }
 
-        if ((r.compareTo(presetQ) == -1) && (s.compareTo(presetQ) == -1)) {
+        if ((r.compareTo(presetQ) == -1) && (s.compareTo(presetQ) == -1)
+                && r.signum() > 0 && s.signum() > 0) {
             BigInteger w = generateW(presetP, presetQ, presetG, s);
             BigInteger v = generateV(presetY, presetP, presetQ, presetG, w, r);
             return v.equals(r);


### PR DESCRIPTION
This change was part of a security fix, JDK-8277233, for 17u during the April update. The rest of 8277233 did not apply to older releases, as it concerned code added to src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSAOperations.java by JDK-8237218 in 15u.

However, the additional checks in src/java.base/share/classes/sun/security/provider/DSA.java that were included in the patch are applicable to older releases.
