### PR TITLE
8255035: Update BCEL to Version 6.5.0

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/Const.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/Const.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,14 +26,14 @@ import java.util.Collections;
  * Constants for the project, mostly defined in the JVM specification.
  *
  * @since 6.0 (intended to replace the Constants interface)
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public final class Const {
 
   /**
    * Java class file format Magic number (0xCAFEBABE)
    *
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.1-200-A">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.1-200-A">
    * The ClassFile Structure in The Java Virtual Machine Specification</a>
    */
   public static final int JVM_CLASSFILE_MAGIC = 0xCAFEBABE;
@@ -211,13 +211,14 @@ public final class Const {
   public static final int MAX_BYTE  = 255; // 2^8 - 1
 
   /** One of the access flags for fields, methods, or classes.
-   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.1-200-E.1'>
+   *
+   *  @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.1-200-E.1">
    *  Flag definitions for Classes in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
-   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.5'>
+   *  @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.5">
    *  Flag definitions for Fields in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
-   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.6'>
+   *  @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.6">
    *  Flag definitions for Methods in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
-   *  @see <a href='http://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.6-300-D.1-D.1'>
+   *  @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.6-300-D.1-D.1">
    *  Flag definitions for Inner Classes in the Java Virtual Machine Specification (Java SE 9 Edition).</a>
    */
   public static final short ACC_PUBLIC       = 0x0001;
@@ -381,87 +382,87 @@ public final class Const {
 
   /**
    * Marks a constant pool entry as type UTF-8.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.7">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.7">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_Utf8               = 1;
 
   /**
    * Marks a constant pool entry as type Integer.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.4">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.4">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_Integer            = 3;
 
   /**
    * Marks a constant pool entry as type Float.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.4">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.4">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_Float              = 4;
 
   /**
    * Marks a constant pool entry as type Long.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.5">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.5">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_Long               = 5;
 
   /**
    * Marks a constant pool entry as type Double.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.5">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.5">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_Double             = 6;
 
   /**
    * Marks a constant pool entry as a Class
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.1">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.1">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_Class              = 7;
 
   /**
    * Marks a constant pool entry as a Field Reference.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_Fieldref           = 9;
 
   /**
    * Marks a constant pool entry as type String
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.3">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.3">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_String             = 8;
 
   /** Marks a constant pool entry as a Method Reference.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2">
    * The Constant Pool in The Java Virtual Machine Specification</a> */
   public static final byte CONSTANT_Methodref          = 10;
 
   /**
    * Marks a constant pool entry as an Interface Method Reference.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.2">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_InterfaceMethodref = 11;
 
   /** Marks a constant pool entry as a name and type.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.6">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.6">
    * The Constant Pool in The Java Virtual Machine Specification</a> */
   public static final byte CONSTANT_NameAndType        = 12;
 
   /**
    * Marks a constant pool entry as a Method Handle.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.8">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.8">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_MethodHandle       = 15;
 
   /**
    * Marks a constant pool entry as a Method Type.
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.9">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.9">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_MethodType         = 16;
@@ -476,7 +477,7 @@ public final class Const {
 
   /**
    * Marks a constant pool entry as an Invoke Dynamic
-   * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10">
+   * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10">
    * The Constant Pool in The Java Virtual Machine Specification</a>
    */
   public static final byte CONSTANT_InvokeDynamic      = 18;
@@ -546,7 +547,7 @@ public final class Const {
   /**
    * Maximum Constant Pool entries.
    * One of the limitations of the Java Virtual Machine.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.11-100-A">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.11-100-A">
    * The Java Virtual Machine Specification, Java SE 8 Edition, page 330, chapter 4.11.</a>
    */
   public static final int MAX_CP_ENTRIES     = 65535;
@@ -564,8 +565,8 @@ public final class Const {
    * The entry in the Limitations section has been removed from later versions of the spec;
    * it is not present in the Java SE 8 edition.
    *
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.3-300-E">
-   * The Java Virtual Machine Specification, Java SE 8 Edition, page 104, chapter 4.7.3</a>
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.3-300-E">
+   * The Java Virtual Machine Specification, Java SE 8 Edition, page 104, chapter 4.7.</a>
    */
   public static final int MAX_CODE_SIZE      = 65536; //bytes
 
@@ -573,1228 +574,1228 @@ public final class Const {
    * The maximum number of dimensions in an array ({@value}).
    * One of the limitations of the Java Virtual Machine.
    *
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2-150">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2-150">
    * Field Descriptors in The Java Virtual Machine Specification</a>
    */
   public static final int MAX_ARRAY_DIMENSIONS = 255;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.nop">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.nop">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short NOP              = 0;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aconst_null">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aconst_null">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ACONST_NULL      = 1;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ICONST_M1        = 2;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ICONST_0         = 3;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ICONST_1         = 4;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ICONST_2         = 5;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ICONST_3         = 6;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ICONST_4         = 7;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iconst_i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ICONST_5         = 8;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lconst_l">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lconst_l">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LCONST_0         = 9;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lconst_l">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lconst_l">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LCONST_1         = 10;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fconst_f">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fconst_f">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FCONST_0         = 11;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fconst_f">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fconst_f">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FCONST_1         = 12;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fconst_f">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fconst_f">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FCONST_2         = 13;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dconst_d">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dconst_d">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DCONST_0         = 14;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dconst_d">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dconst_d">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DCONST_1         = 15;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.bipush">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.bipush">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short BIPUSH           = 16;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.sipush">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.sipush">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short SIPUSH           = 17;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldc">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldc">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LDC              = 18;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldc_w">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldc_w">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LDC_W            = 19;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldc2_w">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldc2_w">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LDC2_W           = 20;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ILOAD            = 21;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LLOAD            = 22;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FLOAD            = 23;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DLOAD            = 24;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ALOAD            = 25;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ILOAD_0          = 26;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ILOAD_1          = 27;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ILOAD_2          = 28;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ILOAD_3          = 29;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LLOAD_0          = 30;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LLOAD_1          = 31;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LLOAD_2          = 32;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LLOAD_3          = 33;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FLOAD_0          = 34;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FLOAD_1          = 35;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FLOAD_2          = 36;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FLOAD_3          = 37;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DLOAD_0          = 38;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DLOAD_1          = 39;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DLOAD_2          = 40;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DLOAD_3          = 41;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ALOAD_0          = 42;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ALOAD_1          = 43;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ALOAD_2          = 44;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aload_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ALOAD_3          = 45;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iaload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iaload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IALOAD           = 46;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.laload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.laload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LALOAD           = 47;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.faload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.faload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FALOAD           = 48;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.daload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.daload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DALOAD           = 49;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aaload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aaload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short AALOAD           = 50;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.baload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.baload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short BALOAD           = 51;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.caload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.caload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short CALOAD           = 52;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.saload">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.saload">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short SALOAD           = 53;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISTORE           = 54;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSTORE           = 55;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FSTORE           = 56;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DSTORE           = 57;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ASTORE           = 58;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISTORE_0         = 59;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISTORE_1         = 60;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISTORE_2         = 61;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.istore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISTORE_3         = 62;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSTORE_0         = 63;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSTORE_1         = 64;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSTORE_2         = 65;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSTORE_3         = 66;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FSTORE_0         = 67;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FSTORE_1         = 68;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FSTORE_2         = 69;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FSTORE_3         = 70;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DSTORE_0         = 71;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DSTORE_1         = 72;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DSTORE_2         = 73;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dstore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DSTORE_3         = 74;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ASTORE_0         = 75;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ASTORE_1         = 76;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ASTORE_2         = 77;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.astore_n">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ASTORE_3         = 78;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iastore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iastore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IASTORE          = 79;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lastore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lastore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LASTORE          = 80;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fastore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fastore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FASTORE          = 81;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dastore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dastore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DASTORE          = 82;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aastore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.aastore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short AASTORE          = 83;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.bastore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.bastore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short BASTORE          = 84;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.castore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.castore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short CASTORE          = 85;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.sastore">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.sastore">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short SASTORE          = 86;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.pop">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.pop">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short POP              = 87;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.pop2">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.pop2">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short POP2             = 88;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DUP              = 89;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup_x1">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup_x1">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DUP_X1           = 90;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup_x2">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup_x2">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DUP_X2           = 91;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup2">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup2">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DUP2             = 92;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup2_x1">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup2_x1">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DUP2_X1          = 93;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup2_x2">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dup2_x2">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DUP2_X2          = 94;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.swap">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.swap">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short SWAP             = 95;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iadd">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iadd">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IADD             = 96;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ladd">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ladd">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LADD             = 97;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fadd">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fadd">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FADD             = 98;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dadd">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dadd">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DADD             = 99;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.isub">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.isub">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISUB             = 100;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lsub">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lsub">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSUB             = 101;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fsub">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fsub">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FSUB             = 102;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dsub">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dsub">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DSUB             = 103;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.imul">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.imul">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IMUL             = 104;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lmul">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lmul">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LMUL             = 105;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fmul">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fmul">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FMUL             = 106;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dmul">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dmul">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DMUL             = 107;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.idiv">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.idiv">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IDIV             = 108;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldiv">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ldiv">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LDIV             = 109;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fdiv">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fdiv">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FDIV             = 110;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ddiv">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ddiv">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DDIV             = 111;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.irem">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.irem">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IREM             = 112;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lrem">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lrem">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LREM             = 113;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.frem">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.frem">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FREM             = 114;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.drem">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.drem">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DREM             = 115;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ineg">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ineg">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INEG             = 116;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lneg">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lneg">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LNEG             = 117;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fneg">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fneg">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FNEG             = 118;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dneg">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dneg">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DNEG             = 119;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ishl">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ishl">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISHL             = 120;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lshl">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lshl">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSHL             = 121;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ishr">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ishr">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ISHR             = 122;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lshr">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lshr">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LSHR             = 123;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iushr">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iushr">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IUSHR            = 124;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lushr">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lushr">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LUSHR            = 125;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iand">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iand">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IAND             = 126;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.land">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.land">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LAND             = 127;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ior">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ior">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IOR              = 128;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lor">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lor">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LOR              = 129;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ixor">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ixor">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IXOR             = 130;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lxor">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lxor">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LXOR             = 131;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iinc">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iinc">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IINC             = 132;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2l">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2l">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short I2L              = 133;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2f">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2f">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short I2F              = 134;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2d">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2d">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short I2D              = 135;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.l2i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.l2i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short L2I              = 136;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.l2f">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.l2f">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short L2F              = 137;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.l2d">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.l2d">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short L2D              = 138;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.f2i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.f2i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short F2I              = 139;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.f2l">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.f2l">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short F2L              = 140;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.f2d">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.f2d">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short F2D              = 141;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.d2i">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.d2i">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short D2I              = 142;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.d2l">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.d2l">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short D2L              = 143;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.d2f">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.d2f">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short D2F              = 144;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2b">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2b">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short I2B              = 145;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INT2BYTE         = 145; // Old notation
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2c">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2c">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short I2C              = 146;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INT2CHAR         = 146; // Old notation
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2s">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.i2s">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short I2S              = 147;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INT2SHORT        = 147; // Old notation
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lcmp">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lcmp">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LCMP             = 148;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fcmpl">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fcmpl">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FCMPL            = 149;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fcmpg">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.fcmpg">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FCMPG            = 150;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dcmpl">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dcmpl">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DCMPL            = 151;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dcmpg">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dcmpg">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DCMPG            = 152;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifeq">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifeq">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFEQ             = 153;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifne">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifne">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFNE             = 154;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iflt">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.iflt">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFLT             = 155;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifge">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifge">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFGE             = 156;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifgt">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifgt">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFGT             = 157;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifle">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifle">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFLE             = 158;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ICMPEQ        = 159;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ICMPNE        = 160;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ICMPLT        = 161;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ICMPGE        = 162;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ICMPGT        = 163;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_icmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ICMPLE        = 164;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_acmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_acmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ACMPEQ        = 165;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_acmp_cond">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.if_acmp_cond">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IF_ACMPNE        = 166;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.goto">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.goto">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short GOTO             = 167;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.jsr">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.jsr">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short JSR              = 168;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ret">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ret">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short RET              = 169;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.tableswitch">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.tableswitch">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short TABLESWITCH      = 170;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lookupswitch">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lookupswitch">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LOOKUPSWITCH     = 171;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ireturn">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ireturn">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IRETURN          = 172;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lreturn">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.lreturn">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short LRETURN          = 173;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.freturn">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.freturn">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short FRETURN          = 174;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dreturn">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.dreturn">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short DRETURN          = 175;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.areturn">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.areturn">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ARETURN          = 176;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.return">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.return">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short RETURN           = 177;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.getstatic">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.getstatic">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short GETSTATIC        = 178;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.putstatic">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.putstatic">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short PUTSTATIC        = 179;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.getfield">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.getfield">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short GETFIELD         = 180;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.putfield">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.putfield">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short PUTFIELD         = 181;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokevirtual">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokevirtual">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INVOKEVIRTUAL    = 182;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INVOKESPECIAL    = 183;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INVOKENONVIRTUAL = 183; // Old name in JDK 1.0
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokestatic">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokestatic">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INVOKESTATIC     = 184;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokeinterface">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokeinterface">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INVOKEINTERFACE  = 185;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INVOKEDYNAMIC    = 186;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.new">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.new">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short NEW              = 187;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.newarray">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.newarray">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short NEWARRAY         = 188;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.anewarray">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.anewarray">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ANEWARRAY        = 189;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.arraylength">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.arraylength">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ARRAYLENGTH      = 190;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.athrow">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.athrow">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short ATHROW           = 191;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.checkcast">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.checkcast">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short CHECKCAST        = 192;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.instanceof">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.instanceof">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short INSTANCEOF       = 193;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.monitorenter">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.monitorenter">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short MONITORENTER     = 194;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.monitorexit">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.monitorexit">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short MONITOREXIT      = 195;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.wide">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.wide">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short WIDE             = 196;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.multianewarray">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.multianewarray">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short MULTIANEWARRAY   = 197;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifnull">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifnull">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFNULL           = 198;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifnonnull">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.ifnonnull">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short IFNONNULL        = 199;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.goto_w">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.goto_w">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short GOTO_W           = 200;
 
   /** Java VM opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.jsr_w">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.jsr_w">
    * Opcode definitions in The Java Virtual Machine Specification</a> */
   public static final short JSR_W            = 201;
 
   /** JVM internal opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.2">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.2">
    * Reserved opcodes in the Java Virtual Machine Specification</a> */
   public static final short BREAKPOINT                = 202;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short LDC_QUICK                 = 203;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short LDC_W_QUICK               = 204;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short LDC2_W_QUICK              = 205;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short GETFIELD_QUICK            = 206;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short PUTFIELD_QUICK            = 207;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short GETFIELD2_QUICK           = 208;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short PUTFIELD2_QUICK           = 209;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short GETSTATIC_QUICK           = 210;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short PUTSTATIC_QUICK           = 211;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short GETSTATIC2_QUICK          = 212;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short PUTSTATIC2_QUICK          = 213;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INVOKEVIRTUAL_QUICK       = 214;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INVOKENONVIRTUAL_QUICK    = 215;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INVOKESUPER_QUICK         = 216;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INVOKESTATIC_QUICK        = 217;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INVOKEINTERFACE_QUICK     = 218;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INVOKEVIRTUALOBJECT_QUICK = 219;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short NEW_QUICK                 = 221;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short ANEWARRAY_QUICK           = 222;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short MULTIANEWARRAY_QUICK      = 223;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short CHECKCAST_QUICK           = 224;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INSTANCEOF_QUICK          = 225;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short INVOKEVIRTUAL_QUICK_W     = 226;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short GETFIELD_QUICK_W          = 227;
 
   /** JVM internal opcode.
    * @see <a href="https://web.archive.org/web/20120108031230/http://java.sun.com/docs/books/jvms/first_edition/html/Quick.doc.html">
    * Specification of _quick opcodes in the Java Virtual Machine Specification (version 1)</a>
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se5.0/html/ChangesAppendix.doc.html#448885">
    * Why the _quick opcodes were removed from the second version of the Java Virtual Machine Specification.</a> */
   public static final short PUTFIELD_QUICK_W          = 228;
 
   /** JVM internal opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.2">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.2">
    * Reserved opcodes in the Java Virtual Machine Specification</a> */
   public static final short IMPDEP1                   = 254;
 
   /** JVM internal opcode.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.2">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.2">
    * Reserved opcodes in the Java Virtual Machine Specification</a> */
   public static final short IMPDEP2                   = 255;
 
@@ -1826,42 +1827,42 @@ public final class Const {
   public static final String ILLEGAL_TYPE   = "<illegal type>";
 
   /** Boolean data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_BOOLEAN = 4;
 
   /** Char data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_CHAR    = 5;
 
   /** Float data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_FLOAT   = 6;
 
   /** Double data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_DOUBLE  = 7;
 
   /** Byte data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_BYTE    = 8;
 
   /** Short data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_SHORT   = 9;
 
   /** Int data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_INT     = 10;
 
   /** Long data type.
-   * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
+   * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.9.1-120-P">
    * Static Constraints in the Java Virtual Machine Specification</a> */
   public static final byte T_LONG    = 11;
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/ExceptionConst.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/ExceptionConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -23,20 +23,27 @@ package com.sun.org.apache.bcel.internal;
 /**
  * Exception constants.
  * @since 6.0 (intended to replace the InstructionConstant interface)
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public final class ExceptionConst {
 
-    /** The mother of all exceptions
+    /**
+     * The mother of all exceptions
      */
     public static final Class<Throwable> THROWABLE = Throwable.class;
-    /** Super class of any run-time exception
+
+    /**
+     * Super class of any run-time exception
      */
     public static final Class<RuntimeException> RUNTIME_EXCEPTION = RuntimeException.class;
-    /** Super class of any linking exception (aka Linkage Error)
+
+    /**
+     * Super class of any linking exception (aka Linkage Error)
      */
     public static final Class<LinkageError> LINKING_EXCEPTION = LinkageError.class;
-    /** Linking Exceptions
+
+    /**
+     * Linking Exceptions
      */
     public static final Class<ClassCircularityError> CLASS_CIRCULARITY_ERROR = ClassCircularityError.class;
     public static final Class<ClassFormatError> CLASS_FORMAT_ERROR = ClassFormatError.class;
@@ -52,7 +59,9 @@ public final class ExceptionConst {
     public static final Class<VerifyError> VERIFY_ERROR = VerifyError.class;
     /* UnsupportedClassVersionError is new in JDK 1.2 */
 //    public static final Class UnsupportedClassVersionError = UnsupportedClassVersionError.class;
-    /** Run-Time Exceptions
+
+    /**
+     * Run-Time Exceptions
      */
     public static final Class<NullPointerException> NULL_POINTER_EXCEPTION = NullPointerException.class;
     public static final Class<ArrayIndexOutOfBoundsException> ARRAY_INDEX_OUT_OF_BOUNDS_EXCEPTION

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationDefault.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationDefault.java
@@ -34,7 +34,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public class AnnotationDefault extends Attribute {
 
-    private ElementValue default_value;
+    private ElementValue defaultValue;
 
     /**
      * @param name_index    Index pointing to the name <em>Code</em>
@@ -44,7 +44,7 @@ public class AnnotationDefault extends Attribute {
      */
     AnnotationDefault(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
         this(name_index, length, (ElementValue) null, constant_pool);
-        default_value = ElementValue.readElementValue(input, constant_pool);
+        defaultValue = ElementValue.readElementValue(input, constant_pool);
     }
 
     /**
@@ -55,7 +55,7 @@ public class AnnotationDefault extends Attribute {
      */
     public AnnotationDefault(final int name_index, final int length, final ElementValue defaultValue, final ConstantPool constant_pool) {
         super(Const.ATTR_ANNOTATION_DEFAULT, name_index, length, constant_pool);
-        this.default_value = defaultValue;
+        this.defaultValue = defaultValue;
     }
 
     /**
@@ -74,14 +74,14 @@ public class AnnotationDefault extends Attribute {
      * @param defaultValue the default value of this methodinfo's annotation
      */
     public final void setDefaultValue(final ElementValue defaultValue) {
-        default_value = defaultValue;
+        this.defaultValue = defaultValue;
     }
 
     /**
      * @return the default value
      */
     public final ElementValue getDefaultValue() {
-        return default_value;
+        return defaultValue;
     }
 
     @Override
@@ -92,6 +92,6 @@ public class AnnotationDefault extends Attribute {
     @Override
     public final void dump(final DataOutputStream dos) throws IOException {
         super.dump(dos);
-        default_value.dump(dos);
+        defaultValue.dump(dos);
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationElementValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationElementValue.java
@@ -37,7 +37,7 @@ public class AnnotationElementValue extends ElementValue
         {
                 super(type, cpool);
                 if (type != ANNOTATION) {
-                    throw new RuntimeException(
+                    throw new IllegalArgumentException(
                                     "Only element values of type annotation can be built with this ctor - type specified: " + type);
                 }
                 this.annotationEntry = annotationEntry;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationEntry.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/AnnotationEntry.java
@@ -37,17 +37,17 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public class AnnotationEntry implements Node {
 
-    private final int type_index;
-    private final ConstantPool constant_pool;
+    private final int typeIndex;
+    private final ConstantPool constantPool;
     private final boolean isRuntimeVisible;
 
-    private List<ElementValuePair> element_value_pairs;
+    private List<ElementValuePair> elementValuePairs;
 
     /*
      * Factory method to create an AnnotionEntry from a DataInput
      *
      * @param input
-     * @param constant_pool
+     * @param constantPool
      * @param isRuntimeVisible
      * @return the entry
      * @throws IOException
@@ -56,9 +56,9 @@ public class AnnotationEntry implements Node {
 
         final AnnotationEntry annotationEntry = new AnnotationEntry(input.readUnsignedShort(), constant_pool, isRuntimeVisible);
         final int num_element_value_pairs = input.readUnsignedShort();
-        annotationEntry.element_value_pairs = new ArrayList<>();
+        annotationEntry.elementValuePairs = new ArrayList<>();
         for (int i = 0; i < num_element_value_pairs; i++) {
-            annotationEntry.element_value_pairs.add(
+            annotationEntry.elementValuePairs.add(
                     new ElementValuePair(input.readUnsignedShort(), ElementValue.readElementValue(input, constant_pool),
                     constant_pool));
         }
@@ -66,17 +66,17 @@ public class AnnotationEntry implements Node {
     }
 
     public AnnotationEntry(final int type_index, final ConstantPool constant_pool, final boolean isRuntimeVisible) {
-        this.type_index = type_index;
-        this.constant_pool = constant_pool;
+        this.typeIndex = type_index;
+        this.constantPool = constant_pool;
         this.isRuntimeVisible = isRuntimeVisible;
     }
 
     public int getTypeIndex() {
-        return type_index;
+        return typeIndex;
     }
 
     public ConstantPool getConstantPool() {
-        return constant_pool;
+        return constantPool;
     }
 
     public boolean isRuntimeVisible() {
@@ -98,7 +98,7 @@ public class AnnotationEntry implements Node {
      * @return the annotation type name
      */
     public String getAnnotationType() {
-        final ConstantUtf8 c = (ConstantUtf8) constant_pool.getConstant(type_index, Const.CONSTANT_Utf8);
+        final ConstantUtf8 c = (ConstantUtf8) constantPool.getConstant(typeIndex, Const.CONSTANT_Utf8);
         return c.getBytes();
     }
 
@@ -106,14 +106,14 @@ public class AnnotationEntry implements Node {
      * @return the annotation type index
      */
     public int getAnnotationTypeIndex() {
-        return type_index;
+        return typeIndex;
     }
 
     /**
      * @return the number of element value pairs in this annotation entry
      */
     public final int getNumElementValuePairs() {
-        return element_value_pairs.size();
+        return elementValuePairs.size();
     }
 
     /**
@@ -121,20 +121,20 @@ public class AnnotationEntry implements Node {
      */
     public ElementValuePair[] getElementValuePairs() {
         // TODO return List
-        return element_value_pairs.toArray(new ElementValuePair[element_value_pairs.size()]);
+        return elementValuePairs.toArray(new ElementValuePair[elementValuePairs.size()]);
     }
 
     public void dump(final DataOutputStream dos) throws IOException {
-        dos.writeShort(type_index); // u2 index of type name in cpool
-        dos.writeShort(element_value_pairs.size()); // u2 element_value pair
+        dos.writeShort(typeIndex); // u2 index of type name in cpool
+        dos.writeShort(elementValuePairs.size()); // u2 element_value pair
         // count
-        for (final ElementValuePair envp : element_value_pairs) {
+        for (final ElementValuePair envp : elementValuePairs) {
             envp.dump(dos);
         }
     }
 
     public void addElementNameValuePair(final ElementValuePair elementNameValuePair) {
-        element_value_pairs.add(elementNameValuePair);
+        elementValuePairs.add(elementNameValuePair);
     }
 
     public String toShortString() {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Annotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Annotations.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  */
 public abstract class Annotations extends Attribute {
 
-    private AnnotationEntry[] annotation_table;
+    private AnnotationEntry[] annotationTable;
     private final boolean isRuntimeVisible;
 
     /**
@@ -46,23 +46,23 @@ public abstract class Annotations extends Attribute {
             final ConstantPool constant_pool, final boolean isRuntimeVisible) throws IOException {
         this(annotation_type, name_index, length, (AnnotationEntry[]) null, constant_pool, isRuntimeVisible);
         final int annotation_table_length = input.readUnsignedShort();
-        annotation_table = new AnnotationEntry[annotation_table_length];
+        annotationTable = new AnnotationEntry[annotation_table_length];
         for (int i = 0; i < annotation_table_length; i++) {
-            annotation_table[i] = AnnotationEntry.read(input, constant_pool, isRuntimeVisible);
+            annotationTable[i] = AnnotationEntry.read(input, constant_pool, isRuntimeVisible);
         }
     }
 
     /**
-     * @param annotation_type the subclass type of the annotation
-     * @param name_index Index pointing to the name <em>Code</em>
+     * @param annotationType the subclass type of the annotation
+     * @param nameIndex Index pointing to the name <em>Code</em>
      * @param length Content length in bytes
-     * @param annotation_table the actual annotations
-     * @param constant_pool Array of constants
+     * @param annotationTable the actual annotations
+     * @param constantPool Array of constants
      */
-    public Annotations(final byte annotation_type, final int name_index, final int length, final AnnotationEntry[] annotation_table,
-            final ConstantPool constant_pool, final boolean isRuntimeVisible) {
-        super(annotation_type, name_index, length, constant_pool);
-        this.annotation_table = annotation_table;
+    public Annotations(final byte annotationType, final int nameIndex, final int length, final AnnotationEntry[] annotationTable,
+            final ConstantPool constantPool, final boolean isRuntimeVisible) {
+        super(annotationType, nameIndex, length, constantPool);
+        this.annotationTable = annotationTable;
         this.isRuntimeVisible = isRuntimeVisible;
     }
 
@@ -78,27 +78,27 @@ public abstract class Annotations extends Attribute {
     }
 
     /**
-     * @param annotation_table the entries to set in this annotation
+     * @param annotationTable the entries to set in this annotation
      */
-    public final void setAnnotationTable(final AnnotationEntry[] annotation_table) {
-        this.annotation_table = annotation_table;
+    public final void setAnnotationTable(final AnnotationEntry[] annotationTable) {
+        this.annotationTable = annotationTable;
     }
 
     /**
      * returns the array of annotation entries in this annotation
      */
     public AnnotationEntry[] getAnnotationEntries() {
-        return annotation_table;
+        return annotationTable;
     }
 
     /**
      * @return the number of annotation entries in this annotation
      */
     public final int getNumAnnotations() {
-        if (annotation_table == null) {
+        if (annotationTable == null) {
             return 0;
         }
-        return annotation_table.length;
+        return annotationTable.length;
     }
 
     public boolean isRuntimeVisible() {
@@ -106,11 +106,11 @@ public abstract class Annotations extends Attribute {
     }
 
     protected void writeAnnotations(final DataOutputStream dos) throws IOException {
-        if (annotation_table == null) {
+        if (annotationTable == null) {
             return;
         }
-        dos.writeShort(annotation_table.length);
-        for (final AnnotationEntry element : annotation_table) {
+        dos.writeShort(annotationTable.length);
+        for (final AnnotationEntry element : annotationTable) {
             element.dump(dos);
         }
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ArrayElementValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ArrayElementValue.java
@@ -30,17 +30,17 @@ import java.io.IOException;
 public class ArrayElementValue extends ElementValue
 {
     // For array types, this is the array
-    private final ElementValue[] evalues;
+    private final ElementValue[] elementValues;
 
     @Override
     public String toString()
     {
         final StringBuilder sb = new StringBuilder();
         sb.append("{");
-        for (int i = 0; i < evalues.length; i++)
+        for (int i = 0; i < elementValues.length; i++)
         {
-            sb.append(evalues[i]);
-            if ((i + 1) < evalues.length) {
+            sb.append(elementValues[i]);
+            if ((i + 1) < elementValues.length) {
                 sb.append(",");
             }
         }
@@ -52,18 +52,18 @@ public class ArrayElementValue extends ElementValue
     {
         super(type, cpool);
         if (type != ARRAY) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "Only element values of type array can be built with this ctor - type specified: " + type);
         }
-        this.evalues = datums;
+        this.elementValues = datums;
     }
 
     @Override
     public void dump(final DataOutputStream dos) throws IOException
     {
         dos.writeByte(super.getType()); // u1 type of value (ARRAY == '[')
-        dos.writeShort(evalues.length);
-        for (final ElementValue evalue : evalues) {
+        dos.writeShort(elementValues.length);
+        for (final ElementValue evalue : elementValues) {
             evalue.dump(dos);
         }
     }
@@ -73,10 +73,10 @@ public class ArrayElementValue extends ElementValue
     {
         final StringBuilder sb = new StringBuilder();
         sb.append("[");
-        for (int i = 0; i < evalues.length; i++)
+        for (int i = 0; i < elementValues.length; i++)
         {
-            sb.append(evalues[i].stringifyValue());
-            if ((i + 1) < evalues.length) {
+            sb.append(elementValues[i].stringifyValue());
+            if ((i + 1) < elementValues.length) {
                 sb.append(",");
             }
         }
@@ -86,11 +86,11 @@ public class ArrayElementValue extends ElementValue
 
     public ElementValue[] getElementValuesArray()
     {
-        return evalues;
+        return elementValues;
     }
 
     public int getElementValuesArraySize()
     {
-        return evalues.length;
+        return elementValues.length;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Attribute.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -47,7 +47,7 @@ import com.sun.org.apache.bcel.internal.Const;
  * @see Synthetic
  * @see Deprecated
  * @see Signature
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public abstract class Attribute implements Cloneable, Node {
     private static final boolean debug = false;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethod.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethod.java
@@ -33,17 +33,17 @@ import com.sun.org.apache.bcel.internal.Const;
  * method ref, the number of bootstrap arguments and an array of the
  * bootstrap arguments.
  *
- * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.23">
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.23">
  * The class File Format : The BootstrapMethods Attribute</a>
  * @since 6.0
  */
 public class BootstrapMethod implements Cloneable {
 
     /** Index of the CONSTANT_MethodHandle_info structure in the constant_pool table */
-    private int bootstrap_method_ref;
+    private int bootstrapMethodRef;
 
     /** Array of references to the constant_pool table */
-    private int[] bootstrap_arguments;
+    private int[] bootstrapArguments;
 
 
     /**
@@ -62,8 +62,8 @@ public class BootstrapMethod implements Cloneable {
     BootstrapMethod(final DataInput input) throws IOException {
         this(input.readUnsignedShort(), input.readUnsignedShort());
 
-        for (int i = 0; i < bootstrap_arguments.length; i++) {
-            bootstrap_arguments[i] = input.readUnsignedShort();
+        for (int i = 0; i < bootstrapArguments.length; i++) {
+            bootstrapArguments[i] = input.readUnsignedShort();
         }
     }
 
@@ -73,47 +73,47 @@ public class BootstrapMethod implements Cloneable {
     }
 
     /**
-     * @param bootstrap_method_ref int index into constant_pool of CONSTANT_MethodHandle
-     * @param bootstrap_arguments int[] indices into constant_pool of CONSTANT_[type]_info
+     * @param bootstrapMethodRef int index into constant_pool of CONSTANT_MethodHandle
+     * @param bootstrapArguments int[] indices into constant_pool of CONSTANT_[type]_info
      */
-    public BootstrapMethod(final int bootstrap_method_ref, final int[] bootstrap_arguments) {
-        this.bootstrap_method_ref = bootstrap_method_ref;
-        this.bootstrap_arguments = bootstrap_arguments;
+    public BootstrapMethod(final int bootstrapMethodRef, final int[] bootstrapArguments) {
+        this.bootstrapMethodRef = bootstrapMethodRef;
+        this.bootstrapArguments = bootstrapArguments;
     }
 
     /**
      * @return index into constant_pool of bootstrap_method
      */
     public int getBootstrapMethodRef() {
-        return bootstrap_method_ref;
+        return bootstrapMethodRef;
     }
 
     /**
-     * @param bootstrap_method_ref int index into constant_pool of CONSTANT_MethodHandle
+     * @param bootstrapMethodRef int index into constant_pool of CONSTANT_MethodHandle
      */
-    public void setBootstrapMethodRef(final int bootstrap_method_ref) {
-        this.bootstrap_method_ref = bootstrap_method_ref;
+    public void setBootstrapMethodRef(final int bootstrapMethodRef) {
+        this.bootstrapMethodRef = bootstrapMethodRef;
     }
 
     /**
      * @return int[] of bootstrap_method indices into constant_pool of CONSTANT_[type]_info
      */
     public int[] getBootstrapArguments() {
-        return bootstrap_arguments;
+        return bootstrapArguments;
     }
 
     /**
      * @return count of number of boostrap arguments
      */
     public int getNumBootstrapArguments() {
-        return bootstrap_arguments.length;
+        return bootstrapArguments.length;
     }
 
     /**
-     * @param bootstrap_arguments int[] indices into constant_pool of CONSTANT_[type]_info
+     * @param bootstrapArguments int[] indices into constant_pool of CONSTANT_[type]_info
      */
-    public void setBootstrapArguments(final int[] bootstrap_arguments) {
-        this.bootstrap_arguments = bootstrap_arguments;
+    public void setBootstrapArguments(final int[] bootstrapArguments) {
+        this.bootstrapArguments = bootstrapArguments;
     }
 
     /**
@@ -121,25 +121,25 @@ public class BootstrapMethod implements Cloneable {
      */
     @Override
     public final String toString() {
-        return "BootstrapMethod(" + bootstrap_method_ref + ", " + bootstrap_arguments.length + ", "
-               + Arrays.toString(bootstrap_arguments) + ")";
+        return "BootstrapMethod(" + bootstrapMethodRef + ", " + bootstrapArguments.length + ", "
+               + Arrays.toString(bootstrapArguments) + ")";
     }
 
     /**
      * @return Resolved string representation
      */
-    public final String toString( final ConstantPool constant_pool ) {
+    public final String toString( final ConstantPool constantPool ) {
         final StringBuilder buf = new StringBuilder();
         String bootstrap_method_name;
-        bootstrap_method_name = constant_pool.constantToString(bootstrap_method_ref,
+        bootstrap_method_name = constantPool.constantToString(bootstrapMethodRef,
                 Const.CONSTANT_MethodHandle);
         buf.append(Utility.compactClassName(bootstrap_method_name, false));
-        final int num_bootstrap_arguments = bootstrap_arguments.length;
+        final int num_bootstrap_arguments = bootstrapArguments.length;
         if (num_bootstrap_arguments > 0) {
             buf.append("\nMethod Arguments:");
             for (int i = 0; i < num_bootstrap_arguments; i++) {
                 buf.append("\n  ").append(i).append(": ");
-                buf.append(constant_pool.constantToString(constant_pool.getConstant(bootstrap_arguments[i])));
+                buf.append(constantPool.constantToString(constantPool.getConstant(bootstrapArguments[i])));
             }
         }
         return buf.toString();
@@ -152,9 +152,9 @@ public class BootstrapMethod implements Cloneable {
      * @throws IOException
      */
     public final void dump(final DataOutputStream file) throws IOException {
-        file.writeShort(bootstrap_method_ref);
-        file.writeShort(bootstrap_arguments.length);
-        for (final int bootstrap_argument : bootstrap_arguments) {
+        file.writeShort(bootstrapMethodRef);
+        file.writeShort(bootstrapArguments.length);
+        for (final int bootstrap_argument : bootstrapArguments) {
             file.writeShort(bootstrap_argument);
         }
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethods.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/BootstrapMethods.java
@@ -30,13 +30,13 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * This class represents a BootstrapMethods attribute.
  *
- * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.23">
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.23">
  * The class File Format : The BootstrapMethods Attribute</a>
  * @since 6.0
  */
 public class BootstrapMethods extends Attribute {
 
-    private BootstrapMethod[] bootstrap_methods;  // TODO this could be made final (setter is not used)
+    private BootstrapMethod[] bootstrapMethods;  // TODO this could be made final (setter is not used)
 
     /**
      * Initialize from another object. Note that both objects use the same
@@ -50,12 +50,12 @@ public class BootstrapMethods extends Attribute {
     /**
      * @param name_index Index in constant pool to CONSTANT_Utf8
      * @param length Content length in bytes
-     * @param bootstrap_methods array of bootstrap methods
+     * @param bootstrapMethods array of bootstrap methods
      * @param constant_pool Array of constants
      */
-    public BootstrapMethods(final int name_index, final int length, final BootstrapMethod[] bootstrap_methods, final ConstantPool constant_pool) {
+    public BootstrapMethods(final int name_index, final int length, final BootstrapMethod[] bootstrapMethods, final ConstantPool constant_pool) {
         super(Const.ATTR_BOOTSTRAP_METHODS, name_index, length, constant_pool);
-        this.bootstrap_methods = bootstrap_methods;
+        this.bootstrapMethods = bootstrapMethods;
     }
 
     /**
@@ -71,9 +71,9 @@ public class BootstrapMethods extends Attribute {
         this(name_index, length, (BootstrapMethod[]) null, constant_pool);
 
         final int num_bootstrap_methods = input.readUnsignedShort();
-        bootstrap_methods = new BootstrapMethod[num_bootstrap_methods];
+        bootstrapMethods = new BootstrapMethod[num_bootstrap_methods];
         for (int i = 0; i < num_bootstrap_methods; i++) {
-            bootstrap_methods[i] = new BootstrapMethod(input);
+            bootstrapMethods[i] = new BootstrapMethod(input);
         }
     }
 
@@ -81,14 +81,14 @@ public class BootstrapMethods extends Attribute {
      * @return array of bootstrap method "records"
      */
     public final BootstrapMethod[] getBootstrapMethods() {
-        return bootstrap_methods;
+        return bootstrapMethods;
     }
 
     /**
-     * @param bootstrap_methods the array of bootstrap methods
+     * @param bootstrapMethods the array of bootstrap methods
      */
-    public final void setBootstrapMethods(final BootstrapMethod[] bootstrap_methods) {
-        this.bootstrap_methods = bootstrap_methods;
+    public final void setBootstrapMethods(final BootstrapMethod[] bootstrapMethods) {
+        this.bootstrapMethods = bootstrapMethods;
     }
 
     /**
@@ -105,10 +105,10 @@ public class BootstrapMethods extends Attribute {
     @Override
     public BootstrapMethods copy(final ConstantPool _constant_pool) {
         final BootstrapMethods c = (BootstrapMethods) clone();
-        c.bootstrap_methods = new BootstrapMethod[bootstrap_methods.length];
+        c.bootstrapMethods = new BootstrapMethod[bootstrapMethods.length];
 
-        for (int i = 0; i < bootstrap_methods.length; i++) {
-            c.bootstrap_methods[i] = bootstrap_methods[i].copy();
+        for (int i = 0; i < bootstrapMethods.length; i++) {
+            c.bootstrapMethods[i] = bootstrapMethods[i].copy();
         }
         c.setConstantPool(_constant_pool);
         return c;
@@ -124,8 +124,8 @@ public class BootstrapMethods extends Attribute {
     public final void dump(final DataOutputStream file) throws IOException {
         super.dump(file);
 
-        file.writeShort(bootstrap_methods.length);
-        for (final BootstrapMethod bootstrap_method : bootstrap_methods) {
+        file.writeShort(bootstrapMethods.length);
+        for (final BootstrapMethod bootstrap_method : bootstrapMethods) {
             bootstrap_method.dump(file);
         }
     }
@@ -137,14 +137,14 @@ public class BootstrapMethods extends Attribute {
     public final String toString() {
         final StringBuilder buf = new StringBuilder();
         buf.append("BootstrapMethods(");
-        buf.append(bootstrap_methods.length);
+        buf.append(bootstrapMethods.length);
         buf.append("):");
-        for (int i = 0; i < bootstrap_methods.length; i++) {
+        for (int i = 0; i < bootstrapMethods.length; i++) {
             buf.append("\n");
             final int start = buf.length();
             buf.append("  ").append(i).append(": ");
             final int indent_count = buf.length() - start;
-            final String[] lines = (bootstrap_methods[i].toString(super.getConstantPool())).split("\\r?\\n");
+            final String[] lines = (bootstrapMethods[i].toString(super.getConstantPool())).split("\\r?\\n");
             buf.append(lines[0]);
             for (int j = 1; j < lines.length; j++) {
                 buf.append("\n").append("          ".substring(0,indent_count)).append(lines[j]);

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ClassParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ClassParser.java
@@ -48,19 +48,19 @@ public final class ClassParser {
 
     private DataInputStream dataInputStream;
     private final boolean fileOwned;
-    private final String file_name;
-    private String zip_file;
-    private int class_name_index;
-    private int superclass_name_index;
+    private final String fileName;
+    private String zipFile;
+    private int classNameIndex;
+    private int superclassNameIndex;
     private int major; // Compiler version
     private int minor; // Compiler version
-    private int access_flags; // Access rights of parsed class
+    private int accessFlags; // Access rights of parsed class
     private int[] interfaces; // Names of implemented interfaces
-    private ConstantPool constant_pool; // collection of constants
+    private ConstantPool constantPool; // collection of constants
     private Field[] fields; // class fields, i.e., its variables
     private Method[] methods; // methods defined in the class
     private Attribute[] attributes; // attributes defined in the class
-    private final boolean is_zip; // Loaded from zip file
+    private final boolean isZip; // Loaded from zip file
     private static final int BUFSIZE = 8192;
 
 
@@ -68,13 +68,13 @@ public final class ClassParser {
      * Parses class from the given stream.
      *
      * @param inputStream Input stream
-     * @param file_name File name
+     * @param fileName File name
      */
-    public ClassParser(final InputStream inputStream, final String file_name) {
-        this.file_name = file_name;
+    public ClassParser(final InputStream inputStream, final String fileName) {
+        this.fileName = fileName;
         fileOwned = false;
         final String clazz = inputStream.getClass().getName(); // Not a very clean solution ...
-        is_zip = clazz.startsWith("java.util.zip.") || clazz.startsWith("java.util.jar.");
+        isZip = clazz.startsWith("java.util.zip.") || clazz.startsWith("java.util.jar.");
         if (inputStream instanceof DataInputStream) {
             this.dataInputStream = (DataInputStream) inputStream;
         } else {
@@ -85,25 +85,25 @@ public final class ClassParser {
 
     /** Parses class from given .class file.
      *
-     * @param file_name file name
+     * @param fileName file name
      */
-    public ClassParser(final String file_name) {
-        is_zip = false;
-        this.file_name = file_name;
+    public ClassParser(final String fileName) {
+        isZip = false;
+        this.fileName = fileName;
         fileOwned = true;
     }
 
 
     /** Parses class from given .class file in a ZIP-archive
      *
-     * @param zip_file zip file name
-     * @param file_name file name
+     * @param zipFile zip file name
+     * @param fileName file name
      */
-    public ClassParser(final String zip_file, final String file_name) {
-        is_zip = true;
+    public ClassParser(final String zipFile, final String fileName) {
+        isZip = true;
         fileOwned = true;
-        this.zip_file = zip_file;
-        this.file_name = file_name;
+        this.zipFile = zipFile;
+        this.fileName = fileName;
     }
 
 
@@ -122,19 +122,19 @@ public final class ClassParser {
         ZipFile zip = null;
         try {
             if (fileOwned) {
-                if (is_zip) {
-                    zip = new ZipFile(zip_file);
-                    final ZipEntry entry = zip.getEntry(file_name);
+                if (isZip) {
+                    zip = new ZipFile(zipFile);
+                    final ZipEntry entry = zip.getEntry(fileName);
 
                     if (entry == null) {
-                        throw new IOException("File " + file_name + " not found");
+                        throw new IOException("File " + fileName + " not found");
                     }
 
                     dataInputStream = new DataInputStream(new BufferedInputStream(zip.getInputStream(entry),
                             BUFSIZE));
                 } else {
                     dataInputStream = new DataInputStream(new BufferedInputStream(new FileInputStream(
-                            file_name), BUFSIZE));
+                            fileName), BUFSIZE));
                 }
             }
             /****************** Read headers ********************************/
@@ -165,8 +165,8 @@ public final class ClassParser {
             //        int bytes = file.available();
             //        byte[] buf = new byte[bytes];
             //        file.read(buf);
-            //        if(!(is_zip && (buf.length == 1))) {
-            //      System.err.println("WARNING: Trailing garbage at end of " + file_name);
+            //        if(!(isZip && (buf.length == 1))) {
+            //      System.err.println("WARNING: Trailing garbage at end of " + fileName);
             //      System.err.println(bytes + " extra bytes: " + Utility.toHexString(buf));
             //        }
             //      }
@@ -190,8 +190,8 @@ public final class ClassParser {
             }
         }
         // Return the information we have gathered in a new object
-        return new JavaClass(class_name_index, superclass_name_index, file_name, major, minor,
-                access_flags, constant_pool, interfaces, fields, methods, attributes, is_zip
+        return new JavaClass(classNameIndex, superclassNameIndex, fileName, major, minor,
+                accessFlags, constantPool, interfaces, fields, methods, attributes, isZip
                         ? JavaClass.ZIP
                         : JavaClass.FILE);
     }
@@ -206,7 +206,7 @@ public final class ClassParser {
         final int attributes_count = dataInputStream.readUnsignedShort();
         attributes = new Attribute[attributes_count];
         for (int i = 0; i < attributes_count; i++) {
-            attributes[i] = Attribute.readAttribute(dataInputStream, constant_pool);
+            attributes[i] = Attribute.readAttribute(dataInputStream, constantPool);
         }
     }
 
@@ -217,19 +217,19 @@ public final class ClassParser {
      * @throws  ClassFormatException
      */
     private void readClassInfo() throws IOException, ClassFormatException {
-        access_flags = dataInputStream.readUnsignedShort();
+        accessFlags = dataInputStream.readUnsignedShort();
         /* Interfaces are implicitely abstract, the flag should be set
          * according to the JVM specification.
          */
-        if ((access_flags & Const.ACC_INTERFACE) != 0) {
-            access_flags |= Const.ACC_ABSTRACT;
+        if ((accessFlags & Const.ACC_INTERFACE) != 0) {
+            accessFlags |= Const.ACC_ABSTRACT;
         }
-        if (((access_flags & Const.ACC_ABSTRACT) != 0)
-                && ((access_flags & Const.ACC_FINAL) != 0)) {
-            throw new ClassFormatException("Class " + file_name + " can't be both final and abstract");
+        if (((accessFlags & Const.ACC_ABSTRACT) != 0)
+                && ((accessFlags & Const.ACC_FINAL) != 0)) {
+            throw new ClassFormatException("Class " + fileName + " can't be both final and abstract");
         }
-        class_name_index = dataInputStream.readUnsignedShort();
-        superclass_name_index = dataInputStream.readUnsignedShort();
+        classNameIndex = dataInputStream.readUnsignedShort();
+        superclassNameIndex = dataInputStream.readUnsignedShort();
     }
 
 
@@ -239,7 +239,7 @@ public final class ClassParser {
      * @throws  ClassFormatException
      */
     private void readConstantPool() throws IOException, ClassFormatException {
-        constant_pool = new ConstantPool(dataInputStream);
+        constantPool = new ConstantPool(dataInputStream);
     }
 
 
@@ -252,7 +252,7 @@ public final class ClassParser {
         final int fields_count = dataInputStream.readUnsignedShort();
         fields = new Field[fields_count];
         for (int i = 0; i < fields_count; i++) {
-            fields[i] = new Field(dataInputStream, constant_pool);
+            fields[i] = new Field(dataInputStream, constantPool);
         }
     }
 
@@ -266,7 +266,7 @@ public final class ClassParser {
      */
     private void readID() throws IOException, ClassFormatException {
         if (dataInputStream.readInt() != Const.JVM_CLASSFILE_MAGIC) {
-            throw new ClassFormatException(file_name + " is not a Java .class file");
+            throw new ClassFormatException(fileName + " is not a Java .class file");
         }
     }
 
@@ -294,7 +294,7 @@ public final class ClassParser {
         final int methods_count = dataInputStream.readUnsignedShort();
         methods = new Method[methods_count];
         for (int i = 0; i < methods_count; i++) {
-            methods[i] = new Method(dataInputStream, constant_pool);
+            methods[i] = new Method(dataInputStream, constantPool);
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Code.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Code.java
@@ -46,10 +46,10 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class Code extends Attribute {
 
-    private int max_stack; // Maximum size of stack used by this method  // TODO this could be made final (setter is not used)
-    private int max_locals; // Number of local variables  // TODO this could be made final (setter is not used)
+    private int maxStack; // Maximum size of stack used by this method  // TODO this could be made final (setter is not used)
+    private int maxLocals; // Number of local variables  // TODO this could be made final (setter is not used)
     private byte[] code; // Actual byte code
-    private CodeException[] exception_table; // Table of handled exceptions
+    private CodeException[] exceptionTable; // Table of handled exceptions
     private Attribute[] attributes; // or LocalVariable
 
 
@@ -81,9 +81,9 @@ public final class Code extends Attribute {
          * handler is active, i.e., a try { ... } catch() block.
          */
         final int exception_table_length = file.readUnsignedShort();
-        exception_table = new CodeException[exception_table_length];
+        exceptionTable = new CodeException[exception_table_length];
         for (int i = 0; i < exception_table_length; i++) {
-            exception_table[i] = new CodeException(file);
+            exceptionTable[i] = new CodeException(file);
         }
         /* Read all attributes, currently `LineNumberTable' and
          * `LocalVariableTable'
@@ -104,20 +104,20 @@ public final class Code extends Attribute {
     /**
      * @param name_index Index pointing to the name <em>Code</em>
      * @param length Content length in bytes
-     * @param max_stack Maximum size of stack
-     * @param max_locals Number of local variables
+     * @param maxStack Maximum size of stack
+     * @param maxLocals Number of local variables
      * @param code Actual byte code
-     * @param exception_table Table of handled exceptions
+     * @param exceptionTable of handled exceptions
      * @param attributes Attributes of code: LineNumber or LocalVariable
      * @param constant_pool Array of constants
      */
-    public Code(final int name_index, final int length, final int max_stack, final int max_locals, final byte[] code,
-            final CodeException[] exception_table, final Attribute[] attributes, final ConstantPool constant_pool) {
+    public Code(final int name_index, final int length, final int maxStack, final int maxLocals, final byte[] code,
+            final CodeException[] exceptionTable, final Attribute[] attributes, final ConstantPool constant_pool) {
         super(Const.ATTR_CODE, name_index, length, constant_pool);
-        this.max_stack = max_stack;
-        this.max_locals = max_locals;
+        this.maxStack = maxStack;
+        this.maxLocals = maxLocals;
         this.code = code != null ? code : new byte[0];
-        this.exception_table = exception_table != null ? exception_table : new CodeException[0];
+        this.exceptionTable = exceptionTable != null ? exceptionTable : new CodeException[0];
         this.attributes = attributes != null ? attributes : new Attribute[0];
         super.setLength(calculateLength()); // Adjust length
     }
@@ -145,12 +145,12 @@ public final class Code extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(max_stack);
-        file.writeShort(max_locals);
+        file.writeShort(maxStack);
+        file.writeShort(maxLocals);
         file.writeInt(code.length);
         file.write(code, 0, code.length);
-        file.writeShort(exception_table.length);
-        for (final CodeException exception : exception_table) {
+        file.writeShort(exceptionTable.length);
+        for (final CodeException exception : exceptionTable) {
             exception.dump(file);
         }
         file.writeShort(attributes.length);
@@ -208,7 +208,7 @@ public final class Code extends Attribute {
      * @see CodeException
      */
     public CodeException[] getExceptionTable() {
-        return exception_table;
+        return exceptionTable;
     }
 
 
@@ -216,7 +216,7 @@ public final class Code extends Attribute {
      * @return Number of local variables.
      */
     public int getMaxLocals() {
-        return max_locals;
+        return maxLocals;
     }
 
 
@@ -224,7 +224,7 @@ public final class Code extends Attribute {
      * @return Maximum size of stack used by this method.
      */
     public int getMaxStack() {
-        return max_stack;
+        return maxStack;
     }
 
 
@@ -233,10 +233,10 @@ public final class Code extends Attribute {
      * and excluding all its attributes
      */
     private int getInternalLength() {
-        return 2 /*max_stack*/+ 2 /*max_locals*/+ 4 /*code length*/
+        return 2 /*maxStack*/+ 2 /*maxLocals*/+ 4 /*code length*/
                 + code.length /*byte-code*/
                 + 2 /*exception-table length*/
-                + 8 * (exception_table == null ? 0 : exception_table.length) /* exception table */
+                + 8 * (exceptionTable == null ? 0 : exceptionTable.length) /* exception table */
                 + 2 /* attributes count */;
     }
 
@@ -275,27 +275,27 @@ public final class Code extends Attribute {
 
 
     /**
-     * @param exception_table exception table
+     * @param exceptionTable exception table
      */
-    public void setExceptionTable( final CodeException[] exception_table ) {
-        this.exception_table = exception_table != null ? exception_table : new CodeException[0];
+    public void setExceptionTable( final CodeException[] exceptionTable ) {
+        this.exceptionTable = exceptionTable != null ? exceptionTable : new CodeException[0];
         super.setLength(calculateLength()); // Adjust length
     }
 
 
     /**
-     * @param max_locals maximum number of local variables
+     * @param maxLocals maximum number of local variables
      */
-    public void setMaxLocals( final int max_locals ) {
-        this.max_locals = max_locals;
+    public void setMaxLocals( final int maxLocals ) {
+        this.maxLocals = maxLocals;
     }
 
 
     /**
-     * @param max_stack maximum stack size
+     * @param maxStack maximum stack size
      */
-    public void setMaxStack( final int max_stack ) {
-        this.max_stack = max_stack;
+    public void setMaxStack( final int maxStack ) {
+        this.maxStack = maxStack;
     }
 
 
@@ -304,18 +304,19 @@ public final class Code extends Attribute {
      */
     public String toString( final boolean verbose ) {
         final StringBuilder buf = new StringBuilder(100); // CHECKSTYLE IGNORE MagicNumber
-        buf.append("Code(max_stack = ").append(max_stack).append(", max_locals = ").append(
-                max_locals).append(", code_length = ").append(code.length).append(")\n").append(
+        buf.append("Code(maxStack = ").append(maxStack).append(", maxLocals = ").append(
+                maxLocals).append(", code_length = ").append(code.length).append(")\n").append(
                 Utility.codeToString(code, super.getConstantPool(), 0, -1, verbose));
-        if (exception_table.length > 0) {
+        if (exceptionTable.length > 0) {
             buf.append("\nException handler(s) = \n").append("From\tTo\tHandler\tType\n");
-            for (final CodeException exception : exception_table) {
+            for (final CodeException exception : exceptionTable) {
                 buf.append(exception.toString(super.getConstantPool(), verbose)).append("\n");
             }
         }
         if (attributes.length > 0) {
             buf.append("\nAttribute(s) = ");
             for (final Attribute attribute : attributes) {
+                buf.append("\n").append(attribute.getName()).append(":");
                 buf.append("\n").append(attribute);
             }
         }
@@ -345,9 +346,9 @@ public final class Code extends Attribute {
             System.arraycopy(code, 0, c.code, 0, code.length);
         }
         c.setConstantPool(_constant_pool);
-        c.exception_table = new CodeException[exception_table.length];
-        for (int i = 0; i < exception_table.length; i++) {
-            c.exception_table[i] = exception_table[i].copy();
+        c.exceptionTable = new CodeException[exceptionTable.length];
+        for (int i = 0; i < exceptionTable.length; i++) {
+            c.exceptionTable[i] = exceptionTable[i].copy();
         }
         c.attributes = new Attribute[attributes.length];
         for (int i = 0; i < attributes.length; i++) {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/CodeException.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/CodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,16 +32,16 @@ import com.sun.org.apache.bcel.internal.Const;
  * particular exception handler is active.
  *
  * @see     Code
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public final class CodeException implements Cloneable, Node {
 
-    private int start_pc; // Range in the code the exception handler is
-    private int end_pc; // active. start_pc is inclusive, end_pc exclusive
-    private int handler_pc; /* Starting address of exception handler, i.e.,
+    private int startPc; // Range in the code the exception handler is
+    private int endPc; // active. startPc is inclusive, endPc exclusive
+    private int handlerPc; /* Starting address of exception handler, i.e.,
      * an offset from start of code.
      */
-    private int catch_type; /* If this is zero the handler catches any
+    private int catchType; /* If this is zero the handler catches any
      * exception, otherwise it points to the
      * exception class which is to be caught.
      */
@@ -67,20 +67,20 @@ public final class CodeException implements Cloneable, Node {
 
 
     /**
-     * @param start_pc Range in the code the exception handler is active,
-     * start_pc is inclusive while
-     * @param end_pc is exclusive
-     * @param handler_pc Starting address of exception handler, i.e.,
+     * @param startPc Range in the code the exception handler is active,
+     * startPc is inclusive while
+     * @param endPc is exclusive
+     * @param handlerPc Starting address of exception handler, i.e.,
      * an offset from start of code.
-     * @param catch_type If zero the handler catches any
+     * @param catchType If zero the handler catches any
      * exception, otherwise it points to the exception class which is
      * to be caught.
      */
-    public CodeException(final int start_pc, final int end_pc, final int handler_pc, final int catch_type) {
-        this.start_pc = start_pc;
-        this.end_pc = end_pc;
-        this.handler_pc = handler_pc;
-        this.catch_type = catch_type;
+    public CodeException(final int startPc, final int endPc, final int handlerPc, final int catchType) {
+        this.startPc = startPc;
+        this.endPc = endPc;
+        this.handlerPc = handlerPc;
+        this.catchType = catchType;
     }
 
 
@@ -104,10 +104,10 @@ public final class CodeException implements Cloneable, Node {
      * @throws IOException
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(start_pc);
-        file.writeShort(end_pc);
-        file.writeShort(handler_pc);
-        file.writeShort(catch_type);
+        file.writeShort(startPc);
+        file.writeShort(endPc);
+        file.writeShort(handlerPc);
+        file.writeShort(catchType);
     }
 
 
@@ -116,7 +116,7 @@ public final class CodeException implements Cloneable, Node {
      * the exception class which is to be caught.
      */
     public int getCatchType() {
-        return catch_type;
+        return catchType;
     }
 
 
@@ -124,7 +124,7 @@ public final class CodeException implements Cloneable, Node {
      * @return Exclusive end index of the region where the handler is active.
      */
     public int getEndPC() {
-        return end_pc;
+        return endPc;
     }
 
 
@@ -132,7 +132,7 @@ public final class CodeException implements Cloneable, Node {
      * @return Starting address of exception handler, relative to the code.
      */
     public int getHandlerPC() {
-        return handler_pc;
+        return handlerPc;
     }
 
 
@@ -140,39 +140,39 @@ public final class CodeException implements Cloneable, Node {
      * @return Inclusive start index of the region where the handler is active.
      */
     public int getStartPC() {
-        return start_pc;
+        return startPc;
     }
 
 
     /**
-     * @param catch_type the type of exception that is caught
+     * @param catchType the type of exception that is caught
      */
-    public void setCatchType( final int catch_type ) {
-        this.catch_type = catch_type;
+    public void setCatchType( final int catchType ) {
+        this.catchType = catchType;
     }
 
 
     /**
-     * @param end_pc end of handled block
+     * @param endPc end of handled block
      */
-    public void setEndPC( final int end_pc ) {
-        this.end_pc = end_pc;
+    public void setEndPC( final int endPc ) {
+        this.endPc = endPc;
     }
 
 
     /**
-     * @param handler_pc where the actual code is
+     * @param handlerPc where the actual code is
      */
-    public void setHandlerPC( final int handler_pc ) { // TODO unused
-        this.handler_pc = handler_pc;
+    public void setHandlerPC( final int handlerPc ) { // TODO unused
+        this.handlerPc = handlerPc;
     }
 
 
     /**
-     * @param start_pc start of handled block
+     * @param startPc start of handled block
      */
-    public void setStartPC( final int start_pc ) { // TODO unused
-        this.start_pc = start_pc;
+    public void setStartPC( final int startPc ) { // TODO unused
+        this.startPc = startPc;
     }
 
 
@@ -181,8 +181,8 @@ public final class CodeException implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "CodeException(start_pc = " + start_pc + ", end_pc = " + end_pc + ", handler_pc = "
-                + handler_pc + ", catch_type = " + catch_type + ")";
+        return "CodeException(startPc = " + startPc + ", endPc = " + endPc + ", handlerPc = "
+                + handlerPc + ", catchType = " + catchType + ")";
     }
 
 
@@ -191,13 +191,13 @@ public final class CodeException implements Cloneable, Node {
      */
     public String toString( final ConstantPool cp, final boolean verbose ) {
         String str;
-        if (catch_type == 0) {
+        if (catchType == 0) {
             str = "<Any exception>(0)";
         } else {
-            str = Utility.compactClassName(cp.getConstantString(catch_type, Const.CONSTANT_Class), false)
-                    + (verbose ? "(" + catch_type + ")" : "");
+            str = Utility.compactClassName(cp.getConstantString(catchType, Const.CONSTANT_Class), false)
+                    + (verbose ? "(" + catchType + ")" : "");
         }
-        return start_pc + "\t" + end_pc + "\t" + handler_pc + "\t" + str;
+        return startPc + "\t" + endPc + "\t" + handlerPc + "\t" + str;
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Constant.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,7 +32,7 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * in the constant pool of a class file. The classes keep closely to
  * the JVM specification.
  *
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public abstract class Constant implements Cloneable, Node {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantClass.java
@@ -35,7 +35,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantClass extends Constant implements ConstantObject {
 
-    private int name_index; // Identical to ConstantString except for the name
+    private int nameIndex; // Identical to ConstantString except for the name
 
 
     /**
@@ -58,12 +58,12 @@ public final class ConstantClass extends Constant implements ConstantObject {
 
 
     /**
-     * @param name_index Name index in constant pool.  Should refer to a
+     * @param nameIndex Name index in constant pool.  Should refer to a
      * ConstantUtf8.
      */
-    public ConstantClass(final int name_index) {
+    public ConstantClass(final int nameIndex) {
         super(Const.CONSTANT_Class);
-        this.name_index = name_index;
+        this.nameIndex = nameIndex;
     }
 
 
@@ -89,7 +89,7 @@ public final class ConstantClass extends Constant implements ConstantObject {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
-        file.writeShort(name_index);
+        file.writeShort(nameIndex);
     }
 
 
@@ -97,15 +97,15 @@ public final class ConstantClass extends Constant implements ConstantObject {
      * @return Name index in constant pool of class name.
      */
     public int getNameIndex() {
-        return name_index;
+        return nameIndex;
     }
 
 
     /**
-     * @param name_index the name index in the constant pool of this Constant Class
+     * @param nameIndex the name index in the constant pool of this Constant Class
      */
-    public void setNameIndex( final int name_index ) {
-        this.name_index = name_index;
+    public void setNameIndex( final int nameIndex ) {
+        this.nameIndex = nameIndex;
     }
 
 
@@ -113,7 +113,7 @@ public final class ConstantClass extends Constant implements ConstantObject {
      */
     @Override
     public Object getConstantValue( final ConstantPool cp ) {
-        final Constant c = cp.getConstant(name_index, Const.CONSTANT_Utf8);
+        final Constant c = cp.getConstant(nameIndex, Const.CONSTANT_Utf8);
         return ((ConstantUtf8) c).getBytes();
     }
 
@@ -130,6 +130,6 @@ public final class ConstantClass extends Constant implements ConstantObject {
      */
     @Override
     public String toString() {
-        return super.toString() + "(name_index = " + name_index + ")";
+        return super.toString() + "(nameIndex = " + nameIndex + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInvokeDynamic.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantInvokeDynamic.java
@@ -31,7 +31,7 @@ import com.sun.org.apache.bcel.internal.Const;
  * and represents a reference to a invoke dynamic.
  *
  * @see     Constant
- * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10">
+ * @see  <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10">
  * The CONSTANT_InvokeDynamic_info Structure in The Java Virtual Machine Specification</a>
  * @since 6.0
  */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodHandle.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodHandle.java
@@ -36,8 +36,8 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantMethodHandle extends Constant {
 
-    private int reference_kind;
-    private int reference_index;
+    private int referenceKind;
+    private int referenceIndex;
 
 
     /**
@@ -61,8 +61,8 @@ public final class ConstantMethodHandle extends Constant {
 
     public ConstantMethodHandle(final int reference_kind, final int reference_index) {
         super(Const.CONSTANT_MethodHandle);
-        this.reference_kind = reference_kind;
-        this.reference_index = reference_index;
+        this.referenceKind = reference_kind;
+        this.referenceIndex = reference_index;
     }
 
 
@@ -88,28 +88,28 @@ public final class ConstantMethodHandle extends Constant {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
-        file.writeByte(reference_kind);
-        file.writeShort(reference_index);
+        file.writeByte(referenceKind);
+        file.writeShort(referenceIndex);
     }
 
 
     public int getReferenceKind() {
-        return reference_kind;
+        return referenceKind;
     }
 
 
     public void setReferenceKind(final int reference_kind) {
-        this.reference_kind = reference_kind;
+        this.referenceKind = reference_kind;
     }
 
 
     public int getReferenceIndex() {
-        return reference_index;
+        return referenceIndex;
     }
 
 
     public void setReferenceIndex(final int reference_index) {
-        this.reference_index = reference_index;
+        this.referenceIndex = reference_index;
     }
 
 
@@ -118,7 +118,7 @@ public final class ConstantMethodHandle extends Constant {
      */
     @Override
     public String toString() {
-        return super.toString() + "(reference_kind = " + reference_kind +
-                ", reference_index = " + reference_index + ")";
+        return super.toString() + "(referenceKind = " + referenceKind +
+                ", referenceIndex = " + referenceIndex + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantMethodType.java
@@ -36,7 +36,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantMethodType extends Constant {
 
-    private int descriptor_index;
+    private int descriptorIndex;
 
 
     /**
@@ -60,7 +60,7 @@ public final class ConstantMethodType extends Constant {
 
     public ConstantMethodType(final int descriptor_index) {
         super(Const.CONSTANT_MethodType);
-        this.descriptor_index = descriptor_index;
+        this.descriptorIndex = descriptor_index;
     }
 
 
@@ -86,17 +86,17 @@ public final class ConstantMethodType extends Constant {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
-        file.writeShort(descriptor_index);
+        file.writeShort(descriptorIndex);
     }
 
 
     public int getDescriptorIndex() {
-        return descriptor_index;
+        return descriptorIndex;
     }
 
 
     public void setDescriptorIndex(final int descriptor_index) {
-        this.descriptor_index = descriptor_index;
+        this.descriptorIndex = descriptor_index;
     }
 
 
@@ -105,6 +105,6 @@ public final class ConstantMethodType extends Constant {
      */
     @Override
     public String toString() {
-        return super.toString() + "(descriptor_index = " + descriptor_index + ")";
+        return super.toString() + "(descriptorIndex = " + descriptorIndex + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantModule.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantModule.java
@@ -38,7 +38,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantModule extends Constant implements ConstantObject {
 
-    private int name_index;
+    private int nameIndex;
 
 
     /**
@@ -61,12 +61,12 @@ public final class ConstantModule extends Constant implements ConstantObject {
 
 
     /**
-     * @param name_index Name index in constant pool.  Should refer to a
+     * @param nameIndex Name index in constant pool.  Should refer to a
      * ConstantUtf8.
      */
-    public ConstantModule(final int name_index) {
+    public ConstantModule(final int nameIndex) {
         super(Const.CONSTANT_Module);
-        this.name_index = name_index;
+        this.nameIndex = nameIndex;
     }
 
 
@@ -92,7 +92,7 @@ public final class ConstantModule extends Constant implements ConstantObject {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
-        file.writeShort(name_index);
+        file.writeShort(nameIndex);
     }
 
 
@@ -100,15 +100,15 @@ public final class ConstantModule extends Constant implements ConstantObject {
      * @return Name index in constant pool of module name.
      */
     public int getNameIndex() {
-        return name_index;
+        return nameIndex;
     }
 
 
     /**
-     * @param name_index the name index in the constant pool of this Constant Module
+     * @param nameIndex the name index in the constant pool of this Constant Module
      */
-    public void setNameIndex( final int name_index ) {
-        this.name_index = name_index;
+    public void setNameIndex( final int nameIndex ) {
+        this.nameIndex = nameIndex;
     }
 
 
@@ -116,7 +116,7 @@ public final class ConstantModule extends Constant implements ConstantObject {
      */
     @Override
     public Object getConstantValue( final ConstantPool cp ) {
-        final Constant c = cp.getConstant(name_index, Const.CONSTANT_Utf8);
+        final Constant c = cp.getConstant(nameIndex, Const.CONSTANT_Utf8);
         return ((ConstantUtf8) c).getBytes();
     }
 
@@ -133,6 +133,6 @@ public final class ConstantModule extends Constant implements ConstantObject {
      */
     @Override
     public String toString() {
-        return super.toString() + "(name_index = " + name_index + ")";
+        return super.toString() + "(nameIndex = " + nameIndex + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantNameAndType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantNameAndType.java
@@ -36,8 +36,8 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantNameAndType extends Constant {
 
-    private int name_index; // Name of field/method
-    private int signature_index; // and its signature.
+    private int nameIndex; // Name of field/method
+    private int signatureIndex; // and its signature.
 
 
     /**
@@ -60,13 +60,13 @@ public final class ConstantNameAndType extends Constant {
 
 
     /**
-     * @param name_index Name of field/method
-     * @param signature_index and its signature
+     * @param nameIndex Name of field/method
+     * @param signatureIndex and its signature
      */
-    public ConstantNameAndType(final int name_index, final int signature_index) {
+    public ConstantNameAndType(final int nameIndex, final int signatureIndex) {
         super(Const.CONSTANT_NameAndType);
-        this.name_index = name_index;
-        this.signature_index = signature_index;
+        this.nameIndex = nameIndex;
+        this.signatureIndex = signatureIndex;
     }
 
 
@@ -92,8 +92,8 @@ public final class ConstantNameAndType extends Constant {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
-        file.writeShort(name_index);
-        file.writeShort(signature_index);
+        file.writeShort(nameIndex);
+        file.writeShort(signatureIndex);
     }
 
 
@@ -101,7 +101,7 @@ public final class ConstantNameAndType extends Constant {
      * @return Name index in constant pool of field/method name.
      */
     public int getNameIndex() {
-        return name_index;
+        return nameIndex;
     }
 
 
@@ -116,7 +116,7 @@ public final class ConstantNameAndType extends Constant {
      * @return Index in constant pool of field/method signature.
      */
     public int getSignatureIndex() {
-        return signature_index;
+        return signatureIndex;
     }
 
 
@@ -128,18 +128,18 @@ public final class ConstantNameAndType extends Constant {
 
 
     /**
-     * @param name_index the name index of this constant
+     * @param nameIndex the name index of this constant
      */
-    public void setNameIndex( final int name_index ) {
-        this.name_index = name_index;
+    public void setNameIndex( final int nameIndex ) {
+        this.nameIndex = nameIndex;
     }
 
 
     /**
-     * @param signature_index the signature index in the constant pool of this type
+     * @param signatureIndex the signature index in the constant pool of this type
      */
-    public void setSignatureIndex( final int signature_index ) {
-        this.signature_index = signature_index;
+    public void setSignatureIndex( final int signatureIndex ) {
+        this.signatureIndex = signatureIndex;
     }
 
 
@@ -148,7 +148,7 @@ public final class ConstantNameAndType extends Constant {
      */
     @Override
     public String toString() {
-        return super.toString() + "(name_index = " + name_index + ", signature_index = "
-                + signature_index + ")";
+        return super.toString() + "(nameIndex = " + nameIndex + ", signatureIndex = "
+                + signatureIndex + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPackage.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPackage.java
@@ -38,7 +38,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantPackage extends Constant implements ConstantObject {
 
-    private int name_index;
+    private int nameIndex;
 
 
     /**
@@ -61,12 +61,12 @@ public final class ConstantPackage extends Constant implements ConstantObject {
 
 
     /**
-     * @param name_index Name index in constant pool.  Should refer to a
+     * @param nameIndex Name index in constant pool.  Should refer to a
      * ConstantUtf8.
      */
-    public ConstantPackage(final int name_index) {
+    public ConstantPackage(final int nameIndex) {
         super(Const.CONSTANT_Package);
-        this.name_index = name_index;
+        this.nameIndex = nameIndex;
     }
 
 
@@ -92,7 +92,7 @@ public final class ConstantPackage extends Constant implements ConstantObject {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
-        file.writeShort(name_index);
+        file.writeShort(nameIndex);
     }
 
 
@@ -100,15 +100,15 @@ public final class ConstantPackage extends Constant implements ConstantObject {
      * @return Name index in constant pool of package name.
      */
     public int getNameIndex() {
-        return name_index;
+        return nameIndex;
     }
 
 
     /**
-     * @param name_index the name index in the constant pool of this Constant Package
+     * @param nameIndex the name index in the constant pool of this Constant Package
      */
-    public void setNameIndex( final int name_index ) {
-        this.name_index = name_index;
+    public void setNameIndex( final int nameIndex ) {
+        this.nameIndex = nameIndex;
     }
 
 
@@ -116,7 +116,7 @@ public final class ConstantPackage extends Constant implements ConstantObject {
      */
     @Override
     public Object getConstantValue( final ConstantPool cp ) {
-        final Constant c = cp.getConstant(name_index, Const.CONSTANT_Utf8);
+        final Constant c = cp.getConstant(nameIndex, Const.CONSTANT_Utf8);
         return ((ConstantUtf8) c).getBytes();
     }
 
@@ -133,6 +133,6 @@ public final class ConstantPackage extends Constant implements ConstantObject {
      */
     @Override
     public String toString() {
-        return super.toString() + "(name_index = " + name_index + ")";
+        return super.toString() + "(nameIndex = " + nameIndex + ")";
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPool.java
@@ -40,13 +40,13 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public class ConstantPool implements Cloneable, Node {
 
-    private Constant[] constant_pool;
+    private Constant[] constantPool;
 
     /**
-     * @param constant_pool Array of constants
+     * @param constantPool Array of constants
      */
-    public ConstantPool(final Constant[] constant_pool) {
-        this.constant_pool = constant_pool;
+    public ConstantPool(final Constant[] constantPool) {
+        this.constantPool = constantPool;
     }
 
     /**
@@ -59,12 +59,12 @@ public class ConstantPool implements Cloneable, Node {
     public ConstantPool(final DataInput input) throws IOException, ClassFormatException {
         byte tag;
         final int constant_pool_count = input.readUnsignedShort();
-        constant_pool = new Constant[constant_pool_count];
-        /* constant_pool[0] is unused by the compiler and may be used freely
+        constantPool = new Constant[constant_pool_count];
+        /* constantPool[0] is unused by the compiler and may be used freely
          * by the implementation.
          */
         for (int i = 1; i < constant_pool_count; i++) {
-            constant_pool[i] = Constant.readConstant(input);
+            constantPool[i] = Constant.readConstant(input);
             /* Quote from the JVM specification:
              * "All eight byte constants take up two spots in the constant pool.
              * If this is the n'th byte in the constant pool, then the next item
@@ -72,7 +72,7 @@ public class ConstantPool implements Cloneable, Node {
              *
              * Thus we have to increment the index counter.
              */
-            tag = constant_pool[i].getTag();
+            tag = constantPool[i].getTag();
             if ((tag == Const.CONSTANT_Double) || (tag == Const.CONSTANT_Long)) {
                 i++;
             }
@@ -169,7 +169,7 @@ public class ConstantPool implements Cloneable, Node {
                 str = Utility.compactClassName(((ConstantUtf8) c).getBytes(), false);
                 break;
             default: // Never reached
-                throw new RuntimeException("Unknown constant type " + tag);
+                throw new IllegalArgumentException("Unknown constant type " + tag);
         }
         return str;
     }
@@ -222,10 +222,10 @@ public class ConstantPool implements Cloneable, Node {
      * @throws IOException
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(constant_pool.length);
-        for (int i = 1; i < constant_pool.length; i++) {
-            if (constant_pool[i] != null) {
-                constant_pool[i].dump(file);
+        file.writeShort(constantPool.length);
+        for (int i = 1; i < constantPool.length; i++) {
+            if (constantPool[i] != null) {
+                constantPool[i].dump(file);
             }
         }
     }
@@ -238,11 +238,11 @@ public class ConstantPool implements Cloneable, Node {
      * @see    Constant
      */
     public Constant getConstant( final int index ) {
-        if (index >= constant_pool.length || index < 0) {
+        if (index >= constantPool.length || index < 0) {
             throw new ClassFormatException("Invalid constant pool reference: " + index
-                    + ". Constant pool size is: " + constant_pool.length);
+                    + ". Constant pool size is: " + constantPool.length);
         }
-        return constant_pool[index];
+        return constantPool[index];
     }
 
     /**
@@ -273,7 +273,7 @@ public class ConstantPool implements Cloneable, Node {
      * @see    Constant
      */
     public Constant[] getConstantPool() {
-        return constant_pool;
+        return constantPool;
     }
 
     /**
@@ -314,7 +314,7 @@ public class ConstantPool implements Cloneable, Node {
                 i = ((ConstantPackage) c).getNameIndex();
                 break;
             default:
-                throw new RuntimeException("getConstantString called with illegal tag " + tag);
+                throw new IllegalArgumentException("getConstantString called with illegal tag " + tag);
         }
         // Finally get the string from the constant pool
         c = getConstant(i, Const.CONSTANT_Utf8);
@@ -326,7 +326,7 @@ public class ConstantPool implements Cloneable, Node {
      * @return Length of constant pool.
      */
     public int getLength() {
-        return constant_pool == null ? 0 : constant_pool.length;
+        return constantPool == null ? 0 : constantPool.length;
     }
 
 
@@ -334,15 +334,15 @@ public class ConstantPool implements Cloneable, Node {
      * @param constant Constant to set
      */
     public void setConstant( final int index, final Constant constant ) {
-        constant_pool[index] = constant;
+        constantPool[index] = constant;
     }
 
 
     /**
-     * @param constant_pool
+     * @param constantPool
      */
-    public void setConstantPool( final Constant[] constant_pool ) {
-        this.constant_pool = constant_pool;
+    public void setConstantPool( final Constant[] constantPool ) {
+        this.constantPool = constantPool;
     }
 
 
@@ -352,8 +352,8 @@ public class ConstantPool implements Cloneable, Node {
     @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder();
-        for (int i = 1; i < constant_pool.length; i++) {
-            buf.append(i).append(")").append(constant_pool[i]).append("\n");
+        for (int i = 1; i < constantPool.length; i++) {
+            buf.append(i).append(")").append(constantPool[i]).append("\n");
         }
         return buf.toString();
     }
@@ -366,10 +366,10 @@ public class ConstantPool implements Cloneable, Node {
         ConstantPool c = null;
         try {
             c = (ConstantPool) clone();
-            c.constant_pool = new Constant[constant_pool.length];
-            for (int i = 1; i < constant_pool.length; i++) {
-                if (constant_pool[i] != null) {
-                    c.constant_pool[i] = constant_pool[i].copy();
+            c.constantPool = new Constant[constantPool.length];
+            for (int i = 1; i < constantPool.length; i++) {
+                if (constantPool[i] != null) {
+                    c.constantPool[i] = constantPool[i].copy();
                 }
             }
         } catch (final CloneNotSupportedException e) {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantString.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantString.java
@@ -35,7 +35,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantString extends Constant implements ConstantObject {
 
-    private int string_index; // Identical to ConstantClass except for this name
+    private int stringIndex; // Identical to ConstantClass except for this name
 
 
     /**
@@ -58,11 +58,11 @@ public final class ConstantString extends Constant implements ConstantObject {
 
 
     /**
-     * @param string_index Index of Constant_Utf8 in constant pool
+     * @param stringIndex Index of Constant_Utf8 in constant pool
      */
-    public ConstantString(final int string_index) {
+    public ConstantString(final int stringIndex) {
         super(Const.CONSTANT_String);
-        this.string_index = string_index;
+        this.stringIndex = stringIndex;
     }
 
 
@@ -88,7 +88,7 @@ public final class ConstantString extends Constant implements ConstantObject {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         file.writeByte(super.getTag());
-        file.writeShort(string_index);
+        file.writeShort(stringIndex);
     }
 
 
@@ -96,15 +96,15 @@ public final class ConstantString extends Constant implements ConstantObject {
      * @return Index in constant pool of the string (ConstantUtf8).
      */
     public int getStringIndex() {
-        return string_index;
+        return stringIndex;
     }
 
 
     /**
-     * @param string_index the index into the constant of the string value
+     * @param stringIndex the index into the constant of the string value
      */
-    public void setStringIndex( final int string_index ) {
-        this.string_index = string_index;
+    public void setStringIndex( final int stringIndex ) {
+        this.stringIndex = stringIndex;
     }
 
 
@@ -113,7 +113,7 @@ public final class ConstantString extends Constant implements ConstantObject {
      */
     @Override
     public String toString() {
-        return super.toString() + "(string_index = " + string_index + ")";
+        return super.toString() + "(stringIndex = " + stringIndex + ")";
     }
 
 
@@ -121,7 +121,7 @@ public final class ConstantString extends Constant implements ConstantObject {
      */
     @Override
     public Object getConstantValue( final ConstantPool cp ) {
-        final Constant c = cp.getConstant(string_index, Const.CONSTANT_Utf8);
+        final Constant c = cp.getConstant(stringIndex, Const.CONSTANT_Utf8);
         return ((ConstantUtf8) c).getBytes();
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantValue.java
@@ -36,7 +36,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ConstantValue extends Attribute {
 
-    private int constantvalue_index;
+    private int constantValueIndex;
 
 
     /**
@@ -65,13 +65,13 @@ public final class ConstantValue extends Attribute {
     /**
      * @param name_index Name index in constant pool
      * @param length Content length in bytes
-     * @param constantvalue_index Index in constant pool
+     * @param constantValueIndex Index in constant pool
      * @param constant_pool Array of constants
      */
-    public ConstantValue(final int name_index, final int length, final int constantvalue_index,
+    public ConstantValue(final int name_index, final int length, final int constantValueIndex,
             final ConstantPool constant_pool) {
         super(Const.ATTR_CONSTANT_VALUE, name_index, length, constant_pool);
-        this.constantvalue_index = constantvalue_index;
+        this.constantValueIndex = constantValueIndex;
     }
 
 
@@ -97,7 +97,7 @@ public final class ConstantValue extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(constantvalue_index);
+        file.writeShort(constantValueIndex);
     }
 
 
@@ -105,15 +105,15 @@ public final class ConstantValue extends Attribute {
      * @return Index in constant pool of constant value.
      */
     public int getConstantValueIndex() {
-        return constantvalue_index;
+        return constantValueIndex;
     }
 
 
     /**
-     * @param constantvalue_index the index info the constant pool of this constant value
+     * @param constantValueIndex the index info the constant pool of this constant value
      */
-    public void setConstantValueIndex( final int constantvalue_index ) {
-        this.constantvalue_index = constantvalue_index;
+    public void setConstantValueIndex( final int constantValueIndex ) {
+        this.constantValueIndex = constantValueIndex;
     }
 
 
@@ -122,7 +122,7 @@ public final class ConstantValue extends Attribute {
      */
     @Override
     public String toString() {
-        Constant c = super.getConstantPool().getConstant(constantvalue_index);
+        Constant c = super.getConstantPool().getConstant(constantValueIndex);
         String buf;
         int i;
         // Print constant to string depending on its type

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ElementValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ElementValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 /**
  * @since 6.0
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public abstract class ElementValue
 {
@@ -105,7 +105,7 @@ public abstract class ElementValue
                 return new ArrayElementValue(ARRAY, evalues, cpool);
 
             default:
-                throw new RuntimeException("Unexpected element value kind in annotation: " + type);
+                throw new IllegalArgumentException("Unexpected element value kind in annotation: " + type);
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/EnumElementValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/EnumElementValue.java
@@ -41,7 +41,7 @@ public class EnumElementValue extends ElementValue
     {
         super(type, cpool);
         if (type != ENUM_CONSTANT) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "Only element values of type enum can be built with this ctor - type specified: " + type);
         }
         this.typeIdx = typeIdx;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ExceptionTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ExceptionTable.java
@@ -39,7 +39,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ExceptionTable extends Attribute {
 
-    private int[] exception_index_table; // constant pool
+    private int[] exceptionIndexTable; // constant pool
 
 
     /**
@@ -54,30 +54,30 @@ public final class ExceptionTable extends Attribute {
     /**
      * @param name_index Index in constant pool
      * @param length Content length in bytes
-     * @param exception_index_table Table of indices in constant pool
+     * @param exceptionIndexTable Table of indices in constant pool
      * @param constant_pool Array of constants
      */
-    public ExceptionTable(final int name_index, final int length, final int[] exception_index_table,
+    public ExceptionTable(final int name_index, final int length, final int[] exceptionIndexTable,
             final ConstantPool constant_pool) {
         super(Const.ATTR_EXCEPTIONS, name_index, length, constant_pool);
-        this.exception_index_table = exception_index_table != null ? exception_index_table : new int[0];
+        this.exceptionIndexTable = exceptionIndexTable != null ? exceptionIndexTable : new int[0];
     }
 
 
     /**
      * Construct object from input stream.
-     * @param name_index Index in constant pool
+     * @param nameIndex Index in constant pool
      * @param length Content length in bytes
      * @param input Input stream
-     * @param constant_pool Array of constants
+     * @param constantPool Array of constants
      * @throws IOException
      */
-    ExceptionTable(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
-        this(name_index, length, (int[]) null, constant_pool);
+    ExceptionTable(final int nameIndex, final int length, final DataInput input, final ConstantPool constantPool) throws IOException {
+        this(nameIndex, length, (int[]) null, constantPool);
         final int number_of_exceptions = input.readUnsignedShort();
-        exception_index_table = new int[number_of_exceptions];
+        exceptionIndexTable = new int[number_of_exceptions];
         for (int i = 0; i < number_of_exceptions; i++) {
-            exception_index_table[i] = input.readUnsignedShort();
+            exceptionIndexTable[i] = input.readUnsignedShort();
         }
     }
 
@@ -104,8 +104,8 @@ public final class ExceptionTable extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(exception_index_table.length);
-        for (final int index : exception_index_table) {
+        file.writeShort(exceptionIndexTable.length);
+        for (final int index : exceptionIndexTable) {
             file.writeShort(index);
         }
     }
@@ -115,7 +115,7 @@ public final class ExceptionTable extends Attribute {
      * @return Array of indices into constant pool of thrown exceptions.
      */
     public int[] getExceptionIndexTable() {
-        return exception_index_table;
+        return exceptionIndexTable;
     }
 
 
@@ -123,7 +123,7 @@ public final class ExceptionTable extends Attribute {
      * @return Length of exception table.
      */
     public int getNumberOfExceptions() {
-        return exception_index_table == null ? 0 : exception_index_table.length;
+        return exceptionIndexTable == null ? 0 : exceptionIndexTable.length;
     }
 
 
@@ -131,9 +131,9 @@ public final class ExceptionTable extends Attribute {
      * @return class names of thrown exceptions
      */
     public String[] getExceptionNames() {
-        final String[] names = new String[exception_index_table.length];
-        for (int i = 0; i < exception_index_table.length; i++) {
-            names[i] = super.getConstantPool().getConstantString(exception_index_table[i],
+        final String[] names = new String[exceptionIndexTable.length];
+        for (int i = 0; i < exceptionIndexTable.length; i++) {
+            names[i] = super.getConstantPool().getConstantString(exceptionIndexTable[i],
                     Const.CONSTANT_Class).replace('/', '.');
         }
         return names;
@@ -141,11 +141,11 @@ public final class ExceptionTable extends Attribute {
 
 
     /**
-     * @param exception_index_table the list of exception indexes
+     * @param exceptionIndexTable the list of exception indexes
      * Also redefines number_of_exceptions according to table length.
      */
-    public void setExceptionIndexTable( final int[] exception_index_table ) {
-        this.exception_index_table = exception_index_table != null ? exception_index_table : new int[0];
+    public void setExceptionIndexTable( final int[] exceptionIndexTable ) {
+        this.exceptionIndexTable = exceptionIndexTable != null ? exceptionIndexTable : new int[0];
     }
 
 
@@ -157,10 +157,10 @@ public final class ExceptionTable extends Attribute {
         final StringBuilder buf = new StringBuilder();
         String str;
         buf.append("Exceptions: ");
-        for (int i = 0; i < exception_index_table.length; i++) {
-            str = super.getConstantPool().getConstantString(exception_index_table[i], Const.CONSTANT_Class);
+        for (int i = 0; i < exceptionIndexTable.length; i++) {
+            str = super.getConstantPool().getConstantString(exceptionIndexTable[i], Const.CONSTANT_Class);
             buf.append(Utility.compactClassName(str, false));
-            if (i < exception_index_table.length - 1) {
+            if (i < exceptionIndexTable.length - 1) {
                 buf.append(", ");
             }
         }
@@ -174,10 +174,10 @@ public final class ExceptionTable extends Attribute {
     @Override
     public Attribute copy( final ConstantPool _constant_pool ) {
         final ExceptionTable c = (ExceptionTable) clone();
-        if (exception_index_table != null) {
-            c.exception_index_table = new int[exception_index_table.length];
-            System.arraycopy(exception_index_table, 0, c.exception_index_table, 0,
-                    exception_index_table.length);
+        if (exceptionIndexTable != null) {
+            c.exceptionIndexTable = new int[exceptionIndexTable.length];
+            System.arraycopy(exceptionIndexTable, 0, c.exceptionIndexTable, 0,
+                    exceptionIndexTable.length);
         }
         c.setConstantPool(_constant_pool);
         return c;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClass.java
@@ -36,10 +36,10 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class InnerClass implements Cloneable, Node {
 
-    private int inner_class_index;
-    private int outer_class_index;
-    private int inner_name_index;
-    private int inner_access_flags;
+    private int innerClassIndex;
+    private int outerClassIndex;
+    private int innerNameIndex;
+    private int innerAccessFlags;
 
 
     /**
@@ -63,17 +63,17 @@ public final class InnerClass implements Cloneable, Node {
 
 
     /**
-     * @param inner_class_index Class index in constant pool of inner class
-     * @param outer_class_index Class index in constant pool of outer class
-     * @param inner_name_index  Name index in constant pool of inner class
-     * @param inner_access_flags Access flags of inner class
+     * @param innerClassIndex Class index in constant pool of inner class
+     * @param outerClassIndex Class index in constant pool of outer class
+     * @param innerNameIndex  Name index in constant pool of inner class
+     * @param innerAccessFlags Access flags of inner class
      */
-    public InnerClass(final int inner_class_index, final int outer_class_index, final int inner_name_index,
-            final int inner_access_flags) {
-        this.inner_class_index = inner_class_index;
-        this.outer_class_index = outer_class_index;
-        this.inner_name_index = inner_name_index;
-        this.inner_access_flags = inner_access_flags;
+    public InnerClass(final int innerClassIndex, final int outerClassIndex, final int innerNameIndex,
+            final int innerAccessFlags) {
+        this.innerClassIndex = innerClassIndex;
+        this.outerClassIndex = outerClassIndex;
+        this.innerNameIndex = innerNameIndex;
+        this.innerAccessFlags = innerAccessFlags;
     }
 
 
@@ -97,10 +97,10 @@ public final class InnerClass implements Cloneable, Node {
      * @throws IOException
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(inner_class_index);
-        file.writeShort(outer_class_index);
-        file.writeShort(inner_name_index);
-        file.writeShort(inner_access_flags);
+        file.writeShort(innerClassIndex);
+        file.writeShort(outerClassIndex);
+        file.writeShort(innerNameIndex);
+        file.writeShort(innerAccessFlags);
     }
 
 
@@ -108,7 +108,7 @@ public final class InnerClass implements Cloneable, Node {
      * @return access flags of inner class.
      */
     public int getInnerAccessFlags() {
-        return inner_access_flags;
+        return innerAccessFlags;
     }
 
 
@@ -116,7 +116,7 @@ public final class InnerClass implements Cloneable, Node {
      * @return class index of inner class.
      */
     public int getInnerClassIndex() {
-        return inner_class_index;
+        return innerClassIndex;
     }
 
 
@@ -124,7 +124,7 @@ public final class InnerClass implements Cloneable, Node {
      * @return name index of inner class.
      */
     public int getInnerNameIndex() {
-        return inner_name_index;
+        return innerNameIndex;
     }
 
 
@@ -132,39 +132,39 @@ public final class InnerClass implements Cloneable, Node {
      * @return class index of outer class.
      */
     public int getOuterClassIndex() {
-        return outer_class_index;
+        return outerClassIndex;
     }
 
 
     /**
-     * @param inner_access_flags access flags for this inner class
+     * @param innerAccessFlags access flags for this inner class
      */
-    public void setInnerAccessFlags( final int inner_access_flags ) {
-        this.inner_access_flags = inner_access_flags;
+    public void setInnerAccessFlags( final int innerAccessFlags ) {
+        this.innerAccessFlags = innerAccessFlags;
     }
 
 
     /**
-     * @param inner_class_index index into the constant pool for this class
+     * @param innerClassIndex index into the constant pool for this class
      */
-    public void setInnerClassIndex( final int inner_class_index ) {
-        this.inner_class_index = inner_class_index;
+    public void setInnerClassIndex( final int innerClassIndex ) {
+        this.innerClassIndex = innerClassIndex;
     }
 
 
     /**
-     * @param inner_name_index index into the constant pool for this class's name
+     * @param innerNameIndex index into the constant pool for this class's name
      */
-    public void setInnerNameIndex( final int inner_name_index ) { // TODO unused
-        this.inner_name_index = inner_name_index;
+    public void setInnerNameIndex( final int innerNameIndex ) { // TODO unused
+        this.innerNameIndex = innerNameIndex;
     }
 
 
     /**
-     * @param outer_class_index index into the constant pool for the owning class
+     * @param outerClassIndex index into the constant pool for the owning class
      */
-    public void setOuterClassIndex( final int outer_class_index ) { // TODO unused
-        this.outer_class_index = outer_class_index;
+    public void setOuterClassIndex( final int outerClassIndex ) { // TODO unused
+        this.outerClassIndex = outerClassIndex;
     }
 
 
@@ -173,34 +173,34 @@ public final class InnerClass implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "InnerClass(" + inner_class_index + ", " + outer_class_index + ", "
-                + inner_name_index + ", " + inner_access_flags + ")";
+        return "InnerClass(" + innerClassIndex + ", " + outerClassIndex + ", "
+                + innerNameIndex + ", " + innerAccessFlags + ")";
     }
 
 
     /**
      * @return Resolved string representation
      */
-    public String toString( final ConstantPool constant_pool ) {
+    public String toString( final ConstantPool constantPool ) {
         String outer_class_name;
         String inner_name;
-        String inner_class_name = constant_pool.getConstantString(inner_class_index,
+        String inner_class_name = constantPool.getConstantString(innerClassIndex,
                 Const.CONSTANT_Class);
         inner_class_name = Utility.compactClassName(inner_class_name, false);
-        if (outer_class_index != 0) {
-            outer_class_name = constant_pool.getConstantString(outer_class_index,
+        if (outerClassIndex != 0) {
+            outer_class_name = constantPool.getConstantString(outerClassIndex,
                     Const.CONSTANT_Class);
             outer_class_name = " of class " + Utility.compactClassName(outer_class_name, false);
         } else {
             outer_class_name = "";
         }
-        if (inner_name_index != 0) {
-            inner_name = ((ConstantUtf8) constant_pool.getConstant(inner_name_index,
+        if (innerNameIndex != 0) {
+            inner_name = ((ConstantUtf8) constantPool.getConstant(innerNameIndex,
                     Const.CONSTANT_Utf8)).getBytes();
         } else {
             inner_name = "(anonymous)";
         }
-        String access = Utility.accessToString(inner_access_flags, true);
+        String access = Utility.accessToString(innerAccessFlags, true);
         access = access.isEmpty() ? "" : (access + " ");
         return "  " + access + inner_name + "=class " + inner_class_name + outer_class_name;
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClasses.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/InnerClasses.java
@@ -37,7 +37,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class InnerClasses extends Attribute {
 
-    private InnerClass[] inner_classes;
+    private InnerClass[] innerClasses;
 
 
     /**
@@ -52,13 +52,13 @@ public final class InnerClasses extends Attribute {
     /**
      * @param name_index Index in constant pool to CONSTANT_Utf8
      * @param length Content length in bytes
-     * @param inner_classes array of inner classes attributes
+     * @param innerClasses array of inner classes attributes
      * @param constant_pool Array of constants
      */
-    public InnerClasses(final int name_index, final int length, final InnerClass[] inner_classes,
+    public InnerClasses(final int name_index, final int length, final InnerClass[] innerClasses,
             final ConstantPool constant_pool) {
         super(Const.ATTR_INNER_CLASSES, name_index, length, constant_pool);
-        this.inner_classes = inner_classes != null ? inner_classes : new InnerClass[0];
+        this.innerClasses = innerClasses != null ? innerClasses : new InnerClass[0];
     }
 
 
@@ -75,9 +75,9 @@ public final class InnerClasses extends Attribute {
             throws IOException {
         this(name_index, length, (InnerClass[]) null, constant_pool);
         final int number_of_classes = input.readUnsignedShort();
-        inner_classes = new InnerClass[number_of_classes];
+        innerClasses = new InnerClass[number_of_classes];
         for (int i = 0; i < number_of_classes; i++) {
-            inner_classes[i] = new InnerClass(input);
+            innerClasses[i] = new InnerClass(input);
         }
     }
 
@@ -104,8 +104,8 @@ public final class InnerClasses extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(inner_classes.length);
-        for (final InnerClass inner_class : inner_classes) {
+        file.writeShort(innerClasses.length);
+        for (final InnerClass inner_class : innerClasses) {
             inner_class.dump(file);
         }
     }
@@ -115,15 +115,15 @@ public final class InnerClasses extends Attribute {
      * @return array of inner class "records"
      */
     public InnerClass[] getInnerClasses() {
-        return inner_classes;
+        return innerClasses;
     }
 
 
     /**
-     * @param inner_classes the array of inner classes
+     * @param innerClasses the array of inner classes
      */
-    public void setInnerClasses( final InnerClass[] inner_classes ) {
-        this.inner_classes = inner_classes != null ? inner_classes : new InnerClass[0];
+    public void setInnerClasses( final InnerClass[] innerClasses ) {
+        this.innerClasses = innerClasses != null ? innerClasses : new InnerClass[0];
     }
 
 
@@ -134,9 +134,9 @@ public final class InnerClasses extends Attribute {
     public String toString() {
         final StringBuilder buf = new StringBuilder();
         buf.append("InnerClasses(");
-        buf.append(inner_classes.length);
+        buf.append(innerClasses.length);
         buf.append("):\n");
-        for (final InnerClass inner_class : inner_classes) {
+        for (final InnerClass inner_class : innerClasses) {
             buf.append(inner_class.toString(super.getConstantPool())).append("\n");
         }
         return buf.substring(0, buf.length()-1); // remove the last newline
@@ -150,9 +150,9 @@ public final class InnerClasses extends Attribute {
     public Attribute copy( final ConstantPool _constant_pool ) {
         // TODO this could be recoded to use a lower level constructor after creating a copy of the inner classes
         final InnerClasses c = (InnerClasses) clone();
-        c.inner_classes = new InnerClass[inner_classes.length];
-        for (int i = 0; i < inner_classes.length; i++) {
-            c.inner_classes[i] = inner_classes[i].copy();
+        c.innerClasses = new InnerClass[innerClasses.length];
+        for (int i = 0; i < innerClasses.length; i++) {
+            c.innerClasses[i] = innerClasses[i].copy();
         }
         c.setConstantPool(_constant_pool);
         return c;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/JavaClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/JavaClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -41,28 +41,28 @@ import com.sun.org.apache.bcel.internal.util.SyntheticRepository;
 /**
  * Represents a Java class, i.e., the data structures, constant pool,
  * fields, methods and commands contained in a Java .class file.
- * See <a href="http://docs.oracle.com/javase/specs/">JVM specification</a> for details.
+ * See <a href="https://docs.oracle.com/javase/specs/">JVM specification</a> for details.
  * The intent of this class is to represent a parsed or otherwise existing
  * class file.  Those interested in programatically generating classes
  * should see the <a href="../generic/ClassGen.html">ClassGen</a> class.
 
  * @see com.sun.org.apache.bcel.internal.generic.ClassGen
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class JavaClass extends AccessFlags implements Cloneable, Node, Comparable<JavaClass> {
 
-    private String file_name;
-    private String package_name;
-    private String source_file_name = "<Unknown>";
-    private int class_name_index;
-    private int superclass_name_index;
-    private String class_name;
-    private String superclass_name;
+    private String fileName;
+    private String packageName;
+    private String sourceFileName = "<Unknown>";
+    private int classNameIndex;
+    private int superclassNameIndex;
+    private String className;
+    private String superclassName;
     private int major;
     private int minor; // Compiler version
-    private ConstantPool constant_pool; // Constant pool
+    private ConstantPool constantPool; // Constant pool
     private int[] interfaces; // implemented interfaces
-    private String[] interface_names;
+    private String[] interfaceNames;
     private Field[] fields; // Fields, i.e., variables of class
     private Method[] methods; // methods defined in the class
     private Attribute[] attributes; // attributes defined in the class
@@ -104,24 +104,24 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     /**
      * Constructor gets all contents as arguments.
      *
-     * @param class_name_index Index into constant pool referencing a
+     * @param classNameIndex Index into constant pool referencing a
      * ConstantClass that represents this class.
-     * @param superclass_name_index Index into constant pool referencing a
+     * @param superclassNameIndex Index into constant pool referencing a
      * ConstantClass that represents this class's superclass.
-     * @param file_name File name
+     * @param fileName File name
      * @param major Major compiler version
      * @param minor Minor compiler version
      * @param access_flags Access rights defined by bit flags
-     * @param constant_pool Array of constants
+     * @param constantPool Array of constants
      * @param interfaces Implemented interfaces
      * @param fields Class fields
      * @param methods Class methods
      * @param attributes Class attributes
      * @param source Read from file or generated in memory?
      */
-    public JavaClass(final int class_name_index, final int superclass_name_index,
-            final String file_name, final int major, final int minor, final int access_flags,
-            final ConstantPool constant_pool, int[] interfaces, Field[] fields,
+    public JavaClass(final int classNameIndex, final int superclassNameIndex,
+            final String fileName, final int major, final int minor, final int access_flags,
+            final ConstantPool constantPool, int[] interfaces, Field[] fields,
             Method[] methods, Attribute[] attributes, final byte source) {
         super(access_flags);
         if (interfaces == null) {
@@ -136,12 +136,12 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
         if (methods == null) {
             methods = new Method[0];
         }
-        this.class_name_index = class_name_index;
-        this.superclass_name_index = superclass_name_index;
-        this.file_name = file_name;
+        this.classNameIndex = classNameIndex;
+        this.superclassNameIndex = superclassNameIndex;
+        this.fileName = fileName;
         this.major = major;
         this.minor = minor;
-        this.constant_pool = constant_pool;
+        this.constantPool = constantPool;
         this.interfaces = interfaces;
         this.fields = fields;
         this.methods = methods;
@@ -150,7 +150,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
         // Get source file name if available
         for (final Attribute attribute : attributes) {
             if (attribute instanceof SourceFile) {
-                source_file_name = ((SourceFile) attribute).getSourceFileName();
+                sourceFileName = ((SourceFile) attribute).getSourceFileName();
                 break;
             }
         }
@@ -158,26 +158,26 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
          * `ConstantClass' but we check that anyway via the
          * `ConstPool.getConstant' method.
          */
-        class_name = constant_pool.getConstantString(class_name_index, Const.CONSTANT_Class);
-        class_name = Utility.compactClassName(class_name, false);
-        final int index = class_name.lastIndexOf('.');
+        className = constantPool.getConstantString(classNameIndex, Const.CONSTANT_Class);
+        className = Utility.compactClassName(className, false);
+        final int index = className.lastIndexOf('.');
         if (index < 0) {
-            package_name = "";
+            packageName = "";
         } else {
-            package_name = class_name.substring(0, index);
+            packageName = className.substring(0, index);
         }
-        if (superclass_name_index > 0) {
+        if (superclassNameIndex > 0) {
             // May be zero -> class is java.lang.Object
-            superclass_name = constant_pool.getConstantString(superclass_name_index,
+            superclassName = constantPool.getConstantString(superclassNameIndex,
                     Const.CONSTANT_Class);
-            superclass_name = Utility.compactClassName(superclass_name, false);
+            superclassName = Utility.compactClassName(superclassName, false);
         } else {
-            superclass_name = "java.lang.Object";
+            superclassName = "java.lang.Object";
         }
-        interface_names = new String[interfaces.length];
+        interfaceNames = new String[interfaces.length];
         for (int i = 0; i < interfaces.length; i++) {
-            final String str = constant_pool.getConstantString(interfaces[i], Const.CONSTANT_Class);
-            interface_names[i] = Utility.compactClassName(str, false);
+            final String str = constantPool.getConstantString(interfaces[i], Const.CONSTANT_Class);
+            interfaceNames[i] = Utility.compactClassName(str, false);
         }
     }
 
@@ -185,24 +185,24 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     /**
      * Constructor gets all contents as arguments.
      *
-     * @param class_name_index Class name
-     * @param superclass_name_index Superclass name
-     * @param file_name File name
+     * @param classNameIndex Class name
+     * @param superclassNameIndex Superclass name
+     * @param fileName File name
      * @param major Major compiler version
      * @param minor Minor compiler version
      * @param access_flags Access rights defined by bit flags
-     * @param constant_pool Array of constants
+     * @param constantPool Array of constants
      * @param interfaces Implemented interfaces
      * @param fields Class fields
      * @param methods Class methods
      * @param attributes Class attributes
      */
-    public JavaClass(final int class_name_index, final int superclass_name_index,
-            final String file_name, final int major, final int minor, final int access_flags,
-            final ConstantPool constant_pool, final int[] interfaces, final Field[] fields,
+    public JavaClass(final int classNameIndex, final int superclassNameIndex,
+            final String fileName, final int major, final int minor, final int access_flags,
+            final ConstantPool constantPool, final int[] interfaces, final Field[] fields,
             final Method[] methods, final Attribute[] attributes) {
-        this(class_name_index, superclass_name_index, file_name, major, minor, access_flags,
-                constant_pool, interfaces, fields, methods, attributes, HEAP);
+        this(classNameIndex, superclassNameIndex, fileName, major, minor, access_flags,
+                constantPool, interfaces, fields, methods, attributes, HEAP);
     }
 
 
@@ -251,7 +251,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
 
 
     /**
-     * Dump class to a file named file_name.
+     * Dump class to a file named fileName.
      *
      * @param _file_name Output file name
      * @throws IOException
@@ -303,10 +303,10 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
         file.writeInt(Const.JVM_CLASSFILE_MAGIC);
         file.writeShort(minor);
         file.writeShort(major);
-        constant_pool.dump(file);
+        constantPool.dump(file);
         file.writeShort(super.getAccessFlags());
-        file.writeShort(class_name_index);
-        file.writeShort(superclass_name_index);
+        file.writeShort(classNameIndex);
+        file.writeShort(superclassNameIndex);
         file.writeShort(interfaces.length);
         for (final int interface1 : interfaces) {
             file.writeShort(interface1);
@@ -354,7 +354,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return Class name.
      */
     public String getClassName() {
-        return class_name;
+        return className;
     }
 
 
@@ -362,7 +362,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return Package name.
      */
     public String getPackageName() {
-        return package_name;
+        return packageName;
     }
 
 
@@ -370,7 +370,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return Class name index.
      */
     public int getClassNameIndex() {
-        return class_name_index;
+        return classNameIndex;
     }
 
 
@@ -378,7 +378,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return Constant pool.
      */
     public ConstantPool getConstantPool() {
-        return constant_pool;
+        return constantPool;
     }
 
 
@@ -396,7 +396,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return File name of class, aka SourceFile attribute value
      */
     public String getFileName() {
-        return file_name;
+        return fileName;
     }
 
 
@@ -404,7 +404,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return Names of implemented interfaces.
      */
     public String[] getInterfaceNames() {
-        return interface_names;
+        return interfaceNames;
     }
 
 
@@ -459,7 +459,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return sbsolute path to file where this class was read from
      */
     public String getSourceFileName() {
-        return source_file_name;
+        return sourceFileName;
     }
 
 
@@ -471,7 +471,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return Superclass name.
      */
     public String getSuperclassName() {
-        return superclass_name;
+        return superclassName;
     }
 
 
@@ -479,7 +479,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * @return Class name index.
      */
     public int getSuperclassNameIndex() {
-        return superclass_name_index;
+        return superclassNameIndex;
     }
 
     /**
@@ -491,26 +491,26 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
 
 
     /**
-     * @param class_name .
+     * @param className .
      */
-    public void setClassName( final String class_name ) {
-        this.class_name = class_name;
+    public void setClassName( final String className ) {
+        this.className = className;
     }
 
 
     /**
-     * @param class_name_index .
+     * @param classNameIndex .
      */
-    public void setClassNameIndex( final int class_name_index ) {
-        this.class_name_index = class_name_index;
+    public void setClassNameIndex( final int classNameIndex ) {
+        this.classNameIndex = classNameIndex;
     }
 
 
     /**
-     * @param constant_pool .
+     * @param constantPool .
      */
-    public void setConstantPool( final ConstantPool constant_pool ) {
-        this.constant_pool = constant_pool;
+    public void setConstantPool( final ConstantPool constantPool ) {
+        this.constantPool = constantPool;
     }
 
 
@@ -525,16 +525,16 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     /**
      * Set File name of class, aka SourceFile attribute value
      */
-    public void setFileName( final String file_name ) {
-        this.file_name = file_name;
+    public void setFileName( final String fileName ) {
+        this.fileName = fileName;
     }
 
 
     /**
-     * @param interface_names .
+     * @param interfaceNames .
      */
-    public void setInterfaceNames( final String[] interface_names ) {
-        this.interface_names = interface_names;
+    public void setInterfaceNames( final String[] interfaceNames ) {
+        this.interfaceNames = interfaceNames;
     }
 
 
@@ -573,24 +573,24 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     /**
      * Set absolute path to file this class was read from.
      */
-    public void setSourceFileName( final String source_file_name ) {
-        this.source_file_name = source_file_name;
+    public void setSourceFileName( final String sourceFileName ) {
+        this.sourceFileName = sourceFileName;
     }
 
 
     /**
-     * @param superclass_name .
+     * @param superclassName .
      */
-    public void setSuperclassName( final String superclass_name ) {
-        this.superclass_name = superclass_name;
+    public void setSuperclassName( final String superclassName ) {
+        this.superclassName = superclassName;
     }
 
 
     /**
-     * @param superclass_name_index .
+     * @param superclassNameIndex .
      */
-    public void setSuperclassNameIndex( final int superclass_name_index ) {
-        this.superclass_name_index = superclass_name_index;
+    public void setSuperclassNameIndex( final int superclassNameIndex ) {
+        this.superclassNameIndex = superclassNameIndex;
     }
 
 
@@ -603,24 +603,24 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
         access = access.isEmpty() ? "" : (access + " ");
         final StringBuilder buf = new StringBuilder(128);
         buf.append(access).append(Utility.classOrInterface(super.getAccessFlags())).append(" ").append(
-                class_name).append(" extends ").append(
-                Utility.compactClassName(superclass_name, false)).append('\n');
+                className).append(" extends ").append(
+                Utility.compactClassName(superclassName, false)).append('\n');
         final int size = interfaces.length;
         if (size > 0) {
             buf.append("implements\t\t");
             for (int i = 0; i < size; i++) {
-                buf.append(interface_names[i]);
+                buf.append(interfaceNames[i]);
                 if (i < size - 1) {
                     buf.append(", ");
                 }
             }
             buf.append('\n');
         }
-        buf.append("file name\t\t").append(file_name).append('\n');
-        buf.append("compiled from\t\t").append(source_file_name).append('\n');
+        buf.append("file name\t\t").append(fileName).append('\n');
+        buf.append("compiled from\t\t").append(sourceFileName).append('\n');
         buf.append("compiler version\t").append(major).append(".").append(minor).append('\n');
         buf.append("access flags\t\t").append(super.getAccessFlags()).append('\n');
-        buf.append("constant pool\t\t").append(constant_pool.getLength()).append(" entries\n");
+        buf.append("constant pool\t\t").append(constantPool.getLength()).append(" entries\n");
         buf.append("ACC_SUPER flag\t\t").append(isSuper()).append("\n");
         if (attributes.length > 0) {
             buf.append("\nAttribute(s):\n");
@@ -668,20 +668,20 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
         JavaClass c = null;
         try {
             c = (JavaClass) clone();
-            c.constant_pool = constant_pool.copy();
+            c.constantPool = constantPool.copy();
             c.interfaces = interfaces.clone();
-            c.interface_names = interface_names.clone();
+            c.interfaceNames = interfaceNames.clone();
             c.fields = new Field[fields.length];
             for (int i = 0; i < fields.length; i++) {
-                c.fields[i] = fields[i].copy(c.constant_pool);
+                c.fields[i] = fields[i].copy(c.constantPool);
             }
             c.methods = new Method[methods.length];
             for (int i = 0; i < methods.length; i++) {
-                c.methods[i] = methods[i].copy(c.constant_pool);
+                c.methods[i] = methods[i].copy(c.constantPool);
             }
             c.attributes = new Attribute[attributes.length];
             for (int i = 0; i < attributes.length; i++) {
-                c.attributes[i] = attributes[i].copy(c.constant_pool);
+                c.attributes[i] = attributes[i].copy(c.constantPool);
             }
         } catch (final CloneNotSupportedException e) {
             // TODO should this throw?
@@ -724,7 +724,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
                   final InnerClass[] innerClasses = ((InnerClasses) attribute).getInnerClasses();
                   for (final InnerClass innerClasse : innerClasses) {
                       boolean innerClassAttributeRefersToMe = false;
-                      String inner_class_name = constant_pool.getConstantString(innerClasse.getInnerClassIndex(),
+                      String inner_class_name = constantPool.getConstantString(innerClasse.getInnerClassIndex(),
                                  Const.CONSTANT_Class);
                       inner_class_name = Utility.compactClassName(inner_class_name, false);
                       if (inner_class_name.equals(getClassName())) {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumber.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumber.java
@@ -35,10 +35,10 @@ import java.io.IOException;
 public final class LineNumber implements Cloneable, Node {
 
     /** Program Counter (PC) corresponds to line */
-    private short start_pc;
+    private short startPc;
 
     /** number in source file */
-    private short line_number;
+    private short lineNumber;
 
     /**
      * Initialize from another object.
@@ -62,12 +62,12 @@ public final class LineNumber implements Cloneable, Node {
 
 
     /**
-     * @param start_pc Program Counter (PC) corresponds to
-     * @param line_number line number in source file
+     * @param startPc Program Counter (PC) corresponds to
+     * @param lineNumber line number in source file
      */
-    public LineNumber(final int start_pc, final int line_number) {
-        this.start_pc = (short) start_pc;
-        this.line_number = (short)line_number;
+    public LineNumber(final int startPc, final int lineNumber) {
+        this.startPc = (short) startPc;
+        this.lineNumber = (short)lineNumber;
     }
 
 
@@ -91,8 +91,8 @@ public final class LineNumber implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in writeShort
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(start_pc);
-        file.writeShort(line_number);
+        file.writeShort(startPc);
+        file.writeShort(lineNumber);
     }
 
 
@@ -100,7 +100,7 @@ public final class LineNumber implements Cloneable, Node {
      * @return Corresponding source line
      */
     public int getLineNumber() {
-        return 0xffff & line_number;
+        return 0xffff & lineNumber;
     }
 
 
@@ -108,23 +108,23 @@ public final class LineNumber implements Cloneable, Node {
      * @return PC in code
      */
     public int getStartPC() {
-        return  0xffff & start_pc;
+        return  0xffff & startPc;
     }
 
 
     /**
-     * @param line_number the source line number
+     * @param lineNumber the source line number
      */
-    public void setLineNumber( final int line_number ) {
-        this.line_number = (short) line_number;
+    public void setLineNumber( final int lineNumber ) {
+        this.lineNumber = (short) lineNumber;
     }
 
 
     /**
-     * @param start_pc the pc for this line number
+     * @param startPc the pc for this line number
      */
-    public void setStartPC( final int start_pc ) {
-        this.start_pc = (short) start_pc;
+    public void setStartPC( final int startPc ) {
+        this.startPc = (short) startPc;
     }
 
 
@@ -133,7 +133,7 @@ public final class LineNumber implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "LineNumber(" + start_pc + ", " + line_number + ")";
+        return "LineNumber(" + startPc + ", " + lineNumber + ")";
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumberTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LineNumberTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,12 +32,12 @@ import jdk.xml.internal.SecuritySupport;
  *
  * @see     Code
  * @see LineNumber
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public final class LineNumberTable extends Attribute {
 
     private static final int MAX_LINE_LENGTH = 72;
-    private LineNumber[] line_number_table; // Table of line/numbers pairs
+    private LineNumber[] lineNumberTable; // Table of line/numbers pairs
 
 
     /*
@@ -52,13 +52,13 @@ public final class LineNumberTable extends Attribute {
     /*
      * @param name_index Index of name
      * @param length Content length in bytes
-     * @param line_number_table Table of line/numbers pairs
+     * @param lineNumberTable Table of line/numbers pairs
      * @param constant_pool Array of constants
      */
     public LineNumberTable(final int name_index, final int length, final LineNumber[] line_number_table,
             final ConstantPool constant_pool) {
         super(Const.ATTR_LINE_NUMBER_TABLE, name_index, length, constant_pool);
-        this.line_number_table = line_number_table;
+        this.lineNumberTable = line_number_table;
     }
 
     /**
@@ -73,9 +73,9 @@ public final class LineNumberTable extends Attribute {
             throws IOException {
         this(name_index, length, (LineNumber[]) null, constant_pool);
         final int line_number_table_length = input.readUnsignedShort();
-        line_number_table = new LineNumber[line_number_table_length];
+        lineNumberTable = new LineNumber[line_number_table_length];
         for (int i = 0; i < line_number_table_length; i++) {
-            line_number_table[i] = new LineNumber(input);
+            lineNumberTable[i] = new LineNumber(input);
         }
     }
 
@@ -100,8 +100,8 @@ public final class LineNumberTable extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(line_number_table.length);
-        for (final LineNumber lineNumber : line_number_table) {
+        file.writeShort(lineNumberTable.length);
+        for (final LineNumber lineNumber : lineNumberTable) {
             lineNumber.dump(file);
         }
     }
@@ -110,14 +110,14 @@ public final class LineNumberTable extends Attribute {
      * @return Array of (pc offset, line number) pairs.
      */
     public LineNumber[] getLineNumberTable() {
-        return line_number_table;
+        return lineNumberTable;
     }
 
     /**
-     * @param line_number_table the line number entries for this table
+     * @param lineNumberTable the line number entries for this table
      */
-    public void setLineNumberTable( final LineNumber[] line_number_table ) {
-        this.line_number_table = line_number_table;
+    public void setLineNumberTable( final LineNumber[] lineNumberTable ) {
+        this.lineNumberTable = lineNumberTable;
     }
 
     /**
@@ -128,12 +128,12 @@ public final class LineNumberTable extends Attribute {
         final StringBuilder buf = new StringBuilder();
         final StringBuilder line = new StringBuilder();
 
-        for (int i = 0; i < line_number_table.length; i++) {
-            line.append(line_number_table[i].toString());
-            if (i < line_number_table.length - 1) {
+        for (int i = 0; i < lineNumberTable.length; i++) {
+            line.append(lineNumberTable[i].toString());
+            if (i < lineNumberTable.length - 1) {
                 line.append(", ");
             }
-            if ((line.length() > MAX_LINE_LENGTH) && (i < line_number_table.length - 1)) {
+            if ((line.length() > MAX_LINE_LENGTH) && (i < lineNumberTable.length - 1)) {
                 line.append(SecuritySupport.NEWLINE);
                 buf.append(line);
                 line.setLength(0);
@@ -151,7 +151,7 @@ public final class LineNumberTable extends Attribute {
      */
     public int getSourceLine( final int pos ) {
         int l = 0;
-        int r = line_number_table.length - 1;
+        int r = lineNumberTable.length - 1;
         if (r < 0) {
             return -1;
         }
@@ -161,9 +161,9 @@ public final class LineNumberTable extends Attribute {
          */
         do {
             final int i = (l + r) >>> 1;
-            final int j = line_number_table[i].getStartPC();
+            final int j = lineNumberTable[i].getStartPC();
             if (j == pos) {
-                return line_number_table[i].getLineNumber();
+                return lineNumberTable[i].getLineNumber();
             } else if (pos < j) {
                 r = i - 1;
             } else {
@@ -184,7 +184,7 @@ public final class LineNumberTable extends Attribute {
         if (min_index < 0) {
             return -1;
         }
-        return line_number_table[min_index].getLineNumber();
+        return lineNumberTable[min_index].getLineNumber();
     }
 
     /**
@@ -193,17 +193,18 @@ public final class LineNumberTable extends Attribute {
     @Override
     public Attribute copy( final ConstantPool _constant_pool ) {
         // TODO could use the lower level constructor and thereby allow
-        // line_number_table to be made final
+        // lineNumberTable to be made final
         final LineNumberTable c = (LineNumberTable) clone();
-        c.line_number_table = new LineNumber[line_number_table.length];
-        for (int i = 0; i < line_number_table.length; i++) {
-            c.line_number_table[i] = line_number_table[i].copy();
+        c.lineNumberTable = new LineNumber[lineNumberTable.length];
+        for (int i = 0; i < lineNumberTable.length; i++) {
+            c.lineNumberTable[i] = lineNumberTable[i].copy();
         }
         c.setConstantPool(_constant_pool);
         return c;
     }
 
+
     public int getTableLength() {
-        return line_number_table == null ? 0 : line_number_table.length;
+        return lineNumberTable == null ? 0 : lineNumberTable.length;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,27 +32,27 @@ import com.sun.org.apache.bcel.internal.Const;
  * to represent an element of the LocalVariableTable as well as an element
  * of the LocalVariableTypeTable.  The nomenclature used here may be a bit confusing;
  * while the two items have the same layout in a class file, a LocalVariableTable
- * attribute contains a descriptor_index, not a signature_index.  The
- * LocalVariableTypeTable attribute does have a signature_index.
+ * attribute contains a descriptor_index, not a signatureIndex.  The
+ * LocalVariableTypeTable attribute does have a signatureIndex.
  * @see com.sun.org.apache.bcel.internal.classfile.Utility for more details on the difference.
  *
  * @see     LocalVariableTable
  * @see     LocalVariableTypeTable
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public final class LocalVariable implements Cloneable, Node {
 
-    private int start_pc; // Range in which the variable is valid
+    private int startPc; // Range in which the variable is valid
     private int length;
-    private int name_index; // Index in constant pool of variable name
+    private int nameIndex; // Index in constant pool of variable name
     // Technically, a decscriptor_index for a local variable table entry
-    // and a signature_index for a local variable type table entry.
-    private int signature_index; // Index of variable signature
+    // and a signatureIndex for a local variable type table entry.
+    private int signatureIndex; // Index of variable signature
     private int index; /* Variable is index'th local variable on
      * this method's frame.
      */
-    private ConstantPool constant_pool;
-    private int orig_index; // never changes; used to match up with LocalVariableTypeTable entries
+    private ConstantPool constantPool;
+    private int origIndex; // never changes; used to match up with LocalVariableTypeTable entries
 
 
     /**
@@ -64,7 +64,7 @@ public final class LocalVariable implements Cloneable, Node {
     public LocalVariable(final LocalVariable localVariable) {
         this(localVariable.getStartPC(), localVariable.getLength(), localVariable.getNameIndex(),
                 localVariable.getSignatureIndex(), localVariable.getIndex(), localVariable.getConstantPool());
-        this.orig_index = localVariable.getOrigIndex();
+        this.origIndex = localVariable.getOrigIndex();
     }
 
     /**
@@ -79,43 +79,43 @@ public final class LocalVariable implements Cloneable, Node {
 
 
     /**
-     * @param start_pc Range in which the variable
+     * @param startPc Range in which the variable
      * @param length ... is valid
-     * @param name_index Index in constant pool of variable name
-     * @param signature_index Index of variable's signature
+     * @param nameIndex Index in constant pool of variable name
+     * @param signatureIndex Index of variable's signature
      * @param index Variable is `index'th local variable on the method's frame
-     * @param constant_pool Array of constants
+     * @param constantPool Array of constants
      */
-    public LocalVariable(final int start_pc, final int length, final int name_index, final int signature_index, final int index,
-            final ConstantPool constant_pool) {
-        this.start_pc = start_pc;
+    public LocalVariable(final int startPc, final int length, final int nameIndex, final int signatureIndex, final int index,
+            final ConstantPool constantPool) {
+        this.startPc = startPc;
         this.length = length;
-        this.name_index = name_index;
-        this.signature_index = signature_index;
+        this.nameIndex = nameIndex;
+        this.signatureIndex = signatureIndex;
         this.index = index;
-        this.constant_pool = constant_pool;
-        this.orig_index = index;
+        this.constantPool = constantPool;
+        this.origIndex = index;
     }
 
 
     /**
-     * @param start_pc Range in which the variable
+     * @param startPc Range in which the variable
      * @param length ... is valid
-     * @param name_index Index in constant pool of variable name
-     * @param signature_index Index of variable's signature
+     * @param nameIndex Index in constant pool of variable name
+     * @param signatureIndex Index of variable's signature
      * @param index Variable is `index'th local variable on the method's frame
-     * @param constant_pool Array of constants
-     * @param orig_index Variable is `index'th local variable on the method's frame prior to any changes
+     * @param constantPool Array of constants
+     * @param origIndex Variable is `index'th local variable on the method's frame prior to any changes
      */
-    public LocalVariable(final int start_pc, final int length, final int name_index, final int signature_index, final int index,
-            final ConstantPool constant_pool, final int orig_index) {
-        this.start_pc = start_pc;
+    public LocalVariable(final int startPc, final int length, final int nameIndex, final int signatureIndex, final int index,
+            final ConstantPool constantPool, final int origIndex) {
+        this.startPc = startPc;
         this.length = length;
-        this.name_index = name_index;
-        this.signature_index = signature_index;
+        this.nameIndex = nameIndex;
+        this.signatureIndex = signatureIndex;
         this.index = index;
-        this.constant_pool = constant_pool;
-        this.orig_index = orig_index;
+        this.constantPool = constantPool;
+        this.origIndex = origIndex;
     }
 
 
@@ -140,10 +140,10 @@ public final class LocalVariable implements Cloneable, Node {
      * @see java.io.FilterOutputStream#out
      */
     public void dump(final DataOutputStream dataOutputStream) throws IOException {
-        dataOutputStream.writeShort(start_pc);
+        dataOutputStream.writeShort(startPc);
         dataOutputStream.writeShort(length);
-        dataOutputStream.writeShort(name_index);
-        dataOutputStream.writeShort(signature_index);
+        dataOutputStream.writeShort(nameIndex);
+        dataOutputStream.writeShort(signatureIndex);
         dataOutputStream.writeShort(index);
     }
 
@@ -151,7 +151,7 @@ public final class LocalVariable implements Cloneable, Node {
      * @return Constant pool used by this object.
      */
     public ConstantPool getConstantPool() {
-        return constant_pool;
+        return constantPool;
     }
 
 
@@ -168,7 +168,7 @@ public final class LocalVariable implements Cloneable, Node {
      */
     public String getName() {
         ConstantUtf8 c;
-        c = (ConstantUtf8) constant_pool.getConstant(name_index, Const.CONSTANT_Utf8);
+        c = (ConstantUtf8) constantPool.getConstant(nameIndex, Const.CONSTANT_Utf8);
         return c.getBytes();
     }
 
@@ -177,7 +177,7 @@ public final class LocalVariable implements Cloneable, Node {
      * @return Index in constant pool of variable name.
      */
     public int getNameIndex() {
-        return name_index;
+        return nameIndex;
     }
 
 
@@ -186,7 +186,7 @@ public final class LocalVariable implements Cloneable, Node {
      */
     public String getSignature() {
         ConstantUtf8 c;
-        c = (ConstantUtf8) constant_pool.getConstant(signature_index, Const.CONSTANT_Utf8);
+        c = (ConstantUtf8) constantPool.getConstant(signatureIndex, Const.CONSTANT_Utf8);
         return c.getBytes();
     }
 
@@ -195,7 +195,7 @@ public final class LocalVariable implements Cloneable, Node {
      * @return Index in constant pool of variable signature.
      */
     public int getSignatureIndex() {
-        return signature_index;
+        return signatureIndex;
     }
 
 
@@ -211,7 +211,7 @@ public final class LocalVariable implements Cloneable, Node {
      * @return index of register where variable was originally stored
      */
     public int getOrigIndex() {
-        return orig_index;
+        return origIndex;
     }
 
 
@@ -219,7 +219,7 @@ public final class LocalVariable implements Cloneable, Node {
      * @return Start of range where the variable is valid
      */
     public int getStartPC() {
-        return start_pc;
+        return startPc;
     }
 
 
@@ -230,16 +230,16 @@ public final class LocalVariable implements Cloneable, Node {
         final String name = getName();
         final String signature = Utility.signatureToString(getSignature(), false);
         final String label = "LocalVariable" + (typeTable ? "Types" : "" );
-        return label + "(start_pc = " + start_pc + ", length = " + length + ", index = "
+        return label + "(startPc = " + startPc + ", length = " + length + ", index = "
                 + index + ":" + signature + " " + name + ")";
     }
 
 
     /**
-     * @param constant_pool Constant pool to be used for this object.
+     * @param constantPool Constant pool to be used for this object.
      */
-    public void setConstantPool( final ConstantPool constant_pool ) {
-        this.constant_pool = constant_pool;
+    public void setConstantPool( final ConstantPool constantPool ) {
+        this.constantPool = constantPool;
     }
 
 
@@ -252,18 +252,18 @@ public final class LocalVariable implements Cloneable, Node {
 
 
     /**
-     * @param name_index the index into the constant pool for the name of this variable
+     * @param nameIndex the index into the constant pool for the name of this variable
      */
-    public void setNameIndex( final int name_index ) { // TODO unused
-        this.name_index = name_index;
+    public void setNameIndex( final int nameIndex ) { // TODO unused
+        this.nameIndex = nameIndex;
     }
 
 
     /**
-     * @param signature_index the index into the constant pool for the signature of this variable
+     * @param signatureIndex the index into the constant pool for the signature of this variable
      */
-    public void setSignatureIndex( final int signature_index ) { // TODO unused
-        this.signature_index = signature_index;
+    public void setSignatureIndex( final int signatureIndex ) { // TODO unused
+        this.signatureIndex = signatureIndex;
     }
 
 
@@ -276,10 +276,10 @@ public final class LocalVariable implements Cloneable, Node {
 
 
     /**
-     * @param start_pc Specify range where the local variable is valid.
+     * @param startPc Specify range where the local variable is valid.
      */
-    public void setStartPC( final int start_pc ) { // TODO unused
-        this.start_pc = start_pc;
+    public void setStartPC( final int startPc ) { // TODO unused
+        this.startPc = startPc;
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariableTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariableTable.java
@@ -36,7 +36,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public class LocalVariableTable extends Attribute {
 
-    private LocalVariable[] local_variable_table; // variables
+    private LocalVariable[] localVariableTable; // variables
 
 
     /**
@@ -49,15 +49,15 @@ public class LocalVariableTable extends Attribute {
 
 
     /**
-     * @param name_index Index in constant pool to `LocalVariableTable'
+     * @param nameIndex Index in constant pool to `LocalVariableTable'
      * @param length Content length in bytes
-     * @param local_variable_table Table of local variables
-     * @param constant_pool Array of constants
+     * @param localVariableTable Table of local variables
+     * @param constantPool Array of constants
      */
-    public LocalVariableTable(final int name_index, final int length, final LocalVariable[] local_variable_table,
-            final ConstantPool constant_pool) {
-        super(Const.ATTR_LOCAL_VARIABLE_TABLE, name_index, length, constant_pool);
-        this.local_variable_table = local_variable_table;
+    public LocalVariableTable(final int nameIndex, final int length, final LocalVariable[] localVariableTable,
+            final ConstantPool constantPool) {
+        super(Const.ATTR_LOCAL_VARIABLE_TABLE, nameIndex, length, constantPool);
+        this.localVariableTable = localVariableTable;
     }
 
 
@@ -73,9 +73,9 @@ public class LocalVariableTable extends Attribute {
             throws IOException {
         this(name_index, length, (LocalVariable[]) null, constant_pool);
         final int local_variable_table_length = input.readUnsignedShort();
-        local_variable_table = new LocalVariable[local_variable_table_length];
+        localVariableTable = new LocalVariable[local_variable_table_length];
         for (int i = 0; i < local_variable_table_length; i++) {
-            local_variable_table[i] = new LocalVariable(input, constant_pool);
+            localVariableTable[i] = new LocalVariable(input, constant_pool);
         }
     }
 
@@ -102,8 +102,8 @@ public class LocalVariableTable extends Attribute {
     @Override
     public final void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(local_variable_table.length);
-        for (final LocalVariable variable : local_variable_table) {
+        file.writeShort(localVariableTable.length);
+        for (final LocalVariable variable : localVariableTable) {
             variable.dump(file);
         }
     }
@@ -113,7 +113,7 @@ public class LocalVariableTable extends Attribute {
      * @return Array of local variables of method.
      */
     public final LocalVariable[] getLocalVariableTable() {
-        return local_variable_table;
+        return localVariableTable;
     }
 
 
@@ -128,7 +128,7 @@ public class LocalVariableTable extends Attribute {
      */
     @java.lang.Deprecated
     public final LocalVariable getLocalVariable( final int index ) {
-        for (final LocalVariable variable : local_variable_table) {
+        for (final LocalVariable variable : localVariableTable) {
             if (variable.getIndex() == index) {
                 return variable;
             }
@@ -145,7 +145,7 @@ public class LocalVariableTable extends Attribute {
      * @return the LocalVariable that matches or null if not found
      */
     public final LocalVariable getLocalVariable( final int index, final int pc ) {
-        for (final LocalVariable variable : local_variable_table) {
+        for (final LocalVariable variable : localVariableTable) {
             if (variable.getIndex() == index) {
                 final int start_pc = variable.getStartPC();
                 final int end_pc = start_pc + variable.getLength();
@@ -159,7 +159,7 @@ public class LocalVariableTable extends Attribute {
 
 
     public final void setLocalVariableTable( final LocalVariable[] local_variable_table ) {
-        this.local_variable_table = local_variable_table;
+        this.localVariableTable = local_variable_table;
     }
 
 
@@ -169,9 +169,9 @@ public class LocalVariableTable extends Attribute {
     @Override
     public final String toString() {
         final StringBuilder buf = new StringBuilder();
-        for (int i = 0; i < local_variable_table.length; i++) {
-            buf.append(local_variable_table[i]);
-            if (i < local_variable_table.length - 1) {
+        for (int i = 0; i < localVariableTable.length; i++) {
+            buf.append(localVariableTable[i]);
+            if (i < localVariableTable.length - 1) {
                 buf.append('\n');
             }
         }
@@ -185,9 +185,9 @@ public class LocalVariableTable extends Attribute {
     @Override
     public Attribute copy( final ConstantPool _constant_pool ) {
         final LocalVariableTable c = (LocalVariableTable) clone();
-        c.local_variable_table = new LocalVariable[local_variable_table.length];
-        for (int i = 0; i < local_variable_table.length; i++) {
-            c.local_variable_table[i] = local_variable_table[i].copy();
+        c.localVariableTable = new LocalVariable[localVariableTable.length];
+        for (int i = 0; i < localVariableTable.length; i++) {
+            c.localVariableTable[i] = localVariableTable[i].copy();
         }
         c.setConstantPool(_constant_pool);
         return c;
@@ -195,6 +195,6 @@ public class LocalVariableTable extends Attribute {
 
 
     public final int getTableLength() {
-        return local_variable_table == null ? 0 : local_variable_table.length;
+        return localVariableTable == null ? 0 : localVariableTable.length;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariableTypeTable.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/LocalVariableTypeTable.java
@@ -50,7 +50,7 @@ import com.sun.org.apache.bcel.internal.Const;
 //      u2 name_index;
 //      u2 signature_index;
 //      u2 index;
-//    } local_variable_type_table[local_variable_type_table_length];
+//    } localVariableTypeTable[local_variable_type_table_length];
 //  }
 // J5TODO: Needs some testing !
 
@@ -59,7 +59,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public class LocalVariableTypeTable extends Attribute {
 
-    private LocalVariable[] local_variable_type_table;        // variables
+    private LocalVariable[] localVariableTypeTable;        // variables
 
     public LocalVariableTypeTable(final LocalVariableTypeTable c) {
         this(c.getNameIndex(), c.getLength(), c.getLocalVariableTypeTable(), c.getConstantPool());
@@ -67,17 +67,17 @@ public class LocalVariableTypeTable extends Attribute {
 
     public LocalVariableTypeTable(final int name_index, final int length, final LocalVariable[] local_variable_table, final ConstantPool constant_pool) {
         super(Const.ATTR_LOCAL_VARIABLE_TYPE_TABLE, name_index, length, constant_pool);
-        this.local_variable_type_table = local_variable_table;
+        this.localVariableTypeTable = local_variable_table;
     }
 
     LocalVariableTypeTable(final int nameIdx, final int len, final DataInput input, final ConstantPool cpool) throws IOException {
         this(nameIdx, len, (LocalVariable[]) null, cpool);
 
         final int local_variable_type_table_length = input.readUnsignedShort();
-        local_variable_type_table = new LocalVariable[local_variable_type_table_length];
+        localVariableTypeTable = new LocalVariable[local_variable_type_table_length];
 
         for (int i = 0; i < local_variable_type_table_length; i++) {
-            local_variable_type_table[i] = new LocalVariable(input, cpool);
+            localVariableTypeTable[i] = new LocalVariable(input, cpool);
         }
     }
 
@@ -89,18 +89,18 @@ public class LocalVariableTypeTable extends Attribute {
     @Override
     public final void dump(final DataOutputStream file) throws IOException {
         super.dump(file);
-        file.writeShort(local_variable_type_table.length);
-        for (final LocalVariable variable : local_variable_type_table) {
+        file.writeShort(localVariableTypeTable.length);
+        for (final LocalVariable variable : localVariableTypeTable) {
             variable.dump(file);
         }
     }
 
     public final LocalVariable[] getLocalVariableTypeTable() {
-        return local_variable_type_table;
+        return localVariableTypeTable;
     }
 
     public final LocalVariable getLocalVariable(final int index) {
-        for (final LocalVariable variable : local_variable_type_table) {
+        for (final LocalVariable variable : localVariableTypeTable) {
             if (variable.getIndex() == index) {
                 return variable;
             }
@@ -110,7 +110,7 @@ public class LocalVariableTypeTable extends Attribute {
     }
 
     public final void setLocalVariableTable(final LocalVariable[] local_variable_table) {
-        this.local_variable_type_table = local_variable_table;
+        this.localVariableTypeTable = local_variable_table;
     }
 
     /**
@@ -120,10 +120,10 @@ public class LocalVariableTypeTable extends Attribute {
     public final String toString() {
         final StringBuilder buf = new StringBuilder();
 
-        for (int i = 0; i < local_variable_type_table.length; i++) {
-            buf.append(local_variable_type_table[i].toStringShared(true));
+        for (int i = 0; i < localVariableTypeTable.length; i++) {
+            buf.append(localVariableTypeTable[i].toStringShared(true));
 
-            if (i < local_variable_type_table.length - 1) {
+            if (i < localVariableTypeTable.length - 1) {
                 buf.append('\n');
             }
         }
@@ -138,9 +138,9 @@ public class LocalVariableTypeTable extends Attribute {
     public Attribute copy(final ConstantPool constant_pool) {
         final LocalVariableTypeTable c = (LocalVariableTypeTable) clone();
 
-        c.local_variable_type_table = new LocalVariable[local_variable_type_table.length];
-        for (int i = 0; i < local_variable_type_table.length; i++) {
-            c.local_variable_type_table[i] = local_variable_type_table[i].copy();
+        c.localVariableTypeTable = new LocalVariable[localVariableTypeTable.length];
+        for (int i = 0; i < localVariableTypeTable.length; i++) {
+            c.localVariableTypeTable[i] = localVariableTypeTable[i].copy();
         }
 
         c.setConstantPool(constant_pool);
@@ -148,6 +148,6 @@ public class LocalVariableTypeTable extends Attribute {
     }
 
     public final int getTableLength() {
-        return local_variable_type_table == null ? 0 : local_variable_type_table.length;
+        return localVariableTypeTable == null ? 0 : localVariableTypeTable.length;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/MethodParameter.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/MethodParameter.java
@@ -30,17 +30,17 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * Entry of the parameters table.
  *
- * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.24">
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.24">
  * The class File Format : The MethodParameters Attribute</a>
  * @since 6.0
  */
 public class MethodParameter implements Cloneable {
 
     /** Index of the CONSTANT_Utf8_info structure in the constant_pool table representing the name of the parameter */
-    private int name_index;
+    private int nameIndex;
 
     /** The access flags */
-    private int access_flags;
+    private int accessFlags;
 
     public MethodParameter() {
     }
@@ -53,46 +53,46 @@ public class MethodParameter implements Cloneable {
      * @throws ClassFormatException
      */
     MethodParameter(final DataInput input) throws IOException {
-        name_index = input.readUnsignedShort();
-        access_flags = input.readUnsignedShort();
+        nameIndex = input.readUnsignedShort();
+        accessFlags = input.readUnsignedShort();
     }
 
     public int getNameIndex() {
-        return name_index;
+        return nameIndex;
     }
 
     public void setNameIndex(final int name_index) {
-        this.name_index = name_index;
+        this.nameIndex = name_index;
     }
 
     /**
      * Returns the name of the parameter.
      */
     public String getParameterName(final ConstantPool constant_pool) {
-        if (name_index == 0) {
+        if (nameIndex == 0) {
             return null;
         }
-        return ((ConstantUtf8) constant_pool.getConstant(name_index, Const.CONSTANT_Utf8)).getBytes();
+        return ((ConstantUtf8) constant_pool.getConstant(nameIndex, Const.CONSTANT_Utf8)).getBytes();
        }
 
     public int getAccessFlags() {
-        return access_flags;
+        return accessFlags;
     }
 
     public void setAccessFlags(final int access_flags) {
-        this.access_flags = access_flags;
+        this.accessFlags = access_flags;
     }
 
     public boolean isFinal() {
-        return (access_flags & Const.ACC_FINAL) != 0;
+        return (accessFlags & Const.ACC_FINAL) != 0;
     }
 
     public boolean isSynthetic() {
-        return (access_flags & Const.ACC_SYNTHETIC) != 0;
+        return (accessFlags & Const.ACC_SYNTHETIC) != 0;
     }
 
     public boolean isMandated() {
-        return (access_flags & Const.ACC_MANDATED) != 0;
+        return (accessFlags & Const.ACC_MANDATED) != 0;
     }
 
     public void accept(final Visitor v) {
@@ -106,8 +106,8 @@ public class MethodParameter implements Cloneable {
      * @throws IOException
      */
     public final void dump(final DataOutputStream file) throws IOException {
-        file.writeShort(name_index);
-        file.writeShort(access_flags);
+        file.writeShort(nameIndex);
+        file.writeShort(accessFlags);
     }
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/MethodParameters.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/MethodParameters.java
@@ -30,7 +30,7 @@ import com.sun.org.apache.bcel.internal.Const;
 /**
  * This class represents a MethodParameters attribute.
  *
- * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.24">
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.24">
  * The class File Format : The MethodParameters Attribute</a>
  * @since 6.0
  */

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Module.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Module.java
@@ -28,7 +28,8 @@ import java.io.IOException;
 import com.sun.org.apache.bcel.internal.Const;
 
 /**
- * This class is derived from <em>Attribute</em> and represents the list of modules required, exported, opened or provided by a module.
+ * This class is derived from <em>Attribute</em> and represents the list of
+ * modules required, exported, opened or provided by a module.
  * There may be at most one Module attribute in a ClassFile structure.
  *
  * @see   Attribute
@@ -36,16 +37,16 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class Module extends Attribute {
 
-    private final int module_name_index;
-    private final int module_flags;
-    private final int module_version_index;
+    private final int moduleNameIndex;
+    private final int moduleFlags;
+    private final int moduleVersionIndex;
 
-    private ModuleRequires[] requires_table;
-    private ModuleExports[] exports_table;
-    private ModuleOpens[] opens_table;
-    private final int uses_count;
-    private final int[] uses_index;
-    private ModuleProvides[] provides_table;
+    private ModuleRequires[] requiresTable;
+    private ModuleExports[] exportsTable;
+    private ModuleOpens[] opensTable;
+    private final int usesCount;
+    private final int[] usesIndex;
+    private ModuleProvides[] providesTable;
 
     /**
      * Construct object from input stream.
@@ -58,38 +59,38 @@ public final class Module extends Attribute {
     Module(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
         super(Const.ATTR_MODULE, name_index, length, constant_pool);
 
-        module_name_index = input.readUnsignedShort();
-        module_flags = input.readUnsignedShort();
-        module_version_index = input.readUnsignedShort();
+        moduleNameIndex = input.readUnsignedShort();
+        moduleFlags = input.readUnsignedShort();
+        moduleVersionIndex = input.readUnsignedShort();
 
         final int requires_count = input.readUnsignedShort();
-        requires_table = new ModuleRequires[requires_count];
+        requiresTable = new ModuleRequires[requires_count];
         for (int i = 0; i < requires_count; i++) {
-            requires_table[i] = new ModuleRequires(input);
+            requiresTable[i] = new ModuleRequires(input);
         }
 
         final int exports_count = input.readUnsignedShort();
-        exports_table = new ModuleExports[exports_count];
+        exportsTable = new ModuleExports[exports_count];
         for (int i = 0; i < exports_count; i++) {
-            exports_table[i] = new ModuleExports(input);
+            exportsTable[i] = new ModuleExports(input);
         }
 
         final int opens_count = input.readUnsignedShort();
-        opens_table = new ModuleOpens[opens_count];
+        opensTable = new ModuleOpens[opens_count];
         for (int i = 0; i < opens_count; i++) {
-            opens_table[i] = new ModuleOpens(input);
+            opensTable[i] = new ModuleOpens(input);
         }
 
-        uses_count = input.readUnsignedShort();
-        uses_index = new int[uses_count];
-        for (int i = 0; i < uses_count; i++) {
-            uses_index[i] = input.readUnsignedShort();
+        usesCount = input.readUnsignedShort();
+        usesIndex = new int[usesCount];
+        for (int i = 0; i < usesCount; i++) {
+            usesIndex[i] = input.readUnsignedShort();
         }
 
         final int provides_count = input.readUnsignedShort();
-        provides_table = new ModuleProvides[provides_count];
+        providesTable = new ModuleProvides[provides_count];
         for (int i = 0; i < provides_count; i++) {
-            provides_table[i] = new ModuleProvides(input);
+            providesTable[i] = new ModuleProvides(input);
         }
     }
 
@@ -113,7 +114,7 @@ public final class Module extends Attribute {
      * @see ModuleRequires
      */
     public ModuleRequires[] getRequiresTable() {
-        return requires_table;
+        return requiresTable;
     }
 
 
@@ -122,7 +123,7 @@ public final class Module extends Attribute {
      * @see ModuleExports
      */
     public ModuleExports[] getExportsTable() {
-        return exports_table;
+        return exportsTable;
     }
 
 
@@ -131,7 +132,7 @@ public final class Module extends Attribute {
      * @see ModuleOpens
      */
     public ModuleOpens[] getOpensTable() {
-        return opens_table;
+        return opensTable;
     }
 
 
@@ -140,7 +141,7 @@ public final class Module extends Attribute {
      * @see ModuleProvides
      */
     public ModuleProvides[] getProvidesTable() {
-        return provides_table;
+        return providesTable;
     }
 
 
@@ -154,32 +155,32 @@ public final class Module extends Attribute {
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
 
-        file.writeShort(module_name_index);
-        file.writeShort(module_flags);
-        file.writeShort(module_version_index);
+        file.writeShort(moduleNameIndex);
+        file.writeShort(moduleFlags);
+        file.writeShort(moduleVersionIndex);
 
-        file.writeShort(requires_table.length);
-        for (final ModuleRequires entry : requires_table) {
+        file.writeShort(requiresTable.length);
+        for (final ModuleRequires entry : requiresTable) {
             entry.dump(file);
         }
 
-        file.writeShort(exports_table.length);
-        for (final ModuleExports entry : exports_table) {
+        file.writeShort(exportsTable.length);
+        for (final ModuleExports entry : exportsTable) {
             entry.dump(file);
         }
 
-        file.writeShort(opens_table.length);
-        for (final ModuleOpens entry : opens_table) {
+        file.writeShort(opensTable.length);
+        for (final ModuleOpens entry : opensTable) {
             entry.dump(file);
         }
 
-        file.writeShort(uses_index.length);
-        for (final int entry : uses_index) {
+        file.writeShort(usesIndex.length);
+        for (final int entry : usesIndex) {
             file.writeShort(entry);
         }
 
-        file.writeShort(provides_table.length);
-        for (final ModuleProvides entry : provides_table) {
+        file.writeShort(providesTable.length);
+        for (final ModuleProvides entry : providesTable) {
             entry.dump(file);
         }
     }
@@ -193,34 +194,34 @@ public final class Module extends Attribute {
         final ConstantPool cp = super.getConstantPool();
         final StringBuilder buf = new StringBuilder();
         buf.append("Module:\n");
-        buf.append("  name:    ") .append(cp.getConstantString(module_name_index, Const.CONSTANT_Module).replace('/', '.')).append("\n");
-        buf.append("  flags:   ") .append(String.format("%04x", module_flags)).append("\n");
-        final String version = module_version_index == 0 ? "0" : cp.getConstantString(module_version_index, Const.CONSTANT_Utf8);
+        buf.append("  name:    ") .append(cp.getConstantString(moduleNameIndex, Const.CONSTANT_Module).replace('/', '.')).append("\n");
+        buf.append("  flags:   ") .append(String.format("%04x", moduleFlags)).append("\n");
+        final String version = moduleVersionIndex == 0 ? "0" : cp.getConstantString(moduleVersionIndex, Const.CONSTANT_Utf8);
         buf.append("  version: ") .append(version).append("\n");
 
-        buf.append("  requires(").append(requires_table.length).append("):\n");
-        for (final ModuleRequires module : requires_table) {
+        buf.append("  requires(").append(requiresTable.length).append("):\n");
+        for (final ModuleRequires module : requiresTable) {
             buf.append("    ").append(module.toString(cp)).append("\n");
         }
 
-        buf.append("  exports(").append(exports_table.length).append("):\n");
-        for (final ModuleExports module : exports_table) {
+        buf.append("  exports(").append(exportsTable.length).append("):\n");
+        for (final ModuleExports module : exportsTable) {
             buf.append("    ").append(module.toString(cp)).append("\n");
         }
 
-        buf.append("  opens(").append(opens_table.length).append("):\n");
-        for (final ModuleOpens module : opens_table) {
+        buf.append("  opens(").append(opensTable.length).append("):\n");
+        for (final ModuleOpens module : opensTable) {
             buf.append("    ").append(module.toString(cp)).append("\n");
         }
 
-        buf.append("  uses(").append(uses_index.length).append("):\n");
-        for (final int index : uses_index) {
+        buf.append("  uses(").append(usesIndex.length).append("):\n");
+        for (final int index : usesIndex) {
             final String class_name = cp.getConstantString(index, Const.CONSTANT_Class);
             buf.append("    ").append(Utility.compactClassName(class_name, false)).append("\n");
         }
 
-        buf.append("  provides(").append(provides_table.length).append("):\n");
-        for (final ModuleProvides module : provides_table) {
+        buf.append("  provides(").append(providesTable.length).append("):\n");
+        for (final ModuleProvides module : providesTable) {
             buf.append("    ").append(module.toString(cp)).append("\n");
         }
 
@@ -235,24 +236,24 @@ public final class Module extends Attribute {
     public Attribute copy( final ConstantPool _constant_pool ) {
         final Module c = (Module) clone();
 
-        c.requires_table = new ModuleRequires[requires_table.length];
-        for (int i = 0; i < requires_table.length; i++) {
-            c.requires_table[i] = requires_table[i].copy();
+        c.requiresTable = new ModuleRequires[requiresTable.length];
+        for (int i = 0; i < requiresTable.length; i++) {
+            c.requiresTable[i] = requiresTable[i].copy();
         }
 
-        c.exports_table = new ModuleExports[exports_table.length];
-        for (int i = 0; i < exports_table.length; i++) {
-            c.exports_table[i] = exports_table[i].copy();
+        c.exportsTable = new ModuleExports[exportsTable.length];
+        for (int i = 0; i < exportsTable.length; i++) {
+            c.exportsTable[i] = exportsTable[i].copy();
         }
 
-        c.opens_table = new ModuleOpens[opens_table.length];
-        for (int i = 0; i < opens_table.length; i++) {
-            c.opens_table[i] = opens_table[i].copy();
+        c.opensTable = new ModuleOpens[opensTable.length];
+        for (int i = 0; i < opensTable.length; i++) {
+            c.opensTable[i] = opensTable[i].copy();
         }
 
-        c.provides_table = new ModuleProvides[provides_table.length];
-        for (int i = 0; i < provides_table.length; i++) {
-            c.provides_table[i] = provides_table[i].copy();
+        c.providesTable = new ModuleProvides[providesTable.length];
+        for (int i = 0; i < providesTable.length; i++) {
+            c.providesTable[i] = providesTable[i].copy();
         }
 
         c.setConstantPool(_constant_pool);

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleExports.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleExports.java
@@ -36,10 +36,10 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ModuleExports implements Cloneable, Node {
 
-    private final int exports_index;  // points to CONSTANT_Package_info
-    private final int exports_flags;
-    private final int exports_to_count;
-    private final int[] exports_to_index;  // points to CONSTANT_Module_info
+    private final int exportsIndex;  // points to CONSTANT_Package_info
+    private final int exportsFlags;
+    private final int exportsToCount;
+    private final int[] exportsToIndex;  // points to CONSTANT_Module_info
 
 
     /**
@@ -49,12 +49,12 @@ public final class ModuleExports implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in readUnsignedShort
      */
     ModuleExports(final DataInput file) throws IOException {
-        exports_index = file.readUnsignedShort();
-        exports_flags = file.readUnsignedShort();
-        exports_to_count = file.readUnsignedShort();
-        exports_to_index = new int[exports_to_count];
-        for (int i = 0; i < exports_to_count; i++) {
-            exports_to_index[i] = file.readUnsignedShort();
+        exportsIndex = file.readUnsignedShort();
+        exportsFlags = file.readUnsignedShort();
+        exportsToCount = file.readUnsignedShort();
+        exportsToIndex = new int[exportsToCount];
+        for (int i = 0; i < exportsToCount; i++) {
+            exportsToIndex[i] = file.readUnsignedShort();
         }
     }
 
@@ -80,10 +80,10 @@ public final class ModuleExports implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in writeShort
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(exports_index);
-        file.writeShort(exports_flags);
-        file.writeShort(exports_to_count);
-        for (final int entry : exports_to_index) {
+        file.writeShort(exportsIndex);
+        file.writeShort(exportsFlags);
+        file.writeShort(exportsToCount);
+        for (final int entry : exportsToIndex) {
             file.writeShort(entry);
         }
     }
@@ -94,7 +94,7 @@ public final class ModuleExports implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "exports(" + exports_index + ", " + exports_flags + ", " + exports_to_count + ", ...)";
+        return "exports(" + exportsIndex + ", " + exportsFlags + ", " + exportsToCount + ", ...)";
     }
 
 
@@ -103,11 +103,11 @@ public final class ModuleExports implements Cloneable, Node {
      */
     public String toString( final ConstantPool constant_pool ) {
         final StringBuilder buf = new StringBuilder();
-        final String package_name = constant_pool.constantToString(exports_index, Const.CONSTANT_Package);
+        final String package_name = constant_pool.constantToString(exportsIndex, Const.CONSTANT_Package);
         buf.append(Utility.compactClassName(package_name, false));
-        buf.append(", ").append(String.format("%04x", exports_flags));
-        buf.append(", to(").append(exports_to_count).append("):\n");
-        for (final int index : exports_to_index) {
+        buf.append(", ").append(String.format("%04x", exportsFlags));
+        buf.append(", to(").append(exportsToCount).append("):\n");
+        for (final int index : exportsToIndex) {
             final String module_name = constant_pool.getConstantString(index, Const.CONSTANT_Module);
             buf.append("      ").append(Utility.compactClassName(module_name, false)).append("\n");
         }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleMainClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleMainClass.java
@@ -35,7 +35,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ModuleMainClass extends Attribute {
 
-    private int main_class_index;
+    private int mainClassIndex;
 
 
     /**
@@ -50,27 +50,27 @@ public final class ModuleMainClass extends Attribute {
     /**
      * @param name_index Index in constant pool
      * @param length Content length in bytes
-     * @param main_class_index Host class index
-     * @param constant_pool Array of constants
+     * @param mainClassIndex Host class index
+     * @param constantPool Array of constants
      */
-    public ModuleMainClass(final int name_index, final int length, final int main_class_index,
-            final ConstantPool constant_pool) {
-        super(Const.ATTR_NEST_MEMBERS, name_index, length, constant_pool);
-        this.main_class_index = main_class_index;
+    public ModuleMainClass(final int name_index, final int length, final int mainClassIndex,
+            final ConstantPool constantPool) {
+        super(Const.ATTR_NEST_MEMBERS, name_index, length, constantPool);
+        this.mainClassIndex = mainClassIndex;
     }
 
 
     /**
      * Construct object from input stream.
-     * @param name_index Index in constant pool
+     * @param nameIndex Index in constant pool
      * @param length Content length in bytes
      * @param input Input stream
-     * @param constant_pool Array of constants
+     * @param constantPool Array of constants
      * @throws IOException
      */
-    ModuleMainClass(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
-        this(name_index, length, 0, constant_pool);
-        main_class_index = input.readUnsignedShort();
+    ModuleMainClass(final int nameIndex, final int length, final DataInput input, final ConstantPool constantPool) throws IOException {
+        this(nameIndex, length, 0, constantPool);
+        mainClassIndex = input.readUnsignedShort();
     }
 
 
@@ -96,7 +96,7 @@ public final class ModuleMainClass extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(main_class_index);
+        file.writeShort(mainClassIndex);
     }
 
 
@@ -104,15 +104,15 @@ public final class ModuleMainClass extends Attribute {
      * @return index into constant pool of host class name.
      */
     public int getHostClassIndex() {
-        return main_class_index;
+        return mainClassIndex;
     }
 
 
     /**
-     * @param main_class_index the host class index
+     * @param mainClassIndex the host class index
      */
-    public void setHostClassIndex( final int main_class_index ) {
-        this.main_class_index = main_class_index;
+    public void setHostClassIndex( final int mainClassIndex ) {
+        this.mainClassIndex = mainClassIndex;
     }
 
 
@@ -123,7 +123,7 @@ public final class ModuleMainClass extends Attribute {
     public String toString() {
         final StringBuilder buf = new StringBuilder();
         buf.append("ModuleMainClass: ");
-        final String class_name = super.getConstantPool().getConstantString(main_class_index, Const.CONSTANT_Class);
+        final String class_name = super.getConstantPool().getConstantString(mainClassIndex, Const.CONSTANT_Class);
         buf.append(Utility.compactClassName(class_name, false));
         return buf.toString();
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleOpens.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleOpens.java
@@ -36,10 +36,10 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ModuleOpens implements Cloneable, Node {
 
-    private final int opens_index;  // points to CONSTANT_Package_info
-    private final int opens_flags;
-    private final int opens_to_count;
-    private final int[] opens_to_index;  // points to CONSTANT_Module_info
+    private final int opensIndex;  // points to CONSTANT_Package_info
+    private final int opensFlags;
+    private final int opensToCount;
+    private final int[] opensToIndex;  // points to CONSTANT_Module_info
 
 
     /**
@@ -49,12 +49,12 @@ public final class ModuleOpens implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in readUnsignedShort
      */
     ModuleOpens(final DataInput file) throws IOException {
-        opens_index = file.readUnsignedShort();
-        opens_flags = file.readUnsignedShort();
-        opens_to_count = file.readUnsignedShort();
-        opens_to_index = new int[opens_to_count];
-        for (int i = 0; i < opens_to_count; i++) {
-            opens_to_index[i] = file.readUnsignedShort();
+        opensIndex = file.readUnsignedShort();
+        opensFlags = file.readUnsignedShort();
+        opensToCount = file.readUnsignedShort();
+        opensToIndex = new int[opensToCount];
+        for (int i = 0; i < opensToCount; i++) {
+            opensToIndex[i] = file.readUnsignedShort();
         }
     }
 
@@ -80,10 +80,10 @@ public final class ModuleOpens implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in writeShort
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(opens_index);
-        file.writeShort(opens_flags);
-        file.writeShort(opens_to_count);
-        for (final int entry : opens_to_index) {
+        file.writeShort(opensIndex);
+        file.writeShort(opensFlags);
+        file.writeShort(opensToCount);
+        for (final int entry : opensToIndex) {
             file.writeShort(entry);
         }
     }
@@ -94,7 +94,7 @@ public final class ModuleOpens implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "opens(" + opens_index + ", " + opens_flags + ", " + opens_to_count + ", ...)";
+        return "opens(" + opensIndex + ", " + opensFlags + ", " + opensToCount + ", ...)";
     }
 
 
@@ -103,11 +103,11 @@ public final class ModuleOpens implements Cloneable, Node {
      */
     public String toString( final ConstantPool constant_pool ) {
         final StringBuilder buf = new StringBuilder();
-        final String package_name = constant_pool.constantToString(opens_index, Const.CONSTANT_Package);
+        final String package_name = constant_pool.constantToString(opensIndex, Const.CONSTANT_Package);
         buf.append(Utility.compactClassName(package_name, false));
-        buf.append(", ").append(String.format("%04x", opens_flags));
-        buf.append(", to(").append(opens_to_count).append("):\n");
-        for (final int index : opens_to_index) {
+        buf.append(", ").append(String.format("%04x", opensFlags));
+        buf.append(", to(").append(opensToCount).append("):\n");
+        for (final int index : opensToIndex) {
             final String module_name = constant_pool.getConstantString(index, Const.CONSTANT_Module);
             buf.append("      ").append(Utility.compactClassName(module_name, false)).append("\n");
         }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModulePackages.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModulePackages.java
@@ -35,7 +35,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ModulePackages extends Attribute {
 
-    private int[] package_index_table;
+    private int[] packageIndexTable;
 
 
     /**
@@ -48,15 +48,15 @@ public final class ModulePackages extends Attribute {
 
 
     /**
-     * @param name_index Index in constant pool
+     * @param nameIndex Index in constant pool
      * @param length Content length in bytes
-     * @param package_index_table Table of indices in constant pool
-     * @param constant_pool Array of constants
+     * @param packageIndexTable Table of indices in constant pool
+     * @param constantPool Array of constants
      */
-    public ModulePackages(final int name_index, final int length, final int[] package_index_table,
-            final ConstantPool constant_pool) {
-        super(Const.ATTR_MODULE_PACKAGES, name_index, length, constant_pool);
-        this.package_index_table = package_index_table != null ? package_index_table : new int[0];
+    public ModulePackages(final int nameIndex, final int length, final int[] packageIndexTable,
+            final ConstantPool constantPool) {
+        super(Const.ATTR_MODULE_PACKAGES, nameIndex, length, constantPool);
+        this.packageIndexTable = packageIndexTable != null ? packageIndexTable : new int[0];
     }
 
 
@@ -71,9 +71,9 @@ public final class ModulePackages extends Attribute {
     ModulePackages(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
         this(name_index, length, (int[]) null, constant_pool);
         final int number_of_packages = input.readUnsignedShort();
-        package_index_table = new int[number_of_packages];
+        packageIndexTable = new int[number_of_packages];
         for (int i = 0; i < number_of_packages; i++) {
-            package_index_table[i] = input.readUnsignedShort();
+            packageIndexTable[i] = input.readUnsignedShort();
         }
     }
 
@@ -100,8 +100,8 @@ public final class ModulePackages extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(package_index_table.length);
-        for (final int index : package_index_table) {
+        file.writeShort(packageIndexTable.length);
+        for (final int index : packageIndexTable) {
             file.writeShort(index);
         }
     }
@@ -111,7 +111,7 @@ public final class ModulePackages extends Attribute {
      * @return array of indices into constant pool of package names.
      */
     public int[] getPackageIndexTable() {
-        return package_index_table;
+        return packageIndexTable;
     }
 
 
@@ -119,7 +119,7 @@ public final class ModulePackages extends Attribute {
      * @return Length of package table.
      */
     public int getNumberOfPackages() {
-        return package_index_table == null ? 0 : package_index_table.length;
+        return packageIndexTable == null ? 0 : packageIndexTable.length;
     }
 
 
@@ -127,9 +127,9 @@ public final class ModulePackages extends Attribute {
      * @return string array of package names
      */
     public String[] getPackageNames() {
-        final String[] names = new String[package_index_table.length];
-        for (int i = 0; i < package_index_table.length; i++) {
-            names[i] = super.getConstantPool().getConstantString(package_index_table[i],
+        final String[] names = new String[packageIndexTable.length];
+        for (int i = 0; i < packageIndexTable.length; i++) {
+            names[i] = super.getConstantPool().getConstantString(packageIndexTable[i],
                     Const.CONSTANT_Package).replace('/', '.');
         }
         return names;
@@ -137,11 +137,11 @@ public final class ModulePackages extends Attribute {
 
 
     /**
-     * @param package_index_table the list of package indexes
+     * @param packageIndexTable the list of package indexes
      * Also redefines number_of_packages according to table length.
      */
-    public void setPackageIndexTable( final int[] package_index_table ) {
-        this.package_index_table = package_index_table != null ? package_index_table : new int[0];
+    public void setPackageIndexTable( final int[] packageIndexTable ) {
+        this.packageIndexTable = packageIndexTable != null ? packageIndexTable : new int[0];
     }
 
 
@@ -152,9 +152,9 @@ public final class ModulePackages extends Attribute {
     public String toString() {
         final StringBuilder buf = new StringBuilder();
         buf.append("ModulePackages(");
-        buf.append(package_index_table.length);
+        buf.append(packageIndexTable.length);
         buf.append("):\n");
-        for (final int index : package_index_table) {
+        for (final int index : packageIndexTable) {
             final String package_name = super.getConstantPool().getConstantString(index, Const.CONSTANT_Package);
             buf.append("  ").append(Utility.compactClassName(package_name, false)).append("\n");
         }
@@ -168,10 +168,10 @@ public final class ModulePackages extends Attribute {
     @Override
     public Attribute copy( final ConstantPool _constant_pool ) {
         final ModulePackages c = (ModulePackages) clone();
-        if (package_index_table != null) {
-            c.package_index_table = new int[package_index_table.length];
-            System.arraycopy(package_index_table, 0, c.package_index_table, 0,
-                    package_index_table.length);
+        if (packageIndexTable != null) {
+            c.packageIndexTable = new int[packageIndexTable.length];
+            System.arraycopy(packageIndexTable, 0, c.packageIndexTable, 0,
+                    packageIndexTable.length);
         }
         c.setConstantPool(_constant_pool);
         return c;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleProvides.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleProvides.java
@@ -36,9 +36,9 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ModuleProvides implements Cloneable, Node {
 
-    private final int provides_index;  // points to CONSTANT_Class_info
-    private final int provides_with_count;
-    private final int[] provides_with_index;  // points to CONSTANT_Class_info
+    private final int providesIndex;  // points to CONSTANT_Class_info
+    private final int providesWithCount;
+    private final int[] providesWithIndex;  // points to CONSTANT_Class_info
 
 
     /**
@@ -48,11 +48,11 @@ public final class ModuleProvides implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in readUnsignedShort
      */
     ModuleProvides(final DataInput file) throws IOException {
-        provides_index = file.readUnsignedShort();
-        provides_with_count = file.readUnsignedShort();
-        provides_with_index = new int[provides_with_count];
-        for (int i = 0; i < provides_with_count; i++) {
-            provides_with_index[i] = file.readUnsignedShort();
+        providesIndex = file.readUnsignedShort();
+        providesWithCount = file.readUnsignedShort();
+        providesWithIndex = new int[providesWithCount];
+        for (int i = 0; i < providesWithCount; i++) {
+            providesWithIndex[i] = file.readUnsignedShort();
         }
     }
 
@@ -78,9 +78,9 @@ public final class ModuleProvides implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in writeShort
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(provides_index);
-        file.writeShort(provides_with_count);
-        for (final int entry : provides_with_index) {
+        file.writeShort(providesIndex);
+        file.writeShort(providesWithCount);
+        for (final int entry : providesWithIndex) {
             file.writeShort(entry);
         }
     }
@@ -91,7 +91,7 @@ public final class ModuleProvides implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "provides(" + provides_index + ", " + provides_with_count + ", ...)";
+        return "provides(" + providesIndex + ", " + providesWithCount + ", ...)";
     }
 
 
@@ -100,10 +100,10 @@ public final class ModuleProvides implements Cloneable, Node {
      */
     public String toString( final ConstantPool constant_pool ) {
         final StringBuilder buf = new StringBuilder();
-        final String interface_name = constant_pool.constantToString(provides_index, Const.CONSTANT_Class);
+        final String interface_name = constant_pool.constantToString(providesIndex, Const.CONSTANT_Class);
         buf.append(Utility.compactClassName(interface_name, false));
-        buf.append(", with(").append(provides_with_count).append("):\n");
-        for (final int index : provides_with_index) {
+        buf.append(", with(").append(providesWithCount).append("):\n");
+        for (final int index : providesWithIndex) {
             final String class_name = constant_pool.getConstantString(index, Const.CONSTANT_Class);
             buf.append("      ").append(Utility.compactClassName(class_name, false)).append("\n");
         }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleRequires.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ModuleRequires.java
@@ -36,9 +36,9 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class ModuleRequires implements Cloneable, Node {
 
-    private final int requires_index;  // points to CONSTANT_Module_info
-    private final int requires_flags;
-    private final int requires_version_index;  // either 0 or points to CONSTANT_Utf8_info
+    private final int requiresIndex;  // points to CONSTANT_Module_info
+    private final int requiresFlags;
+    private final int requiresVersionIndex;  // either 0 or points to CONSTANT_Utf8_info
 
 
     /**
@@ -48,9 +48,9 @@ public final class ModuleRequires implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in readUnsignedShort
      */
     ModuleRequires(final DataInput file) throws IOException {
-        requires_index = file.readUnsignedShort();
-        requires_flags = file.readUnsignedShort();
-        requires_version_index = file.readUnsignedShort();
+        requiresIndex = file.readUnsignedShort();
+        requiresFlags = file.readUnsignedShort();
+        requiresVersionIndex = file.readUnsignedShort();
     }
 
 
@@ -75,9 +75,9 @@ public final class ModuleRequires implements Cloneable, Node {
      * @throws IOException if an I/O Exception occurs in writeShort
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.writeShort(requires_index);
-        file.writeShort(requires_flags);
-        file.writeShort(requires_version_index);
+        file.writeShort(requiresIndex);
+        file.writeShort(requiresFlags);
+        file.writeShort(requiresVersionIndex);
     }
 
 
@@ -86,7 +86,7 @@ public final class ModuleRequires implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "requires(" + requires_index + ", " + String.format("%04x", requires_flags) + ", " + requires_version_index + ")";
+        return "requires(" + requiresIndex + ", " + String.format("%04x", requiresFlags) + ", " + requiresVersionIndex + ")";
     }
 
 
@@ -95,10 +95,10 @@ public final class ModuleRequires implements Cloneable, Node {
      */
     public String toString( final ConstantPool constant_pool ) {
         final StringBuilder buf = new StringBuilder();
-        final String module_name = constant_pool.constantToString(requires_index, Const.CONSTANT_Module);
+        final String module_name = constant_pool.constantToString(requiresIndex, Const.CONSTANT_Module);
         buf.append(Utility.compactClassName(module_name, false));
-        buf.append(", ").append(String.format("%04x", requires_flags));
-        final String version = requires_version_index == 0 ? "0" : constant_pool.getConstantString(requires_version_index, Const.CONSTANT_Utf8);
+        buf.append(", ").append(String.format("%04x", requiresFlags));
+        final String version = requiresVersionIndex == 0 ? "0" : constant_pool.getConstantString(requiresVersionIndex, Const.CONSTANT_Utf8);
         buf.append(", ").append(version);
         return buf.toString();
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/NestHost.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/NestHost.java
@@ -36,7 +36,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class NestHost extends Attribute {
 
-    private int host_class_index;
+    private int hostClassIndex;
 
 
     /**
@@ -49,15 +49,15 @@ public final class NestHost extends Attribute {
 
 
     /**
-     * @param name_index Index in constant pool
+     * @param nameIndex Index in constant pool
      * @param length Content length in bytes
-     * @param host_class_index Host class index
-     * @param constant_pool Array of constants
+     * @param hostClassIndex Host class index
+     * @param constantPool Array of constants
      */
-    public NestHost(final int name_index, final int length, final int host_class_index,
-            final ConstantPool constant_pool) {
-        super(Const.ATTR_NEST_MEMBERS, name_index, length, constant_pool);
-        this.host_class_index = host_class_index;
+    public NestHost(final int nameIndex, final int length, final int hostClassIndex,
+            final ConstantPool constantPool) {
+        super(Const.ATTR_NEST_MEMBERS, nameIndex, length, constantPool);
+        this.hostClassIndex = hostClassIndex;
     }
 
 
@@ -71,7 +71,7 @@ public final class NestHost extends Attribute {
      */
     NestHost(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
         this(name_index, length, 0, constant_pool);
-        host_class_index = input.readUnsignedShort();
+        hostClassIndex = input.readUnsignedShort();
     }
 
 
@@ -97,7 +97,7 @@ public final class NestHost extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(host_class_index);
+        file.writeShort(hostClassIndex);
     }
 
 
@@ -105,15 +105,15 @@ public final class NestHost extends Attribute {
      * @return index into constant pool of host class name.
      */
     public int getHostClassIndex() {
-        return host_class_index;
+        return hostClassIndex;
     }
 
 
     /**
-     * @param host_class_index the host class index
+     * @param hostClassIndex the host class index
      */
-    public void setHostClassIndex( final int host_class_index ) {
-        this.host_class_index = host_class_index;
+    public void setHostClassIndex( final int hostClassIndex ) {
+        this.hostClassIndex = hostClassIndex;
     }
 
 
@@ -124,7 +124,7 @@ public final class NestHost extends Attribute {
     public String toString() {
         final StringBuilder buf = new StringBuilder();
         buf.append("NestHost: ");
-        final String class_name = super.getConstantPool().getConstantString(host_class_index, Const.CONSTANT_Class);
+        final String class_name = super.getConstantPool().getConstantString(hostClassIndex, Const.CONSTANT_Class);
         buf.append(Utility.compactClassName(class_name, false));
         return buf.toString();
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/PMGClass.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/PMGClass.java
@@ -35,17 +35,17 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class PMGClass extends Attribute {
 
-    private int pmg_class_index;
-    private int pmg_index;
+    private int pmgClassIndex;
+    private int pmgIndex;
 
 
     /**
      * Initialize from another object. Note that both objects use the same
      * references (shallow copy). Use copy() for a physical copy.
      */
-    public PMGClass(final PMGClass c) {
-        this(c.getNameIndex(), c.getLength(), c.getPMGIndex(), c.getPMGClassIndex(), c
-                .getConstantPool());
+    public PMGClass(final PMGClass pgmClass) {
+        this(pgmClass.getNameIndex(), pgmClass.getLength(), pgmClass.getPMGIndex(), pgmClass.getPMGClassIndex(),
+            pgmClass.getConstantPool());
     }
 
 
@@ -66,15 +66,15 @@ public final class PMGClass extends Attribute {
     /**
      * @param name_index Index in constant pool to CONSTANT_Utf8
      * @param length Content length in bytes
-     * @param pmg_index index in constant pool for source file name
-     * @param pmg_class_index Index in constant pool to CONSTANT_Utf8
-     * @param constant_pool Array of constants
+     * @param pmgIndex index in constant pool for source file name
+     * @param pmgClassIndex Index in constant pool to CONSTANT_Utf8
+     * @param constantPool Array of constants
      */
-    public PMGClass(final int name_index, final int length, final int pmg_index, final int pmg_class_index,
-            final ConstantPool constant_pool) {
-        super(Const.ATTR_PMG, name_index, length, constant_pool);
-        this.pmg_index = pmg_index;
-        this.pmg_class_index = pmg_class_index;
+    public PMGClass(final int name_index, final int length, final int pmgIndex, final int pmgClassIndex,
+            final ConstantPool constantPool) {
+        super(Const.ATTR_PMG, name_index, length, constantPool);
+        this.pmgIndex = pmgIndex;
+        this.pmgClassIndex = pmgClassIndex;
     }
 
 
@@ -100,8 +100,8 @@ public final class PMGClass extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(pmg_index);
-        file.writeShort(pmg_class_index);
+        file.writeShort(pmgIndex);
+        file.writeShort(pmgClassIndex);
     }
 
 
@@ -109,15 +109,15 @@ public final class PMGClass extends Attribute {
      * @return Index in constant pool of source file name.
      */
     public int getPMGClassIndex() {
-        return pmg_class_index;
+        return pmgClassIndex;
     }
 
 
     /**
-     * @param pmg_class_index
+     * @param pmgClassIndex
      */
-    public void setPMGClassIndex( final int pmg_class_index ) {
-        this.pmg_class_index = pmg_class_index;
+    public void setPMGClassIndex( final int pmgClassIndex ) {
+        this.pmgClassIndex = pmgClassIndex;
     }
 
 
@@ -125,15 +125,15 @@ public final class PMGClass extends Attribute {
      * @return Index in constant pool of source file name.
      */
     public int getPMGIndex() {
-        return pmg_index;
+        return pmgIndex;
     }
 
 
     /**
-     * @param pmg_index
+     * @param pmgIndex
      */
-    public void setPMGIndex( final int pmg_index ) {
-        this.pmg_index = pmg_index;
+    public void setPMGIndex( final int pmgIndex ) {
+        this.pmgIndex = pmgIndex;
     }
 
 
@@ -141,7 +141,7 @@ public final class PMGClass extends Attribute {
      * @return PMG name.
      */
     public String getPMGName() {
-        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(pmg_index,
+        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(pmgIndex,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
     }
@@ -151,7 +151,7 @@ public final class PMGClass extends Attribute {
      * @return PMG class name.
      */
     public String getPMGClassName() {
-        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(pmg_class_index,
+        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(pmgClassIndex,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotationEntry.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotationEntry.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class ParameterAnnotationEntry implements Node {
 
-    private final AnnotationEntry[] annotation_table;
+    private final AnnotationEntry[] annotationTable;
 
 
     /**
@@ -46,10 +46,10 @@ public class ParameterAnnotationEntry implements Node {
      */
     ParameterAnnotationEntry(final DataInput input, final ConstantPool constant_pool) throws IOException {
         final int annotation_table_length = input.readUnsignedShort();
-        annotation_table = new AnnotationEntry[annotation_table_length];
+        annotationTable = new AnnotationEntry[annotation_table_length];
         for (int i = 0; i < annotation_table_length; i++) {
             // TODO isRuntimeVisible
-            annotation_table[i] = AnnotationEntry.read(input, constant_pool, false);
+            annotationTable[i] = AnnotationEntry.read(input, constant_pool, false);
         }
     }
 
@@ -70,12 +70,12 @@ public class ParameterAnnotationEntry implements Node {
      * returns the array of annotation entries in this annotation
      */
     public AnnotationEntry[] getAnnotationEntries() {
-        return annotation_table;
+        return annotationTable;
     }
 
     public void dump(final DataOutputStream dos) throws IOException {
-        dos.writeShort(annotation_table.length);
-        for (final AnnotationEntry entry : annotation_table) {
+        dos.writeShort(annotationTable.length);
+        for (final AnnotationEntry entry : annotationTable) {
             entry.dump(dos);
         }
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotations.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ParameterAnnotations.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 public abstract class ParameterAnnotations extends Attribute {
 
     /** Table of parameter annotations */
-    private ParameterAnnotationEntry[] parameter_annotation_table;
+    private ParameterAnnotationEntry[] parameterAnnotationTable;
 
     /**
      * @param parameter_annotation_type the subclass type of the parameter annotation
@@ -47,24 +47,24 @@ public abstract class ParameterAnnotations extends Attribute {
         this(parameter_annotation_type, name_index, length, (ParameterAnnotationEntry[]) null,
                 constant_pool);
         final int num_parameters = input.readUnsignedByte();
-        parameter_annotation_table = new ParameterAnnotationEntry[num_parameters];
+        parameterAnnotationTable = new ParameterAnnotationEntry[num_parameters];
         for (int i = 0; i < num_parameters; i++) {
-            parameter_annotation_table[i] = new ParameterAnnotationEntry(input, constant_pool);
+            parameterAnnotationTable[i] = new ParameterAnnotationEntry(input, constant_pool);
         }
     }
 
 
     /**
-     * @param parameter_annotation_type the subclass type of the parameter annotation
-     * @param name_index Index pointing to the name <em>Code</em>
+     * @param parameterAnnotationType the subclass type of the parameter annotation
+     * @param nameIndex Index pointing to the name <em>Code</em>
      * @param length Content length in bytes
-     * @param parameter_annotation_table the actual parameter annotations
-     * @param constant_pool Array of constants
+     * @param parameterAnnotationTable the actual parameter annotations
+     * @param constantPool Array of constants
      */
-    public ParameterAnnotations(final byte parameter_annotation_type, final int name_index, final int length,
-            final ParameterAnnotationEntry[] parameter_annotation_table, final ConstantPool constant_pool) {
-        super(parameter_annotation_type, name_index, length, constant_pool);
-        this.parameter_annotation_table = parameter_annotation_table;
+    public ParameterAnnotations(final byte parameterAnnotationType, final int nameIndex, final int length,
+            final ParameterAnnotationEntry[] parameterAnnotationTable, final ConstantPool constantPool) {
+        super(parameterAnnotationType, nameIndex, length, constantPool);
+        this.parameterAnnotationTable = parameterAnnotationTable;
     }
 
 
@@ -82,10 +82,10 @@ public abstract class ParameterAnnotations extends Attribute {
 
 
     /**
-     * @param parameter_annotation_table the entries to set in this parameter annotation
+     * @param parameterAnnotationTable the entries to set in this parameter annotation
      */
-    public final void setParameterAnnotationTable(final ParameterAnnotationEntry[] parameter_annotation_table ) {
-        this.parameter_annotation_table = parameter_annotation_table;
+    public final void setParameterAnnotationTable(final ParameterAnnotationEntry[] parameterAnnotationTable ) {
+        this.parameterAnnotationTable = parameterAnnotationTable;
     }
 
 
@@ -93,7 +93,7 @@ public abstract class ParameterAnnotations extends Attribute {
      * @return the parameter annotation entry table
      */
     public final ParameterAnnotationEntry[] getParameterAnnotationTable() {
-        return parameter_annotation_table;
+        return parameterAnnotationTable;
     }
 
 
@@ -101,16 +101,16 @@ public abstract class ParameterAnnotations extends Attribute {
      * returns the array of parameter annotation entries in this parameter annotation
      */
     public ParameterAnnotationEntry[] getParameterAnnotationEntries() {
-        return parameter_annotation_table;
+        return parameterAnnotationTable;
     }
 
     @Override
     public void dump(final DataOutputStream dos) throws IOException
     {
         super.dump(dos);
-        dos.writeByte(parameter_annotation_table.length);
+        dos.writeByte(parameterAnnotationTable.length);
 
-        for (final ParameterAnnotationEntry element : parameter_annotation_table) {
+        for (final ParameterAnnotationEntry element : parameterAnnotationTable) {
             element.dump(dos);
         }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Signature.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Signature.java
@@ -36,7 +36,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class Signature extends Attribute {
 
-    private int signature_index;
+    private int signatureIndex;
 
 
     /**
@@ -65,12 +65,12 @@ public final class Signature extends Attribute {
     /**
      * @param name_index Index in constant pool to CONSTANT_Utf8
      * @param length Content length in bytes
-     * @param signature_index Index in constant pool to CONSTANT_Utf8
+     * @param signatureIndex Index in constant pool to CONSTANT_Utf8
      * @param constant_pool Array of constants
      */
-    public Signature(final int name_index, final int length, final int signature_index, final ConstantPool constant_pool) {
+    public Signature(final int name_index, final int length, final int signatureIndex, final ConstantPool constant_pool) {
         super(Const.ATTR_SIGNATURE, name_index, length, constant_pool);
-        this.signature_index = signature_index;
+        this.signatureIndex = signatureIndex;
     }
 
 
@@ -97,7 +97,7 @@ public final class Signature extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(signature_index);
+        file.writeShort(signatureIndex);
     }
 
 
@@ -105,15 +105,15 @@ public final class Signature extends Attribute {
      * @return Index in constant pool of source file name.
      */
     public int getSignatureIndex() {
-        return signature_index;
+        return signatureIndex;
     }
 
 
     /**
-     * @param signature_index the index info the constant pool of this signature
+     * @param signatureIndex the index info the constant pool of this signature
      */
-    public void setSignatureIndex( final int signature_index ) {
-        this.signature_index = signature_index;
+    public void setSignatureIndex( final int signatureIndex ) {
+        this.signatureIndex = signatureIndex;
     }
 
 
@@ -121,7 +121,7 @@ public final class Signature extends Attribute {
      * @return GJ signature.
      */
     public String getSignature() {
-        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(signature_index,
+        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(signatureIndex,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
     }
@@ -157,7 +157,7 @@ public final class Signature extends Attribute {
     private static void matchIdent( final MyByteArrayInputStream in, final StringBuilder buf ) {
         int ch;
         if ((ch = in.read()) == -1) {
-            throw new RuntimeException("Illegal signature: " + in.getData()
+            throw new IllegalArgumentException("Illegal signature: " + in.getData()
                     + " no ident, reaching EOF");
         }
         //System.out.println("return from ident:" + (char)ch);
@@ -207,7 +207,7 @@ public final class Signature extends Attribute {
             matchGJIdent(in, buf);
             while (((ch = in.read()) != '>') && (ch != ')')) { // List of parameters
                 if (ch == -1) {
-                    throw new RuntimeException("Illegal signature: " + in.getData()
+                    throw new IllegalArgumentException("Illegal signature: " + in.getData()
                             + " reaching EOF");
                 }
                 //System.out.println("Still no >");
@@ -228,7 +228,7 @@ public final class Signature extends Attribute {
             in.unread();
             return;
         } else if (ch != ';') {
-            throw new RuntimeException("Illegal signature: " + in.getData() + " read " + (char) ch);
+            throw new IllegalArgumentException("Illegal signature: " + in.getData() + " read " + (char) ch);
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/SimpleElementValue.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/SimpleElementValue.java
@@ -55,7 +55,7 @@ public class SimpleElementValue extends ElementValue
     public String getValueString()
     {
         if (super.getType() != STRING) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueString() on a non STRING ElementValue");
         }
         final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(getIndex(),
@@ -66,7 +66,7 @@ public class SimpleElementValue extends ElementValue
     public int getValueInt()
     {
         if (super.getType() != PRIMITIVE_INT) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueString() on a non STRING ElementValue");
         }
         final ConstantInteger c = (ConstantInteger) super.getConstantPool().getConstant(getIndex(),
@@ -77,7 +77,7 @@ public class SimpleElementValue extends ElementValue
     public byte getValueByte()
     {
         if (super.getType() != PRIMITIVE_BYTE) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueByte() on a non BYTE ElementValue");
         }
         final ConstantInteger c = (ConstantInteger) super.getConstantPool().getConstant(getIndex(),
@@ -88,7 +88,7 @@ public class SimpleElementValue extends ElementValue
     public char getValueChar()
     {
         if (super.getType() != PRIMITIVE_CHAR) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueChar() on a non CHAR ElementValue");
         }
         final ConstantInteger c = (ConstantInteger) super.getConstantPool().getConstant(getIndex(),
@@ -99,7 +99,7 @@ public class SimpleElementValue extends ElementValue
     public long getValueLong()
     {
         if (super.getType() != PRIMITIVE_LONG) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueLong() on a non LONG ElementValue");
         }
         final ConstantLong j = (ConstantLong) super.getConstantPool().getConstant(getIndex());
@@ -109,7 +109,7 @@ public class SimpleElementValue extends ElementValue
     public float getValueFloat()
     {
         if (super.getType() != PRIMITIVE_FLOAT) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueFloat() on a non FLOAT ElementValue");
         }
         final ConstantFloat f = (ConstantFloat) super.getConstantPool().getConstant(getIndex());
@@ -119,7 +119,7 @@ public class SimpleElementValue extends ElementValue
     public double getValueDouble()
     {
         if (super.getType() != PRIMITIVE_DOUBLE) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueDouble() on a non DOUBLE ElementValue");
         }
         final ConstantDouble d = (ConstantDouble) super.getConstantPool().getConstant(getIndex());
@@ -129,7 +129,7 @@ public class SimpleElementValue extends ElementValue
     public boolean getValueBoolean()
     {
         if (super.getType() != PRIMITIVE_BOOLEAN) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueBoolean() on a non BOOLEAN ElementValue");
         }
         final ConstantInteger bo = (ConstantInteger) super.getConstantPool().getConstant(getIndex());
@@ -139,7 +139,7 @@ public class SimpleElementValue extends ElementValue
     public short getValueShort()
     {
         if (super.getType() != PRIMITIVE_SHORT) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueShort() on a non SHORT ElementValue");
         }
         final ConstantInteger s = (ConstantInteger) super.getConstantPool().getConstant(getIndex());
@@ -200,7 +200,7 @@ public class SimpleElementValue extends ElementValue
                     Const.CONSTANT_Utf8);
             return cu8.getBytes();
         default:
-            throw new RuntimeException("SimpleElementValue class does not know how to stringify type " + _type);
+            throw new IllegalStateException("SimpleElementValue class does not know how to stringify type " + _type);
         }
     }
 
@@ -223,7 +223,7 @@ public class SimpleElementValue extends ElementValue
             dos.writeShort(getIndex());
             break;
         default:
-            throw new RuntimeException("SimpleElementValue doesnt know how to write out type " + _type);
+            throw new IllegalStateException("SimpleElementValue doesnt know how to write out type " + _type);
         }
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/SourceFile.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/SourceFile.java
@@ -37,7 +37,7 @@ import com.sun.org.apache.bcel.internal.Const;
  */
 public final class SourceFile extends Attribute {
 
-    private int sourcefile_index;
+    private int sourceFileIndex;
 
 
     /**
@@ -67,18 +67,18 @@ public final class SourceFile extends Attribute {
      * @param name_index Index in constant pool to CONSTANT_Utf8, which
      * should represent the string "SourceFile".
      * @param length Content length in bytes, the value should be 2.
-     * @param constant_pool The constant pool that this attribute is
+     * @param constantPool The constant pool that this attribute is
      * associated with.
-     * @param sourcefile_index Index in constant pool to CONSTANT_Utf8.  This
+     * @param sourceFileIndex Index in constant pool to CONSTANT_Utf8.  This
      * string will be interpreted as the name of the file from which this
      * class was compiled.  It will not be interpreted as indicating the name
      * of the directory contqining the file or an absolute path; this
      * information has to be supplied the consumer of this attribute - in
      * many cases, the JVM.
      */
-    public SourceFile(final int name_index, final int length, final int sourcefile_index, final ConstantPool constant_pool) {
-        super(Const.ATTR_SOURCE_FILE, name_index, length, constant_pool);
-        this.sourcefile_index = sourcefile_index;
+    public SourceFile(final int name_index, final int length, final int sourceFileIndex, final ConstantPool constantPool) {
+        super(Const.ATTR_SOURCE_FILE, name_index, length, constantPool);
+        this.sourceFileIndex = sourceFileIndex;
     }
 
 
@@ -104,7 +104,7 @@ public final class SourceFile extends Attribute {
     @Override
     public void dump( final DataOutputStream file ) throws IOException {
         super.dump(file);
-        file.writeShort(sourcefile_index);
+        file.writeShort(sourceFileIndex);
     }
 
 
@@ -112,15 +112,15 @@ public final class SourceFile extends Attribute {
      * @return Index in constant pool of source file name.
      */
     public int getSourceFileIndex() {
-        return sourcefile_index;
+        return sourceFileIndex;
     }
 
 
     /**
-     * @param sourcefile_index
+     * @param sourceFileIndex
      */
-    public void setSourceFileIndex( final int sourcefile_index ) {
-        this.sourcefile_index = sourcefile_index;
+    public void setSourceFileIndex( final int sourceFileIndex ) {
+        this.sourceFileIndex = sourceFileIndex;
     }
 
 
@@ -128,7 +128,7 @@ public final class SourceFile extends Attribute {
      * @return Source file name.
      */
     public String getSourceFileName() {
-        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(sourcefile_index,
+        final ConstantUtf8 c = (ConstantUtf8) super.getConstantPool().getConstant(sourceFileIndex,
                 Const.CONSTANT_Utf8);
         return c.getBytes();
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMap.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMap.java
@@ -1,6 +1,5 @@
 /*
- * reserved comment block
- * DO NOT REMOVE OR ALTER!
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,6 +38,7 @@ import com.sun.org.apache.bcel.internal.Const;
  * @see     Code
  * @see     StackMapEntry
  * @see     StackMapType
+ * @LastModified: Oct 2020
  */
 public final class StackMap extends Attribute {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapEntry.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapEntry.java
@@ -37,11 +37,11 @@ import com.sun.org.apache.bcel.internal.Const;
 public final class StackMapEntry implements Node, Cloneable
 {
 
-    private int frame_type;
-    private int byte_code_offset;
-    private StackMapType[] types_of_locals;
-    private StackMapType[] types_of_stack_items;
-    private ConstantPool constant_pool;
+    private int frameType;
+    private int byteCodeOffset;
+    private StackMapType[] typesOfLocals;
+    private StackMapType[] typesOfStackItems;
+    private ConstantPool constantPool;
 
 
     /**
@@ -53,43 +53,43 @@ public final class StackMapEntry implements Node, Cloneable
     StackMapEntry(final DataInput input, final ConstantPool constantPool) throws IOException {
         this(input.readByte() & 0xFF, -1, null, null, constantPool);
 
-        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
-            byte_code_offset = frame_type - Const.SAME_FRAME;
-        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
-                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
-            byte_code_offset = frame_type - Const.SAME_LOCALS_1_STACK_ITEM_FRAME;
-            types_of_stack_items = new StackMapType[1];
-            types_of_stack_items[0] = new StackMapType(input, constantPool);
-        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
-            byte_code_offset = input.readShort();
-            types_of_stack_items = new StackMapType[1];
-            types_of_stack_items[0] = new StackMapType(input, constantPool);
-        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
-            byte_code_offset = input.readShort();
-        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
-            byte_code_offset = input.readShort();
-        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
-            byte_code_offset = input.readShort();
-            final int number_of_locals = frame_type - 251;
-            types_of_locals = new StackMapType[number_of_locals];
+        if (frameType >= Const.SAME_FRAME && frameType <= Const.SAME_FRAME_MAX) {
+            byteCodeOffset = frameType - Const.SAME_FRAME;
+        } else if (frameType >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                   frameType <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            byteCodeOffset = frameType - Const.SAME_LOCALS_1_STACK_ITEM_FRAME;
+            typesOfStackItems = new StackMapType[1];
+            typesOfStackItems[0] = new StackMapType(input, constantPool);
+        } else if (frameType == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            byteCodeOffset = input.readShort();
+            typesOfStackItems = new StackMapType[1];
+            typesOfStackItems[0] = new StackMapType(input, constantPool);
+        } else if (frameType >= Const.CHOP_FRAME && frameType <= Const.CHOP_FRAME_MAX) {
+            byteCodeOffset = input.readShort();
+        } else if (frameType == Const.SAME_FRAME_EXTENDED) {
+            byteCodeOffset = input.readShort();
+        } else if (frameType >= Const.APPEND_FRAME && frameType <= Const.APPEND_FRAME_MAX) {
+            byteCodeOffset = input.readShort();
+            final int number_of_locals = frameType - 251;
+            typesOfLocals = new StackMapType[number_of_locals];
             for (int i = 0; i < number_of_locals; i++) {
-                types_of_locals[i] = new StackMapType(input, constantPool);
+                typesOfLocals[i] = new StackMapType(input, constantPool);
             }
-        } else if (frame_type == Const.FULL_FRAME) {
-            byte_code_offset = input.readShort();
+        } else if (frameType == Const.FULL_FRAME) {
+            byteCodeOffset = input.readShort();
             final int number_of_locals = input.readShort();
-            types_of_locals = new StackMapType[number_of_locals];
+            typesOfLocals = new StackMapType[number_of_locals];
             for (int i = 0; i < number_of_locals; i++) {
-                types_of_locals[i] = new StackMapType(input, constantPool);
+                typesOfLocals[i] = new StackMapType(input, constantPool);
             }
             final int number_of_stack_items = input.readShort();
-            types_of_stack_items = new StackMapType[number_of_stack_items];
+            typesOfStackItems = new StackMapType[number_of_stack_items];
             for (int i = 0; i < number_of_stack_items; i++) {
-                types_of_stack_items[i] = new StackMapType(input, constantPool);
+                typesOfStackItems[i] = new StackMapType(input, constantPool);
             }
         } else {
             /* Can't happen */
-            throw new ClassFormatException ("Invalid frame type found while parsing stack map table: " + frame_type);
+            throw new ClassFormatException ("Invalid frame type found while parsing stack map table: " + frameType);
         }
     }
 
@@ -109,16 +109,16 @@ public final class StackMapEntry implements Node, Cloneable
     public StackMapEntry(final int byteCodeOffset, final int numberOfLocals,
             final StackMapType[] typesOfLocals, final int numberOfStackItems,
             final StackMapType[] typesOfStackItems, final ConstantPool constantPool) {
-        this.byte_code_offset = byteCodeOffset;
-        this.types_of_locals = typesOfLocals != null ? typesOfLocals : new StackMapType[0];
-        this.types_of_stack_items = typesOfStackItems != null ? typesOfStackItems : new StackMapType[0];
-        this.constant_pool = constantPool;
+        this.byteCodeOffset = byteCodeOffset;
+        this.typesOfLocals = typesOfLocals != null ? typesOfLocals : new StackMapType[0];
+        this.typesOfStackItems = typesOfStackItems != null ? typesOfStackItems : new StackMapType[0];
+        this.constantPool = constantPool;
     }
 
     /**
      * Create an instance
      *
-     * @param tag the frame_type to use
+     * @param tag the frameType to use
      * @param byteCodeOffset
      * @param typesOfLocals array of {@link StackMapType}s of locals
      * @param typesOfStackItems array ot {@link StackMapType}s of stack items
@@ -127,11 +127,11 @@ public final class StackMapEntry implements Node, Cloneable
     public StackMapEntry(final int tag, final int byteCodeOffset,
             final StackMapType[] typesOfLocals,
             final StackMapType[] typesOfStackItems, final ConstantPool constantPool) {
-        this.frame_type = tag;
-        this.byte_code_offset = byteCodeOffset;
-        this.types_of_locals = typesOfLocals != null ? typesOfLocals : new StackMapType[0];
-        this.types_of_stack_items = typesOfStackItems != null ? typesOfStackItems : new StackMapType[0];
-        this.constant_pool = constantPool;
+        this.frameType = tag;
+        this.byteCodeOffset = byteCodeOffset;
+        this.typesOfLocals = typesOfLocals != null ? typesOfLocals : new StackMapType[0];
+        this.typesOfStackItems = typesOfStackItems != null ? typesOfStackItems : new StackMapType[0];
+        this.constantPool = constantPool;
     }
 
 
@@ -142,37 +142,37 @@ public final class StackMapEntry implements Node, Cloneable
      * @throws IOException
      */
     public void dump( final DataOutputStream file ) throws IOException {
-        file.write(frame_type);
-        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
+        file.write(frameType);
+        if (frameType >= Const.SAME_FRAME && frameType <= Const.SAME_FRAME_MAX) {
             // nothing to be done
-        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
-                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
-            types_of_stack_items[0].dump(file);
-        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
-            file.writeShort(byte_code_offset);
-            types_of_stack_items[0].dump(file);
-        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
-            file.writeShort(byte_code_offset);
-        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
-            file.writeShort(byte_code_offset);
-        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
-            file.writeShort(byte_code_offset);
-            for (final StackMapType type : types_of_locals) {
+        } else if (frameType >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                   frameType <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            typesOfStackItems[0].dump(file);
+        } else if (frameType == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            file.writeShort(byteCodeOffset);
+            typesOfStackItems[0].dump(file);
+        } else if (frameType >= Const.CHOP_FRAME && frameType <= Const.CHOP_FRAME_MAX) {
+            file.writeShort(byteCodeOffset);
+        } else if (frameType == Const.SAME_FRAME_EXTENDED) {
+            file.writeShort(byteCodeOffset);
+        } else if (frameType >= Const.APPEND_FRAME && frameType <= Const.APPEND_FRAME_MAX) {
+            file.writeShort(byteCodeOffset);
+            for (final StackMapType type : typesOfLocals) {
                 type.dump(file);
             }
-        } else if (frame_type == Const.FULL_FRAME) {
-            file.writeShort(byte_code_offset);
-            file.writeShort(types_of_locals.length);
-            for (final StackMapType type : types_of_locals) {
+        } else if (frameType == Const.FULL_FRAME) {
+            file.writeShort(byteCodeOffset);
+            file.writeShort(typesOfLocals.length);
+            for (final StackMapType type : typesOfLocals) {
                 type.dump(file);
             }
-            file.writeShort(types_of_stack_items.length);
-            for (final StackMapType type : types_of_stack_items) {
+            file.writeShort(typesOfStackItems.length);
+            for (final StackMapType type : typesOfStackItems) {
                 type.dump(file);
             }
         } else {
             /* Can't happen */
-            throw new ClassFormatException ("Invalid Stack map table tag: " + frame_type);
+            throw new ClassFormatException ("Invalid Stack map table tag: " + frameType);
         }
     }
 
@@ -184,40 +184,40 @@ public final class StackMapEntry implements Node, Cloneable
     public String toString() {
         final StringBuilder buf = new StringBuilder(64);
         buf.append("(");
-        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
+        if (frameType >= Const.SAME_FRAME && frameType <= Const.SAME_FRAME_MAX) {
             buf.append("SAME");
-        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
-                  frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+        } else if (frameType >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                  frameType <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
             buf.append("SAME_LOCALS_1_STACK");
-        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+        } else if (frameType == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
             buf.append("SAME_LOCALS_1_STACK_EXTENDED");
-        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
-            buf.append("CHOP ").append(String.valueOf(251-frame_type));
-        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
+        } else if (frameType >= Const.CHOP_FRAME && frameType <= Const.CHOP_FRAME_MAX) {
+            buf.append("CHOP ").append(String.valueOf(251-frameType));
+        } else if (frameType == Const.SAME_FRAME_EXTENDED) {
             buf.append("SAME_EXTENDED");
-        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
-            buf.append("APPEND ").append(String.valueOf(frame_type-251));
-        } else if (frame_type == Const.FULL_FRAME) {
+        } else if (frameType >= Const.APPEND_FRAME && frameType <= Const.APPEND_FRAME_MAX) {
+            buf.append("APPEND ").append(String.valueOf(frameType-251));
+        } else if (frameType == Const.FULL_FRAME) {
             buf.append("FULL");
         } else {
-            buf.append("UNKNOWN (").append(frame_type).append(")");
+            buf.append("UNKNOWN (").append(frameType).append(")");
         }
-        buf.append(", offset delta=").append(byte_code_offset);
-        if (types_of_locals.length > 0) {
+        buf.append(", offset delta=").append(byteCodeOffset);
+        if (typesOfLocals.length > 0) {
             buf.append(", locals={");
-            for (int i = 0; i < types_of_locals.length; i++) {
-                buf.append(types_of_locals[i]);
-                if (i < types_of_locals.length - 1) {
+            for (int i = 0; i < typesOfLocals.length; i++) {
+                buf.append(typesOfLocals[i]);
+                if (i < typesOfLocals.length - 1) {
                     buf.append(", ");
                 }
             }
             buf.append("}");
         }
-        if (types_of_stack_items.length > 0) {
+        if (typesOfStackItems.length > 0) {
             buf.append(", stack items={");
-            for (int i = 0; i < types_of_stack_items.length; i++) {
-                buf.append(types_of_stack_items[i]);
-                if (i < types_of_stack_items.length - 1) {
+            for (int i = 0; i < typesOfStackItems.length; i++) {
+                buf.append(typesOfStackItems[i]);
+                if (i < typesOfStackItems.length - 1) {
                     buf.append(", ");
                 }
             }
@@ -233,91 +233,91 @@ public final class StackMapEntry implements Node, Cloneable
      *
      */
     int getMapEntrySize() {
-        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
+        if (frameType >= Const.SAME_FRAME && frameType <= Const.SAME_FRAME_MAX) {
             return 1;
-        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
-                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
-            return 1 + (types_of_stack_items[0].hasIndex() ? 3 : 1);
-        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
-            return 3 + (types_of_stack_items[0].hasIndex() ? 3 : 1);
-        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
+        } else if (frameType >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                   frameType <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            return 1 + (typesOfStackItems[0].hasIndex() ? 3 : 1);
+        } else if (frameType == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            return 3 + (typesOfStackItems[0].hasIndex() ? 3 : 1);
+        } else if (frameType >= Const.CHOP_FRAME && frameType <= Const.CHOP_FRAME_MAX) {
             return 3;
-        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
+        } else if (frameType == Const.SAME_FRAME_EXTENDED) {
             return 3;
-        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
+        } else if (frameType >= Const.APPEND_FRAME && frameType <= Const.APPEND_FRAME_MAX) {
             int len = 3;
-            for (final StackMapType types_of_local : types_of_locals) {
+            for (final StackMapType types_of_local : typesOfLocals) {
                 len += types_of_local.hasIndex() ? 3 : 1;
             }
             return len;
-        } else if (frame_type == Const.FULL_FRAME) {
+        } else if (frameType == Const.FULL_FRAME) {
             int len = 7;
-            for (final StackMapType types_of_local : types_of_locals) {
+            for (final StackMapType types_of_local : typesOfLocals) {
                 len += types_of_local.hasIndex() ? 3 : 1;
             }
-            for (final StackMapType types_of_stack_item : types_of_stack_items) {
+            for (final StackMapType types_of_stack_item : typesOfStackItems) {
                 len += types_of_stack_item.hasIndex() ? 3 : 1;
             }
             return len;
         } else {
-            throw new RuntimeException("Invalid StackMap frame_type: " + frame_type);
+            throw new IllegalStateException("Invalid StackMap frameType: " + frameType);
         }
     }
 
 
     public void setFrameType( final int f ) {
         if (f >= Const.SAME_FRAME && f <= Const.SAME_FRAME_MAX) {
-            byte_code_offset = f - Const.SAME_FRAME;
+            byteCodeOffset = f - Const.SAME_FRAME;
         } else if (f >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
                    f <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
-            byte_code_offset = f - Const.SAME_LOCALS_1_STACK_ITEM_FRAME;
+            byteCodeOffset = f - Const.SAME_LOCALS_1_STACK_ITEM_FRAME;
         } else if (f == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
         } else if (f >= Const.CHOP_FRAME && f <= Const.CHOP_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
         } else if (f == Const.SAME_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
         } else if (f >= Const.APPEND_FRAME && f <= Const.APPEND_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
         } else if (f == Const.FULL_FRAME) { // CHECKSTYLE IGNORE EmptyBlock
         } else {
-            throw new RuntimeException("Invalid StackMap frame_type");
+            throw new IllegalArgumentException("Invalid StackMap frameType");
         }
-        frame_type = f;
+        frameType = f;
     }
 
 
     public int getFrameType() {
-        return frame_type;
+        return frameType;
     }
 
 
     public void setByteCodeOffset( final int new_offset ) {
         if (new_offset < 0 || new_offset > 32767) {
-            throw new RuntimeException("Invalid StackMap offset: " + new_offset);
+            throw new IllegalArgumentException("Invalid StackMap offset: " + new_offset);
         }
 
-        if (frame_type >= Const.SAME_FRAME &&
-            frame_type <= Const.SAME_FRAME_MAX) {
+        if (frameType >= Const.SAME_FRAME &&
+            frameType <= Const.SAME_FRAME_MAX) {
             if (new_offset > Const.SAME_FRAME_MAX) {
-                frame_type = Const.SAME_FRAME_EXTENDED;
+                frameType = Const.SAME_FRAME_EXTENDED;
             } else {
-                frame_type = new_offset;
+                frameType = new_offset;
             }
-        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
-                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+        } else if (frameType >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                   frameType <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
             if (new_offset > Const.SAME_FRAME_MAX) {
-                frame_type = Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED;
+                frameType = Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED;
             } else {
-                frame_type = Const.SAME_LOCALS_1_STACK_ITEM_FRAME + new_offset;
+                frameType = Const.SAME_LOCALS_1_STACK_ITEM_FRAME + new_offset;
             }
-        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
-        } else if (frame_type >= Const.CHOP_FRAME &&
-                   frame_type <= Const.CHOP_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
-        } else if (frame_type == Const.SAME_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
-        } else if (frame_type >= Const.APPEND_FRAME &&
-                   frame_type <= Const.APPEND_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
-        } else if (frame_type == Const.FULL_FRAME) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frameType == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frameType >= Const.CHOP_FRAME &&
+                   frameType <= Const.CHOP_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frameType == Const.SAME_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frameType >= Const.APPEND_FRAME &&
+                   frameType <= Const.APPEND_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frameType == Const.FULL_FRAME) { // CHECKSTYLE IGNORE EmptyBlock
         } else {
-            throw new RuntimeException("Invalid StackMap frame_type: " + frame_type);
+            throw new IllegalStateException("Invalid StackMap frameType: " + frameType);
         }
-        byte_code_offset = new_offset;
+        byteCodeOffset = new_offset;
     }
 
 
@@ -329,12 +329,12 @@ public final class StackMapEntry implements Node, Cloneable
      * @param delta offset delta
      */
     public void updateByteCodeOffset(final int delta) {
-        setByteCodeOffset(byte_code_offset + delta);
+        setByteCodeOffset(byteCodeOffset + delta);
     }
 
 
     public int getByteCodeOffset() {
-        return byte_code_offset;
+        return byteCodeOffset;
     }
 
 
@@ -348,17 +348,17 @@ public final class StackMapEntry implements Node, Cloneable
 
 
     public int getNumberOfLocals() {
-        return types_of_locals.length;
+        return typesOfLocals.length;
     }
 
 
     public void setTypesOfLocals( final StackMapType[] types ) {
-        types_of_locals = types != null ? types : new StackMapType[0];
+        typesOfLocals = types != null ? types : new StackMapType[0];
     }
 
 
     public StackMapType[] getTypesOfLocals() {
-        return types_of_locals;
+        return typesOfLocals;
     }
 
 
@@ -372,17 +372,17 @@ public final class StackMapEntry implements Node, Cloneable
 
 
     public int getNumberOfStackItems() {
-        return types_of_stack_items.length;
+        return typesOfStackItems.length;
     }
 
 
     public void setTypesOfStackItems( final StackMapType[] types ) {
-        types_of_stack_items = types != null ? types : new StackMapType[0];
+        typesOfStackItems = types != null ? types : new StackMapType[0];
     }
 
 
     public StackMapType[] getTypesOfStackItems() {
-        return types_of_stack_items;
+        return typesOfStackItems;
     }
 
 
@@ -397,13 +397,13 @@ public final class StackMapEntry implements Node, Cloneable
             throw new Error("Clone Not Supported");
         }
 
-        e.types_of_locals = new StackMapType[types_of_locals.length];
-        for (int i = 0; i < types_of_locals.length; i++) {
-            e.types_of_locals[i] = types_of_locals[i].copy();
+        e.typesOfLocals = new StackMapType[typesOfLocals.length];
+        for (int i = 0; i < typesOfLocals.length; i++) {
+            e.typesOfLocals[i] = typesOfLocals[i].copy();
         }
-        e.types_of_stack_items = new StackMapType[types_of_stack_items.length];
-        for (int i = 0; i < types_of_stack_items.length; i++) {
-            e.types_of_stack_items[i] = types_of_stack_items[i].copy();
+        e.typesOfStackItems = new StackMapType[typesOfStackItems.length];
+        for (int i = 0; i < typesOfStackItems.length; i++) {
+            e.typesOfStackItems[i] = typesOfStackItems[i].copy();
         }
         return e;
     }
@@ -426,14 +426,14 @@ public final class StackMapEntry implements Node, Cloneable
      * @return Constant pool used by this object.
      */
     public ConstantPool getConstantPool() {
-        return constant_pool;
+        return constantPool;
     }
 
 
     /**
-     * @param constant_pool Constant pool to be used for this object.
+     * @param constantPool Constant pool to be used for this object.
      */
-    public void setConstantPool( final ConstantPool constant_pool ) {
-        this.constant_pool = constant_pool;
+    public void setConstantPool( final ConstantPool constantPool ) {
+        this.constantPool = constantPool;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/StackMapType.java
@@ -39,7 +39,7 @@ public final class StackMapType implements Cloneable {
 
     private byte type;
     private int index = -1; // Index to CONSTANT_Class or offset
-    private ConstantPool constant_pool;
+    private ConstantPool constantPool;
 
 
     /**
@@ -52,7 +52,7 @@ public final class StackMapType implements Cloneable {
         if (hasIndex()) {
             this.index = file.readShort();
         }
-        this.constant_pool = constant_pool;
+        this.constantPool = constant_pool;
     }
 
 
@@ -62,17 +62,17 @@ public final class StackMapType implements Cloneable {
      */
     public StackMapType(final byte type, final int index, final ConstantPool constant_pool) {
         if ((type < Const.ITEM_Bogus) || (type > Const.ITEM_NewObject)) {
-            throw new RuntimeException("Illegal type for StackMapType: " + type);
+            throw new IllegalArgumentException("Illegal type for StackMapType: " + type);
         }
         this.type = type;
         this.index = index;
-        this.constant_pool = constant_pool;
+        this.constantPool = constant_pool;
     }
 
 
     public void setType( final byte t ) {
         if ((t < Const.ITEM_Bogus) || (t > Const.ITEM_NewObject)) {
-            throw new RuntimeException("Illegal type for StackMapType: " + t);
+            throw new IllegalArgumentException("Illegal type for StackMapType: " + t);
         }
         type = t;
     }
@@ -122,7 +122,7 @@ public final class StackMapType implements Cloneable {
             if (index < 0) {
                 return ", class=<unknown>";
             }
-            return ", class=" + constant_pool.constantToString(index, Const.CONSTANT_Class);
+            return ", class=" + constantPool.constantToString(index, Const.CONSTANT_Class);
         } else if (type == Const.ITEM_NewObject) {
             return ", offset=" + index;
         } else {
@@ -157,14 +157,14 @@ public final class StackMapType implements Cloneable {
      * @return Constant pool used by this object.
      */
     public ConstantPool getConstantPool() {
-        return constant_pool;
+        return constantPool;
     }
 
 
     /**
-     * @param constant_pool Constant pool to be used for this object.
+     * @param constantPool Constant pool to be used for this object.
      */
-    public void setConstantPool( final ConstantPool constant_pool ) {
-        this.constant_pool = constant_pool;
+    public void setConstantPool( final ConstantPool constantPool ) {
+        this.constantPool = constantPool;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Unknown.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Unknown.java
@@ -45,15 +45,15 @@ public final class Unknown extends Attribute {
 
     private byte[] bytes;
     private final String name;
-    private static final Map<String, Unknown> unknown_attributes = new HashMap<>();
+    private static final Map<String, Unknown> unknownAttributes = new HashMap<>();
 
 
     /** @return array of unknown attributes, but just one for each kind.
      */
     static Unknown[] getUnknownAttributes() {
-        final Unknown[] unknowns = new Unknown[unknown_attributes.size()];
-        unknown_attributes.values().toArray(unknowns);
-        unknown_attributes.clear();
+        final Unknown[] unknowns = new Unknown[unknownAttributes.size()];
+        unknownAttributes.values().toArray(unknowns);
+        unknownAttributes.clear();
         return unknowns;
     }
 
@@ -80,7 +80,7 @@ public final class Unknown extends Attribute {
         this.bytes = bytes;
         name = ((ConstantUtf8) constant_pool.getConstant(name_index, Const.CONSTANT_Utf8))
                 .getBytes();
-        unknown_attributes.put(name, this);
+        unknownAttributes.put(name, this);
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Utility.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/Utility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -42,7 +42,7 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * Utility functions that do not really belong to any class in particular.
  *
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 // @since 6.0 methods are no longer final
 public abstract class Utility {
@@ -772,10 +772,10 @@ public abstract class Utility {
      * There is some nomenclature confusion through much of the BCEL code base with
      * respect to the terms Descriptor and Signature.  For the offical definitions see:
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3">
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3">
      * Descriptors in The Java Virtual Machine Specification</a>
      *
-     * @see <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.9.1">
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.9.1">
      * Signatures in The Java Virtual Machine Specification</a>
      *
      * In brief, a descriptor is a string representing the type of a field or method.
@@ -835,30 +835,29 @@ public abstract class Utility {
             index += unwrap(consumed_chars); // update position
             // ignore any throws information in the signature
             return type;
-        } else {
-            // Could be Class or Type...
-            type = typeSignatureToString(signature.substring(index), chopit);
-            index += unwrap(consumed_chars); // update position
-            if ((typeParams.length() == 0) && (index == signature.length())) {
-                // We have a Type signature.
-                return type;
-            }
-            // We have a Class signature.
-            final StringBuilder typeClass = new StringBuilder(typeParams);
-            typeClass.append(" extends ");
-            typeClass.append(type);
-            if (index < signature.length()) {
-                typeClass.append(" implements ");
-                typeClass.append(typeSignatureToString(signature.substring(index), chopit));
-                index += unwrap(consumed_chars); // update position
-            }
-            while (index < signature.length()) {
-                typeClass.append(", ");
-                typeClass.append(typeSignatureToString(signature.substring(index), chopit));
-                index += unwrap(consumed_chars); // update position
-            }
-            return typeClass.toString();
         }
+        // Could be Class or Type...
+        type = typeSignatureToString(signature.substring(index), chopit);
+        index += unwrap(consumed_chars); // update position
+        if ((typeParams.length() == 0) && (index == signature.length())) {
+            // We have a Type signature.
+            return type;
+        }
+        // We have a Class signature.
+        final StringBuilder typeClass = new StringBuilder(typeParams);
+        typeClass.append(" extends ");
+        typeClass.append(type);
+        if (index < signature.length()) {
+            typeClass.append(" implements ");
+            typeClass.append(typeSignatureToString(signature.substring(index), chopit));
+            index += unwrap(consumed_chars); // update position
+        }
+        while (index < signature.length()) {
+            typeClass.append(", ");
+            typeClass.append(typeSignatureToString(signature.substring(index), chopit));
+            index += unwrap(consumed_chars); // update position
+        }
+        return typeClass.toString();
     }
 
 
@@ -1149,7 +1148,7 @@ public abstract class Utility {
                     break;
                 case '[':
                     if (!char_found) {
-                        throw new RuntimeException("Illegal type: " + type);
+                        throw new IllegalArgumentException("Illegal type: " + type);
                     }
                     index = i;
                     break loop;
@@ -1191,13 +1190,13 @@ public abstract class Utility {
             switch (c) {
                 case '[':
                     if (open) {
-                        throw new RuntimeException("Illegally nested brackets:" + brackets);
+                        throw new IllegalArgumentException("Illegally nested brackets:" + brackets);
                     }
                     open = true;
                     break;
                 case ']':
                     if (!open) {
-                        throw new RuntimeException("Illegally nested brackets:" + brackets);
+                        throw new IllegalArgumentException("Illegally nested brackets:" + brackets);
                     }
                     open = false;
                     count++;
@@ -1208,7 +1207,7 @@ public abstract class Utility {
             }
         }
         if (open) {
-            throw new RuntimeException("Illegally nested brackets:" + brackets);
+            throw new IllegalArgumentException("Illegally nested brackets:" + brackets);
         }
         return count;
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AnnotationElementValueGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/AnnotationElementValueGen.java
@@ -46,7 +46,7 @@ public class AnnotationElementValueGen extends ElementValueGen
     {
         super(type, cpool);
         if (type != ANNOTATION) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "Only element values of type annotation can be built with this ctor - type specified: " + type);
         }
         this.a = annotation;
@@ -69,7 +69,7 @@ public class AnnotationElementValueGen extends ElementValueGen
     @Override
     public String stringifyValue()
     {
-        throw new RuntimeException("Not implemented yet");
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayElementValueGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayElementValueGen.java
@@ -49,7 +49,7 @@ public class ArrayElementValueGen extends ElementValueGen
     {
         super(type, cpool);
         if (type != ARRAY) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "Only element values of type array can be built with this ctor - type specified: " + type);
         }
         this.evalues = new ArrayList<>();

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayInstruction.java
@@ -83,7 +83,7 @@ public abstract class ArrayInstruction extends Instruction implements ExceptionT
             case com.sun.org.apache.bcel.internal.Const.AASTORE:
                 return Type.OBJECT;
             default:
-                throw new ClassGenException("Oops: unknown case in switch" + _opcode);
+                throw new ClassGenException("Unknown case in switch" + _opcode);
         }
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ArrayType.java
@@ -29,7 +29,7 @@ import com.sun.org.apache.bcel.internal.Const;
 public final class ArrayType extends ReferenceType {
 
     private int dimensions;
-    private Type basic_type;
+    private Type basicType;
 
 
     /**
@@ -66,20 +66,20 @@ public final class ArrayType extends ReferenceType {
             case Const.T_ARRAY:
                 final ArrayType array = (ArrayType) type;
                 this.dimensions = dimensions + array.dimensions;
-                basic_type = array.basic_type;
+                basicType = array.basicType;
                 break;
             case Const.T_VOID:
                 throw new ClassGenException("Invalid type: void[]");
             default: // Basic type or reference
                 this.dimensions = dimensions;
-                basic_type = type;
+                basicType = type;
                 break;
         }
         final StringBuilder buf = new StringBuilder();
         for (int i = 0; i < this.dimensions; i++) {
             buf.append('[');
         }
-        buf.append(basic_type.getSignature());
+        buf.append(basicType.getSignature());
         super.setSignature(buf.toString());
     }
 
@@ -88,7 +88,7 @@ public final class ArrayType extends ReferenceType {
      * @return basic type of array, i.e., for int[][][] the basic type is int
      */
     public Type getBasicType() {
-        return basic_type;
+        return basicType;
     }
 
 
@@ -97,9 +97,9 @@ public final class ArrayType extends ReferenceType {
      */
     public Type getElementType() {
         if (dimensions == 1) {
-            return basic_type;
+            return basicType;
         }
-        return new ArrayType(basic_type, dimensions - 1);
+        return new ArrayType(basicType, dimensions - 1);
     }
 
 
@@ -114,7 +114,7 @@ public final class ArrayType extends ReferenceType {
      */
     @Override
     public int hashCode() {
-        return basic_type.hashCode() ^ dimensions;
+        return basicType.hashCode() ^ dimensions;
     }
 
 
@@ -124,7 +124,7 @@ public final class ArrayType extends ReferenceType {
     public boolean equals( final Object _type ) {
         if (_type instanceof ArrayType) {
             final ArrayType array = (ArrayType) _type;
-            return (array.dimensions == dimensions) && array.basic_type.equals(basic_type);
+            return (array.dimensions == dimensions) && array.basicType.equals(basicType);
         }
         return false;
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ClassGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -42,28 +42,28 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * existing java class (file).
  *
  * @see JavaClass
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class ClassGen extends AccessFlags implements Cloneable {
 
     /* Corresponds to the fields found in a JavaClass object.
      */
-    private String class_name;
-    private String super_class_name;
-    private final String file_name;
-    private int class_name_index = -1;
+    private String className;
+    private String superClassName;
+    private final String fileName;
+    private int classNameIndex = -1;
     private int superclass_name_index = -1;
-    private int major = Const.MAJOR;
-    private int minor = Const.MINOR;
+    private int major = Const.MAJOR_1_1;
+    private int minor = Const.MINOR_1_1;
     private ConstantPoolGen cp; // Template for building up constant pool
     // ArrayLists instead of arrays to gather fields, methods, etc.
-    private final List<Field> field_vec = new ArrayList<>();
-    private final List<Method> method_vec = new ArrayList<>();
-    private final List<Attribute> attribute_vec = new ArrayList<>();
-    private final List<String> interface_vec = new ArrayList<>();
-    private final List<AnnotationEntryGen> annotation_vec = new ArrayList<>();
+    private final List<Field> fieldList = new ArrayList<>();
+    private final List<Method> methodList = new ArrayList<>();
+    private final List<Attribute> attributeList = new ArrayList<>();
+    private final List<String> interfaceList = new ArrayList<>();
+    private final List<AnnotationEntryGen> annotationList = new ArrayList<>();
 
-    private static BCELComparator _cmp = new BCELComparator() {
+    private static BCELComparator bcelComparator = new BCELComparator() {
 
         @Override
         public boolean equals( final Object o1, final Object o2 ) {
@@ -83,27 +83,27 @@ public class ClassGen extends AccessFlags implements Cloneable {
 
     /** Convenience constructor to set up some important values initially.
      *
-     * @param class_name fully qualified class name
-     * @param super_class_name fully qualified superclass name
-     * @param file_name source file name
-     * @param access_flags access qualifiers
+     * @param className fully qualified class name
+     * @param superClassName fully qualified superclass name
+     * @param fileName source file name
+     * @param accessFlags access qualifiers
      * @param interfaces implemented interfaces
      * @param cp constant pool to use
      */
-    public ClassGen(final String class_name, final String super_class_name, final String file_name, final int access_flags,
+    public ClassGen(final String className, final String superClassName, final String fileName, final int accessFlags,
             final String[] interfaces, final ConstantPoolGen cp) {
-        super(access_flags);
-        this.class_name = class_name;
-        this.super_class_name = super_class_name;
-        this.file_name = file_name;
+        super(accessFlags);
+        this.className = className;
+        this.superClassName = superClassName;
+        this.fileName = fileName;
         this.cp = cp;
         // Put everything needed by default into the constant pool and the vectors
-        if (file_name != null) {
-            addAttribute(new SourceFile(cp.addUtf8("SourceFile"), 2, cp.addUtf8(file_name), cp
+        if (fileName != null) {
+            addAttribute(new SourceFile(cp.addUtf8("SourceFile"), 2, cp.addUtf8(fileName), cp
                     .getConstantPool()));
         }
-        class_name_index = cp.addClass(class_name);
-        superclass_name_index = cp.addClass(super_class_name);
+        classNameIndex = cp.addClass(className);
+        superclass_name_index = cp.addClass(superClassName);
         if (interfaces != null) {
             for (final String interface1 : interfaces) {
                 addInterface(interface1);
@@ -114,15 +114,15 @@ public class ClassGen extends AccessFlags implements Cloneable {
 
     /** Convenience constructor to set up some important values initially.
      *
-     * @param class_name fully qualified class name
-     * @param super_class_name fully qualified superclass name
-     * @param file_name source file name
-     * @param access_flags access qualifiers
+     * @param className fully qualified class name
+     * @param superClassName fully qualified superclass name
+     * @param fileName source file name
+     * @param accessFlags access qualifiers
      * @param interfaces implemented interfaces
      */
-    public ClassGen(final String class_name, final String super_class_name, final String file_name, final int access_flags,
+    public ClassGen(final String className, final String superClassName, final String fileName, final int accessFlags,
             final String[] interfaces) {
-        this(class_name, super_class_name, file_name, access_flags, interfaces,
+        this(className, superClassName, fileName, accessFlags, interfaces,
                 new ConstantPoolGen());
     }
 
@@ -133,11 +133,11 @@ public class ClassGen extends AccessFlags implements Cloneable {
      */
     public ClassGen(final JavaClass clazz) {
         super(clazz.getAccessFlags());
-        class_name_index = clazz.getClassNameIndex();
+        classNameIndex = clazz.getClassNameIndex();
         superclass_name_index = clazz.getSuperclassNameIndex();
-        class_name = clazz.getClassName();
-        super_class_name = clazz.getSuperclassName();
-        file_name = clazz.getSourceFileName();
+        className = clazz.getClassName();
+        superClassName = clazz.getSuperclassName();
+        fileName = clazz.getSourceFileName();
         cp = new ConstantPoolGen(clazz.getConstantPool());
         major = clazz.getMajor();
         minor = clazz.getMinor();
@@ -205,18 +205,18 @@ public class ClassGen extends AccessFlags implements Cloneable {
         final Field[] fields = getFields();
         final Method[] methods = getMethods();
         Attribute[] attributes = null;
-        if (annotation_vec.isEmpty()) {
+        if (annotationList.isEmpty()) {
             attributes = getAttributes();
         } else {
             // TODO: Sometime later, trash any attributes called 'RuntimeVisibleAnnotations' or 'RuntimeInvisibleAnnotations'
             final Attribute[] annAttributes  = AnnotationEntryGen.getAnnotationAttributes(cp, getAnnotationEntries());
-            attributes = new Attribute[attribute_vec.size()+annAttributes.length];
-            attribute_vec.toArray(attributes);
-            System.arraycopy(annAttributes,0,attributes,attribute_vec.size(),annAttributes.length);
+            attributes = new Attribute[attributeList.size()+annAttributes.length];
+            attributeList.toArray(attributes);
+            System.arraycopy(annAttributes,0,attributes,attributeList.size(),annAttributes.length);
         }
         // Must be last since the above calls may still add something to it
         final ConstantPool _cp = this.cp.getFinalConstantPool();
-        return new JavaClass(class_name_index, superclass_name_index, file_name, major, minor,
+        return new JavaClass(classNameIndex, superclass_name_index, fileName, major, minor,
                 super.getAccessFlags(), _cp, interfaces, fields, methods, attributes);
     }
 
@@ -226,7 +226,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param name interface to implement (fully qualified class name)
      */
     public void addInterface( final String name ) {
-        interface_vec.add(name);
+        interfaceList.add(name);
     }
 
 
@@ -235,7 +235,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param name interface to remove (fully qualified name)
      */
     public void removeInterface( final String name ) {
-        interface_vec.remove(name);
+        interfaceList.remove(name);
     }
 
 
@@ -275,11 +275,11 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param a attribute to add
      */
     public void addAttribute( final Attribute a ) {
-        attribute_vec.add(a);
+        attributeList.add(a);
     }
 
     public void addAnnotationEntry(final AnnotationEntryGen a) {
-        annotation_vec.add(a);
+        annotationList.add(a);
     }
 
 
@@ -288,7 +288,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param m method to add
      */
     public void addMethod( final Method m ) {
-        method_vec.add(m);
+        methodList.add(m);
     }
 
 
@@ -301,10 +301,10 @@ public class ClassGen extends AccessFlags implements Cloneable {
     public void addEmptyConstructor( final int access_flags ) {
         final InstructionList il = new InstructionList();
         il.append(InstructionConst.THIS); // Push `this'
-        il.append(new INVOKESPECIAL(cp.addMethodref(super_class_name, "<init>", "()V")));
+        il.append(new INVOKESPECIAL(cp.addMethodref(superClassName, "<init>", "()V")));
         il.append(InstructionConst.RETURN);
         final MethodGen mg = new MethodGen(access_flags, Type.VOID, Type.NO_ARGS, null, "<init>",
-                class_name, il, cp);
+                className, il, cp);
         mg.setMaxStack(1);
         addMethod(mg.getMethod());
     }
@@ -315,19 +315,19 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param f field to add
      */
     public void addField( final Field f ) {
-        field_vec.add(f);
+        fieldList.add(f);
     }
 
 
     public boolean containsField( final Field f ) {
-        return field_vec.contains(f);
+        return fieldList.contains(f);
     }
 
 
     /** @return field object with given name, or null
      */
     public Field containsField( final String name ) {
-        for (final Field f : field_vec) {
+        for (final Field f : fieldList) {
             if (f.getName().equals(name)) {
                 return f;
             }
@@ -339,7 +339,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
     /** @return method object with given name and signature, or null
      */
     public Method containsMethod( final String name, final String signature ) {
-        for (final Method m : method_vec) {
+        for (final Method m : methodList) {
             if (m.getName().equals(name) && m.getSignature().equals(signature)) {
                 return m;
             }
@@ -353,7 +353,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param a attribute to remove
      */
     public void removeAttribute( final Attribute a ) {
-        attribute_vec.remove(a);
+        attributeList.remove(a);
     }
 
 
@@ -362,7 +362,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param m method to remove
      */
     public void removeMethod( final Method m ) {
-        method_vec.remove(m);
+        methodList.remove(m);
     }
 
 
@@ -373,11 +373,11 @@ public class ClassGen extends AccessFlags implements Cloneable {
         if (new_ == null) {
             throw new ClassGenException("Replacement method must not be null");
         }
-        final int i = method_vec.indexOf(old);
+        final int i = methodList.indexOf(old);
         if (i < 0) {
-            method_vec.add(new_);
+            methodList.add(new_);
         } else {
-            method_vec.set(i, new_);
+            methodList.set(i, new_);
         }
     }
 
@@ -389,11 +389,11 @@ public class ClassGen extends AccessFlags implements Cloneable {
         if (new_ == null) {
             throw new ClassGenException("Replacement method must not be null");
         }
-        final int i = field_vec.indexOf(old);
+        final int i = fieldList.indexOf(old);
         if (i < 0) {
-            field_vec.add(new_);
+            fieldList.add(new_);
         } else {
-            field_vec.set(i, new_);
+            fieldList.set(i, new_);
         }
     }
 
@@ -403,44 +403,44 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param f field to remove
      */
     public void removeField( final Field f ) {
-        field_vec.remove(f);
+        fieldList.remove(f);
     }
 
 
     public String getClassName() {
-        return class_name;
+        return className;
     }
 
 
     public String getSuperclassName() {
-        return super_class_name;
+        return superClassName;
     }
 
 
     public String getFileName() {
-        return file_name;
+        return fileName;
     }
 
 
     public void setClassName( final String name ) {
-        class_name = name.replace('/', '.');
-        class_name_index = cp.addClass(name);
+        className = name.replace('/', '.');
+        classNameIndex = cp.addClass(name);
     }
 
 
     public void setSuperclassName( final String name ) {
-        super_class_name = name.replace('/', '.');
+        superClassName = name.replace('/', '.');
         superclass_name_index = cp.addClass(name);
     }
 
 
     public Method[] getMethods() {
-        return method_vec.toArray(new Method[method_vec.size()]);
+        return methodList.toArray(new Method[methodList.size()]);
     }
 
 
     public void setMethods( final Method[] methods ) {
-        method_vec.clear();
+        methodList.clear();
         for (final Method method : methods) {
             addMethod(method);
         }
@@ -448,45 +448,45 @@ public class ClassGen extends AccessFlags implements Cloneable {
 
 
     public void setMethodAt( final Method method, final int pos ) {
-        method_vec.set(pos, method);
+        methodList.set(pos, method);
     }
 
 
     public Method getMethodAt( final int pos ) {
-        return method_vec.get(pos);
+        return methodList.get(pos);
     }
 
 
     public String[] getInterfaceNames() {
-        final int size = interface_vec.size();
+        final int size = interfaceList.size();
         final String[] interfaces = new String[size];
-        interface_vec.toArray(interfaces);
+        interfaceList.toArray(interfaces);
         return interfaces;
     }
 
 
     public int[] getInterfaces() {
-        final int size = interface_vec.size();
+        final int size = interfaceList.size();
         final int[] interfaces = new int[size];
         for (int i = 0; i < size; i++) {
-            interfaces[i] = cp.addClass(interface_vec.get(i));
+            interfaces[i] = cp.addClass(interfaceList.get(i));
         }
         return interfaces;
     }
 
 
     public Field[] getFields() {
-        return field_vec.toArray(new Field[field_vec.size()]);
+        return fieldList.toArray(new Field[fieldList.size()]);
     }
 
 
     public Attribute[] getAttributes() {
-        return attribute_vec.toArray(new Attribute[attribute_vec.size()]);
+        return attributeList.toArray(new Attribute[attributeList.size()]);
     }
 
     //  J5TODO: Should we make calling unpackAnnotations() lazy and put it in here?
     public AnnotationEntryGen[] getAnnotationEntries() {
-        return annotation_vec.toArray(new AnnotationEntryGen[annotation_vec.size()]);
+        return annotationList.toArray(new AnnotationEntryGen[annotationList.size()]);
     }
 
 
@@ -501,15 +501,15 @@ public class ClassGen extends AccessFlags implements Cloneable {
 
 
     public void setClassNameIndex( final int class_name_index ) {
-        this.class_name_index = class_name_index;
-        class_name = cp.getConstantPool().getConstantString(class_name_index,
+        this.classNameIndex = class_name_index;
+        className = cp.getConstantPool().getConstantString(class_name_index,
                 Const.CONSTANT_Class).replace('/', '.');
     }
 
 
     public void setSuperclassNameIndex( final int superclass_name_index ) {
         this.superclass_name_index = superclass_name_index;
-        super_class_name = cp.getConstantPool().getConstantString(superclass_name_index,
+        superClassName = cp.getConstantPool().getConstantString(superclass_name_index,
                 Const.CONSTANT_Class).replace('/', '.');
     }
 
@@ -520,7 +520,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
 
 
     public int getClassNameIndex() {
-        return class_name_index;
+        return classNameIndex;
     }
 
     private List<ClassObserver> observers;
@@ -572,7 +572,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @return Comparison strategy object
      */
     public static BCELComparator getComparator() {
-        return _cmp;
+        return bcelComparator;
     }
 
 
@@ -580,7 +580,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      * @param comparator Comparison strategy object
      */
     public static void setComparator( final BCELComparator comparator ) {
-        _cmp = comparator;
+        bcelComparator = comparator;
     }
 
 
@@ -593,7 +593,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      */
     @Override
     public boolean equals( final Object obj ) {
-        return _cmp.equals(this, obj);
+        return bcelComparator.equals(this, obj);
     }
 
 
@@ -605,6 +605,6 @@ public class ClassGen extends AccessFlags implements Cloneable {
      */
     @Override
     public int hashCode() {
-        return _cmp.hashCode(this);
+        return bcelComparator.hashCode(this);
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CodeExceptionGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/CodeExceptionGen.java
@@ -37,27 +37,27 @@ import com.sun.org.apache.bcel.internal.classfile.CodeException;
  */
 public final class CodeExceptionGen implements InstructionTargeter, Cloneable {
 
-    private InstructionHandle start_pc;
-    private InstructionHandle end_pc;
-    private InstructionHandle handler_pc;
-    private ObjectType catch_type;
+    private InstructionHandle startPc;
+    private InstructionHandle endPc;
+    private InstructionHandle handlerPc;
+    private ObjectType catchType;
 
 
     /**
      * Add an exception handler, i.e., specify region where a handler is active and an
      * instruction where the actual handling is done.
      *
-     * @param start_pc Start of handled region (inclusive)
-     * @param end_pc End of handled region (inclusive)
-     * @param handler_pc Where handling is done
-     * @param catch_type which exception is handled, null for ANY
+     * @param startPc Start of handled region (inclusive)
+     * @param endPc End of handled region (inclusive)
+     * @param handlerPc Where handling is done
+     * @param catchType which exception is handled, null for ANY
      */
-    public CodeExceptionGen(final InstructionHandle start_pc, final InstructionHandle end_pc,
-            final InstructionHandle handler_pc, final ObjectType catch_type) {
-        setStartPC(start_pc);
-        setEndPC(end_pc);
-        setHandlerPC(handler_pc);
-        this.catch_type = catch_type;
+    public CodeExceptionGen(final InstructionHandle startPc, final InstructionHandle endPc,
+            final InstructionHandle handlerPc, final ObjectType catchType) {
+        setStartPC(startPc);
+        setEndPC(endPc);
+        setHandlerPC(handlerPc);
+        this.catchType = catchType;
     }
 
 
@@ -71,36 +71,36 @@ public final class CodeExceptionGen implements InstructionTargeter, Cloneable {
      * @param cp constant pool
      */
     public CodeException getCodeException( final ConstantPoolGen cp ) {
-        return new CodeException(start_pc.getPosition(), end_pc.getPosition()
-                + end_pc.getInstruction().getLength(), handler_pc.getPosition(),
-                (catch_type == null) ? 0 : cp.addClass(catch_type));
+        return new CodeException(startPc.getPosition(), endPc.getPosition()
+                + endPc.getInstruction().getLength(), handlerPc.getPosition(),
+                (catchType == null) ? 0 : cp.addClass(catchType));
     }
 
 
     /* Set start of handler
-     * @param start_pc Start of handled region (inclusive)
+     * @param startPc Start of handled region (inclusive)
      */
     public void setStartPC( final InstructionHandle start_pc ) { // TODO could be package-protected?
-        BranchInstruction.notifyTarget(this.start_pc, start_pc, this);
-        this.start_pc = start_pc;
+        BranchInstruction.notifyTarget(this.startPc, start_pc, this);
+        this.startPc = start_pc;
     }
 
 
     /* Set end of handler
-     * @param end_pc End of handled region (inclusive)
+     * @param endPc End of handled region (inclusive)
      */
     public void setEndPC( final InstructionHandle end_pc ) { // TODO could be package-protected?
-        BranchInstruction.notifyTarget(this.end_pc, end_pc, this);
-        this.end_pc = end_pc;
+        BranchInstruction.notifyTarget(this.endPc, end_pc, this);
+        this.endPc = end_pc;
     }
 
 
     /* Set handler code
-     * @param handler_pc Start of handler
+     * @param handlerPc Start of handler
      */
     public void setHandlerPC( final InstructionHandle handler_pc ) { // TODO could be package-protected?
-        BranchInstruction.notifyTarget(this.handler_pc, handler_pc, this);
-        this.handler_pc = handler_pc;
+        BranchInstruction.notifyTarget(this.handlerPc, handler_pc, this);
+        this.handlerPc = handler_pc;
     }
 
 
@@ -111,21 +111,21 @@ public final class CodeExceptionGen implements InstructionTargeter, Cloneable {
     @Override
     public void updateTarget( final InstructionHandle old_ih, final InstructionHandle new_ih ) {
         boolean targeted = false;
-        if (start_pc == old_ih) {
+        if (startPc == old_ih) {
             targeted = true;
             setStartPC(new_ih);
         }
-        if (end_pc == old_ih) {
+        if (endPc == old_ih) {
             targeted = true;
             setEndPC(new_ih);
         }
-        if (handler_pc == old_ih) {
+        if (handlerPc == old_ih) {
             targeted = true;
             setHandlerPC(new_ih);
         }
         if (!targeted) {
-            throw new ClassGenException("Not targeting " + old_ih + ", but {" + start_pc + ", "
-                    + end_pc + ", " + handler_pc + "}");
+            throw new ClassGenException("Not targeting " + old_ih + ", but {" + startPc + ", "
+                    + endPc + ", " + handlerPc + "}");
         }
     }
 
@@ -135,46 +135,46 @@ public final class CodeExceptionGen implements InstructionTargeter, Cloneable {
      */
     @Override
     public boolean containsTarget( final InstructionHandle ih ) {
-        return (start_pc == ih) || (end_pc == ih) || (handler_pc == ih);
+        return (startPc == ih) || (endPc == ih) || (handlerPc == ih);
     }
 
 
     /** Sets the type of the Exception to catch. Set 'null' for ANY. */
-    public void setCatchType( final ObjectType catch_type ) {
-        this.catch_type = catch_type;
+    public void setCatchType( final ObjectType catchType ) {
+        this.catchType = catchType;
     }
 
 
     /** Gets the type of the Exception to catch, 'null' for ANY. */
     public ObjectType getCatchType() {
-        return catch_type;
+        return catchType;
     }
 
 
     /** @return start of handled region (inclusive)
      */
     public InstructionHandle getStartPC() {
-        return start_pc;
+        return startPc;
     }
 
 
     /** @return end of handled region (inclusive)
      */
     public InstructionHandle getEndPC() {
-        return end_pc;
+        return endPc;
     }
 
 
     /** @return start of handler
      */
     public InstructionHandle getHandlerPC() {
-        return handler_pc;
+        return handlerPc;
     }
 
 
     @Override
     public String toString() {
-        return "CodeExceptionGen(" + start_pc + ", " + end_pc + ", " + handler_pc + ")";
+        return "CodeExceptionGen(" + startPc + ", " + endPc + ", " + handlerPc + ")";
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConstantPoolGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ConstantPoolGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -50,7 +50,7 @@ import com.sun.org.apache.bcel.internal.classfile.ConstantUtf8;
  * JVM and that Double and Long constants need two slots.
  *
  * @see Constant
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class ConstantPoolGen {
 
@@ -98,15 +98,15 @@ public class ConstantPoolGen {
                 final ConstantString s = (ConstantString) c;
                 final ConstantUtf8 u8 = (ConstantUtf8) constants[s.getStringIndex()];
                 final String key = u8.getBytes();
-                if (!string_table.containsKey(key)) {
-                    string_table.put(key, new Index(i));
+                if (!stringTable.containsKey(key)) {
+                    stringTable.put(key, new Index(i));
                 }
             } else if (c instanceof ConstantClass) {
                 final ConstantClass s = (ConstantClass) c;
                 final ConstantUtf8 u8 = (ConstantUtf8) constants[s.getNameIndex()];
                 final String key = u8.getBytes();
-                if (!class_table.containsKey(key)) {
-                    class_table.put(key, new Index(i));
+                if (!classTable.containsKey(key)) {
+                    classTable.put(key, new Index(i));
                 }
             } else if (c instanceof ConstantNameAndType) {
                 final ConstantNameAndType n = (ConstantNameAndType) c;
@@ -119,14 +119,14 @@ public class ConstantPoolGen {
                 final String key = sb.toString();
                 sb.delete(0, sb.length());
 
-                if (!n_a_t_table.containsKey(key)) {
-                    n_a_t_table.put(key, new Index(i));
+                if (!natTable.containsKey(key)) {
+                    natTable.put(key, new Index(i));
                 }
             } else if (c instanceof ConstantUtf8) {
                 final ConstantUtf8 u = (ConstantUtf8) c;
                 final String key = u.getBytes();
-                if (!utf8_table.containsKey(key)) {
-                    utf8_table.put(key, new Index(i));
+                if (!utf8Table.containsKey(key)) {
+                    utf8Table.put(key, new Index(i));
                 }
             } else if (c instanceof ConstantCP) {
                 final ConstantCP m = (ConstantCP) c;
@@ -164,8 +164,8 @@ public class ConstantPoolGen {
                 final String key = sb.toString();
                 sb.delete(0, sb.length());
 
-                if (!cp_table.containsKey(key)) {
-                    cp_table.put(key, new Index(i));
+                if (!cpTable.containsKey(key)) {
+                    cpTable.put(key, new Index(i));
                 }
             } else if (c == null) { // entries may be null
                 // nothing to do
@@ -220,7 +220,7 @@ public class ConstantPoolGen {
         }
     }
 
-    private final Map<String, Index> string_table = new HashMap<>();
+    private final Map<String, Index> stringTable = new HashMap<>();
 
 
     /**
@@ -230,7 +230,7 @@ public class ConstantPoolGen {
      * @return index on success, -1 otherwise
      */
     public int lookupString( final String str ) {
-        final Index index = string_table.get(str);
+        final Index index = stringTable.get(str);
         return (index != null) ? index.index : -1;
     }
 
@@ -251,13 +251,13 @@ public class ConstantPoolGen {
         final ConstantString s = new ConstantString(utf8);
         ret = index;
         constants[index++] = s;
-        if (!string_table.containsKey(str)) {
-            string_table.put(str, new Index(ret));
+        if (!stringTable.containsKey(str)) {
+            stringTable.put(str, new Index(ret));
         }
         return ret;
     }
 
-    private final Map<String, Index> class_table = new HashMap<>();
+    private final Map<String, Index> classTable = new HashMap<>();
 
 
     /**
@@ -267,7 +267,7 @@ public class ConstantPoolGen {
      * @return index on success, -1 otherwise
      */
     public int lookupClass( final String str ) {
-        final Index index = class_table.get(str.replace('.', '/'));
+        final Index index = classTable.get(str.replace('.', '/'));
         return (index != null) ? index.index : -1;
     }
 
@@ -281,8 +281,8 @@ public class ConstantPoolGen {
         final ConstantClass c = new ConstantClass(addUtf8(clazz));
         ret = index;
         constants[index++] = c;
-        if (!class_table.containsKey(clazz)) {
-            class_table.put(clazz, new Index(ret));
+        if (!classTable.containsKey(clazz)) {
+            classTable.put(clazz, new Index(ret));
         }
         return ret;
     }
@@ -396,7 +396,7 @@ public class ConstantPoolGen {
         return ret;
     }
 
-    private final Map<String, Index> utf8_table = new HashMap<>();
+    private final Map<String, Index> utf8Table = new HashMap<>();
 
 
     /**
@@ -406,7 +406,7 @@ public class ConstantPoolGen {
      * @return index on success, -1 otherwise
      */
     public int lookupUtf8( final String n ) {
-        final Index index = utf8_table.get(n);
+        final Index index = utf8Table.get(n);
         return (index != null) ? index.index : -1;
     }
 
@@ -425,8 +425,8 @@ public class ConstantPoolGen {
         adjustSize();
         ret = index;
         constants[index++] = new ConstantUtf8(n);
-        if (!utf8_table.containsKey(n)) {
-            utf8_table.put(n, new Index(ret));
+        if (!utf8Table.containsKey(n)) {
+            utf8Table.put(n, new Index(ret));
         }
         return ret;
     }
@@ -508,7 +508,7 @@ public class ConstantPoolGen {
         return ret;
     }
 
-    private final Map<String, Index> n_a_t_table = new HashMap<>();
+    private final Map<String, Index> natTable = new HashMap<>();
 
 
     /**
@@ -519,7 +519,7 @@ public class ConstantPoolGen {
      * @return index on success, -1 otherwise
      */
     public int lookupNameAndType( final String name, final String signature ) {
-        final Index _index = n_a_t_table.get(name + NAT_DELIM + signature);
+        final Index _index = natTable.get(name + NAT_DELIM + signature);
         return (_index != null) ? _index.index : -1;
     }
 
@@ -545,13 +545,13 @@ public class ConstantPoolGen {
         ret = index;
         constants[index++] = new ConstantNameAndType(name_index, signature_index);
         final String key = name + NAT_DELIM + signature;
-        if (!n_a_t_table.containsKey(key)) {
-            n_a_t_table.put(key, new Index(ret));
+        if (!natTable.containsKey(key)) {
+            natTable.put(key, new Index(ret));
         }
         return ret;
     }
 
-    private final Map<String, Index> cp_table = new HashMap<>();
+    private final Map<String, Index> cpTable = new HashMap<>();
 
 
     /**
@@ -563,7 +563,7 @@ public class ConstantPoolGen {
      * @return index on success, -1 otherwise
      */
     public int lookupMethodref( final String class_name, final String method_name, final String signature ) {
-        final Index index = cp_table.get(class_name + METHODREF_DELIM + method_name
+        final Index index = cpTable.get(class_name + METHODREF_DELIM + method_name
                 + METHODREF_DELIM + signature);
         return (index != null) ? index.index : -1;
     }
@@ -596,8 +596,8 @@ public class ConstantPoolGen {
         ret = index;
         constants[index++] = new ConstantMethodref(class_index, name_and_type_index);
         final String key = class_name + METHODREF_DELIM + method_name + METHODREF_DELIM + signature;
-        if (!cp_table.containsKey(key)) {
-            cp_table.put(key, new Index(ret));
+        if (!cpTable.containsKey(key)) {
+            cpTable.put(key, new Index(ret));
         }
         return ret;
     }
@@ -617,7 +617,7 @@ public class ConstantPoolGen {
      * @return index on success, -1 otherwise
      */
     public int lookupInterfaceMethodref( final String class_name, final String method_name, final String signature ) {
-        final Index index = cp_table.get(class_name + IMETHODREF_DELIM + method_name
+        final Index index = cpTable.get(class_name + IMETHODREF_DELIM + method_name
                 + IMETHODREF_DELIM + signature);
         return (index != null) ? index.index : -1;
     }
@@ -651,8 +651,8 @@ public class ConstantPoolGen {
         ret = index;
         constants[index++] = new ConstantInterfaceMethodref(class_index, name_and_type_index);
         final String key = class_name + IMETHODREF_DELIM + method_name + IMETHODREF_DELIM + signature;
-        if (!cp_table.containsKey(key)) {
-            cp_table.put(key, new Index(ret));
+        if (!cpTable.containsKey(key)) {
+            cpTable.put(key, new Index(ret));
         }
         return ret;
     }
@@ -672,7 +672,7 @@ public class ConstantPoolGen {
      * @return index on success, -1 otherwise
      */
     public int lookupFieldref( final String class_name, final String field_name, final String signature ) {
-        final Index index = cp_table.get(class_name + FIELDREF_DELIM + field_name
+        final Index index = cpTable.get(class_name + FIELDREF_DELIM + field_name
                 + FIELDREF_DELIM + signature);
         return (index != null) ? index.index : -1;
     }
@@ -700,8 +700,8 @@ public class ConstantPoolGen {
         ret = index;
         constants[index++] = new ConstantFieldref(class_index, name_and_type_index);
         final String key = class_name + FIELDREF_DELIM + field_name + FIELDREF_DELIM + signature;
-        if (!cp_table.containsKey(key)) {
-            cp_table.put(key, new Index(ret));
+        if (!cpTable.containsKey(key)) {
+            cpTable.put(key, new Index(ret));
         }
         return ret;
     }
@@ -817,11 +817,11 @@ public class ConstantPoolGen {
                     case Const.CONSTANT_Fieldref:
                         return addFieldref(class_name, name, signature);
                     default: // Never reached
-                        throw new RuntimeException("Unknown constant type " + c);
+                        throw new IllegalArgumentException("Unknown constant type " + c);
                 }
             }
             default: // Never reached
-                throw new RuntimeException("Unknown constant type " + c);
+                throw new IllegalArgumentException("Unknown constant type " + c);
         }
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ElementValueGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ElementValueGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -34,7 +34,7 @@ import com.sun.org.apache.bcel.internal.classfile.SimpleElementValue;
 
 /**
  * @since 6.0
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public abstract class ElementValueGen
 {
@@ -141,7 +141,7 @@ public abstract class ElementValueGen
             }
             return new ArrayElementValueGen(ARRAY, evalues, cpGen);
         default:
-            throw new RuntimeException("Unexpected element value kind in annotation: " + type);
+            throw new IllegalArgumentException("Unexpected element value kind in annotation: " + type);
         }
     }
 
@@ -183,7 +183,7 @@ public abstract class ElementValueGen
             return new ClassElementValueGen((ClassElementValue) value, cpool,
                     copyPoolEntries);
         default:
-            throw new RuntimeException("Not implemented yet! (" + value.getElementValueType() + ")");
+            throw new UnsupportedOperationException("Not implemented yet! (" + value.getElementValueType() + ")");
         }
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ElementValuePairGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ElementValuePairGen.java
@@ -37,19 +37,19 @@ public class ElementValuePairGen
 
     private final ElementValueGen value;
 
-    private final ConstantPoolGen cpool;
+    private final ConstantPoolGen constantPoolGen;
 
     public ElementValuePairGen(final ElementValuePair nvp, final ConstantPoolGen cpool,
             final boolean copyPoolEntries)
     {
-        this.cpool = cpool;
+        this.constantPoolGen = cpool;
         // J5ASSERT:
         // Could assert nvp.getNameString() points to the same thing as
-        // cpool.getConstant(nvp.getNameIndex())
+        // constantPoolGen.getConstant(nvp.getNameIndex())
         // if
-        // (!nvp.getNameString().equals(((ConstantUtf8)cpool.getConstant(nvp.getNameIndex())).getBytes()))
+        // (!nvp.getNameString().equals(((ConstantUtf8)constantPoolGen.getConstant(nvp.getNameIndex())).getBytes()))
         // {
-        // throw new RuntimeException("envp buggered");
+        // throw new IllegalArgumentException("envp buggered");
         // }
         if (copyPoolEntries)
         {
@@ -68,7 +68,7 @@ public class ElementValuePairGen
     public ElementValuePair getElementNameValuePair()
     {
         final ElementValue immutableValue = value.getElementValue();
-        return new ElementValuePair(nameIdx, immutableValue, cpool
+        return new ElementValuePair(nameIdx, immutableValue, constantPoolGen
                 .getConstantPool());
     }
 
@@ -77,7 +77,7 @@ public class ElementValuePairGen
     {
         this.nameIdx = idx;
         this.value = value;
-        this.cpool = cpool;
+        this.constantPoolGen = cpool;
     }
 
     public ElementValuePairGen(final String name, final ElementValueGen value,
@@ -85,7 +85,7 @@ public class ElementValuePairGen
     {
         this.nameIdx = cpool.addUtf8(name);
         this.value = value;
-        this.cpool = cpool;
+        this.constantPoolGen = cpool;
     }
 
     protected void dump(final DataOutputStream dos) throws IOException
@@ -101,8 +101,8 @@ public class ElementValuePairGen
 
     public final String getNameString()
     {
-        // ConstantString cu8 = (ConstantString)cpool.getConstant(nameIdx);
-        return ((ConstantUtf8) cpool.getConstant(nameIdx)).getBytes();
+        // ConstantString cu8 = (ConstantString)constantPoolGen.getConstant(nameIdx);
+        return ((ConstantUtf8) constantPoolGen.getConstant(nameIdx)).getBytes();
     }
 
     public final ElementValueGen getValue()

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/EnumElementValueGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/EnumElementValueGen.java
@@ -48,7 +48,7 @@ public class EnumElementValueGen extends ElementValueGen
     {
         super(ElementValueGen.ENUM_CONSTANT, cpool);
         if (super.getElementValueType() != ENUM_CONSTANT) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "Only element values of type enum can be built with this ctor - type specified: "
                             + super.getElementValueType());
         }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -41,7 +41,7 @@ import com.sun.org.apache.bcel.internal.util.BCELComparator;
  * course be compatible with to the declared type).
  *
  * @see Field
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class FieldGen extends FieldGenOrMethodGen {
 
@@ -255,7 +255,7 @@ public class FieldGen extends FieldGenOrMethodGen {
             case Const.T_REFERENCE:
                 return super.getConstantPool().addString((String) value);
             default:
-                throw new RuntimeException("Oops: Unhandled : " + super.getType().getType()); // sic
+                throw new IllegalStateException("Unhandled : " + super.getType().getType()); // sic
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGenOrMethodGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/FieldGenOrMethodGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,7 +30,7 @@ import com.sun.org.apache.bcel.internal.classfile.Attribute;
  * Super class for FieldGen and MethodGen objects, since they have
  * some methods in common!
  *
- * @LastModified: Jun 2020
+ * @LastModified: May 2021
  */
 public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAndTyped, Cloneable {
 
@@ -38,10 +38,10 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
     private Type type;
     private ConstantPoolGen cp;
 
-    private final List<Attribute> attribute_vec = new ArrayList<>();
+    private final List<Attribute> attributeList = new ArrayList<>();
 
     // @since 6.0
-    private final List<AnnotationEntryGen>       annotation_vec= new ArrayList<>();
+    private final List<AnnotationEntryGen> annotationList = new ArrayList<>();
 
 
     protected FieldGenOrMethodGen() {
@@ -103,15 +103,15 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
      * @param a attribute to be added
      */
     public void addAttribute( final Attribute a ) {
-        attribute_vec.add(a);
+        attributeList.add(a);
     }
 
     /**
      * @since 6.0
      */
-    protected void addAnnotationEntry(final AnnotationEntryGen ag) // TODO could this be package protected?
+    public void addAnnotationEntry(final AnnotationEntryGen ag)
     {
-        annotation_vec.add(ag);
+        annotationList.add(ag);
     }
 
 
@@ -119,15 +119,15 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
      * Remove an attribute.
      */
     public void removeAttribute( final Attribute a ) {
-        attribute_vec.remove(a);
+        attributeList.remove(a);
     }
 
     /**
      * @since 6.0
      */
-    protected void removeAnnotationEntry(final AnnotationEntryGen ag) // TODO could this be package protected?
+    public void removeAnnotationEntry(final AnnotationEntryGen ag)
     {
-        annotation_vec.remove(ag);
+        annotationList.remove(ag);
     }
 
 
@@ -135,15 +135,15 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
      * Remove all attributes.
      */
     public void removeAttributes() {
-        attribute_vec.clear();
+        attributeList.clear();
     }
 
     /**
      * @since 6.0
      */
-    protected void removeAnnotationEntries() // TODO could this be package protected?
+    public void removeAnnotationEntries()
     {
-        annotation_vec.clear();
+        annotationList.clear();
     }
 
 
@@ -151,15 +151,11 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
      * @return all attributes of this method.
      */
     public Attribute[] getAttributes() {
-        final Attribute[] attributes = new Attribute[attribute_vec.size()];
-        attribute_vec.toArray(attributes);
-        return attributes;
+        return attributeList.toArray(new Attribute[0]);
     }
 
     public AnnotationEntryGen[] getAnnotationEntries() {
-        final AnnotationEntryGen[] annotations = new AnnotationEntryGen[annotation_vec.size()];
-          annotation_vec.toArray(annotations);
-          return annotations;
+        return annotationList.toArray(new AnnotationEntryGen[0]);
       }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEDYNAMIC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEDYNAMIC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -36,10 +36,10 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  * mechanism entirely.
  *
  * @see
- * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic">
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic">
  * The invokedynamic instruction in The Java Virtual Machine Specification</a>
  * @since 6.0
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class INVOKEDYNAMIC extends InvokeInstruction {
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEINTERFACE.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEINTERFACE.java
@@ -34,7 +34,7 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  * <PRE>Stack: ..., objectref, [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
  * @see
- * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokeinterface">
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokeinterface">
  * The invokeinterface instruction in The Java Virtual Machine Specification</a>
  */
 public final class INVOKEINTERFACE extends InvokeInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESPECIAL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESPECIAL.java
@@ -34,7 +34,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * <PRE>Stack: ..., objectref, [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
  * @see
- * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial">
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokespecial">
  * The invokespecial instruction in The Java Virtual Machine Specification</a>
  */
 public class INVOKESPECIAL extends InvokeInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESTATIC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKESTATIC.java
@@ -33,7 +33,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * <PRE>Stack: ..., [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
  * @see
- * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokestatic">
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokestatic">
  * The invokestatic instruction in The Java Virtual Machine Specification</a>
  */
 public class INVOKESTATIC extends InvokeInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEVIRTUAL.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/INVOKEVIRTUAL.java
@@ -33,7 +33,7 @@ import com.sun.org.apache.bcel.internal.ExceptionConst;
  * <PRE>Stack: ..., objectref, [arg1, [arg2 ...]] -&gt; ...</PRE>
  *
  * @see
- * <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokevirtual">
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokevirtual">
  * The invokevirtual instruction in The Java Virtual Machine Specification</a>
  */
 public class INVOKEVIRTUAL extends InvokeInstruction {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -32,7 +32,7 @@ import com.sun.org.apache.bcel.internal.Const;
  *
  * @see Const
  * @see InstructionConst
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class InstructionFactory {
 
@@ -76,30 +76,52 @@ public class InstructionFactory {
      */
     public InvokeInstruction createInvoke( final String class_name, final String name,
             final Type ret_type, final Type[] arg_types, final short kind ) {
+        return createInvoke(class_name, name, ret_type, arg_types, kind, kind == Const.INVOKEINTERFACE);
+    }
+
+    /**
+     * Creates an invoke instruction. (Except for invokedynamic.)
+     *
+     * @param class_name name of the called class
+     * @param name name of the called method
+     * @param ret_type return type of method
+     * @param arg_types argument types of method
+     * @param kind how to invoke: INVOKEINTERFACE, INVOKESTATIC, INVOKEVIRTUAL, or INVOKESPECIAL
+     * @param use_interface force use of InterfaceMethodref
+     * @return A new InvokeInstruction.
+     * @since 6.5.0
+     */
+    public InvokeInstruction createInvoke( final String class_name, final String name, final Type ret_type,
+        final Type[] arg_types, final short kind, final boolean use_interface) {
+        if (kind != Const.INVOKESPECIAL && kind != Const.INVOKEVIRTUAL && kind != Const.INVOKESTATIC
+            && kind != Const.INVOKEINTERFACE && kind != Const.INVOKEDYNAMIC) {
+            throw new IllegalArgumentException("Unknown invoke kind: " + kind);
+        }
         int index;
         int nargs = 0;
         final String signature = Type.getMethodSignature(ret_type, arg_types);
         for (final Type arg_type : arg_types) {
             nargs += arg_type.getSize();
         }
-        if (kind == Const.INVOKEINTERFACE) {
+        if (use_interface) {
             index = cp.addInterfaceMethodref(class_name, name, signature);
         } else {
             index = cp.addMethodref(class_name, name, signature);
         }
         switch (kind) {
-            case Const.INVOKESPECIAL:
-                return new INVOKESPECIAL(index);
-            case Const.INVOKEVIRTUAL:
-                return new INVOKEVIRTUAL(index);
-            case Const.INVOKESTATIC:
-                return new INVOKESTATIC(index);
-            case Const.INVOKEINTERFACE:
-                return new INVOKEINTERFACE(index, nargs + 1);
-            case Const.INVOKEDYNAMIC:
-                return new INVOKEDYNAMIC(index);
-            default:
-                throw new RuntimeException("Oops: Unknown invoke kind: " + kind);
+        case Const.INVOKESPECIAL:
+            return new INVOKESPECIAL(index);
+        case Const.INVOKEVIRTUAL:
+            return new INVOKEVIRTUAL(index);
+        case Const.INVOKESTATIC:
+            return new INVOKESTATIC(index);
+        case Const.INVOKEINTERFACE:
+            return new INVOKEINTERFACE(index, nargs + 1);
+        case Const.INVOKEDYNAMIC:
+            return new INVOKEDYNAMIC(index);
+        default:
+            // Can't happen
+            throw new IllegalStateException("Unknown invoke kind: " + kind);
         }
     }
 
@@ -248,7 +270,7 @@ public class InstructionFactory {
             case Const.T_OBJECT:
                 return createInvoke(append_mos[1], Const.INVOKEVIRTUAL);
             default:
-                throw new RuntimeException("Oops: No append for this type? " + type);
+                throw new IllegalArgumentException("No append for this type? " + type);
         }
     }
 
@@ -276,7 +298,7 @@ public class InstructionFactory {
             case Const.PUTSTATIC:
                 return new PUTSTATIC(index);
             default:
-                throw new RuntimeException("Oops: Unknown getfield kind:" + kind);
+                throw new IllegalArgumentException("Unknown getfield kind:" + kind);
         }
     }
 
@@ -310,7 +332,7 @@ public class InstructionFactory {
             case Const.T_VOID:
                 return InstructionConst.RETURN;
             default:
-                throw new RuntimeException("Invalid type: " + type);
+                throw new IllegalArgumentException("Invalid type: " + type);
         }
     }
 
@@ -338,7 +360,7 @@ public class InstructionFactory {
             case '>':
                 return op.equals(">>>") ? InstructionConst.IUSHR : InstructionConst.ISHR;
             default:
-                throw new RuntimeException("Invalid operand " + op);
+                throw new IllegalArgumentException("Invalid operand " + op);
         }
     }
 
@@ -366,7 +388,7 @@ public class InstructionFactory {
             case '>':
                 return op.equals(">>>") ? InstructionConst.LUSHR : InstructionConst.LSHR;
             default:
-                throw new RuntimeException("Invalid operand " + op);
+                throw new IllegalArgumentException("Invalid operand " + op);
         }
     }
 
@@ -384,7 +406,7 @@ public class InstructionFactory {
             case '%':
                 return InstructionConst.FREM;
             default:
-                throw new RuntimeException("Invalid operand " + op);
+                throw new IllegalArgumentException("Invalid operand " + op);
         }
     }
 
@@ -402,7 +424,7 @@ public class InstructionFactory {
             case '%':
                 return InstructionConst.DREM;
             default:
-                throw new RuntimeException("Invalid operand " + op);
+                throw new IllegalArgumentException("Invalid operand " + op);
         }
     }
 
@@ -427,7 +449,7 @@ public class InstructionFactory {
             case Const.T_DOUBLE:
                 return createBinaryDoubleOp(first);
             default:
-                throw new RuntimeException("Invalid type " + type);
+                throw new IllegalArgumentException("Invalid type " + type);
         }
     }
 
@@ -485,7 +507,7 @@ public class InstructionFactory {
             case Const.T_OBJECT:
                 return new ASTORE(index);
             default:
-                throw new RuntimeException("Invalid type " + type);
+                throw new IllegalArgumentException("Invalid type " + type);
         }
     }
 
@@ -511,7 +533,7 @@ public class InstructionFactory {
             case Const.T_OBJECT:
                 return new ALOAD(index);
             default:
-                throw new RuntimeException("Invalid type " + type);
+                throw new IllegalArgumentException("Invalid type " + type);
         }
     }
 
@@ -540,7 +562,7 @@ public class InstructionFactory {
             case Const.T_OBJECT:
                 return InstructionConst.AALOAD;
             default:
-                throw new RuntimeException("Invalid type " + type);
+                throw new IllegalArgumentException("Invalid type " + type);
         }
     }
 
@@ -569,7 +591,7 @@ public class InstructionFactory {
             case Const.T_OBJECT:
                 return InstructionConst.AASTORE;
             default:
-                throw new RuntimeException("Invalid type " + type);
+                throw new IllegalArgumentException("Invalid type " + type);
         }
     }
 
@@ -592,7 +614,7 @@ public class InstructionFactory {
             try {
                 i = (Instruction) java.lang.Class.forName(name).getDeclaredConstructor().newInstance();
             } catch (final Exception e) {
-                throw new RuntimeException("Could not find instruction: " + name, e);
+                throw new IllegalArgumentException("Could not find instruction: " + name, e);
             }
             return i;
         } else if ((src_type instanceof ReferenceType) && (dest_type instanceof ReferenceType)) {
@@ -601,7 +623,7 @@ public class InstructionFactory {
             }
             return new CHECKCAST(cp.addClass(((ObjectType) dest_type).getClassName()));
         } else {
-            throw new RuntimeException("Can not cast " + src_type + " to " + dest_type);
+            throw new IllegalArgumentException("Cannot cast " + src_type + " to " + dest_type);
         }
     }
 
@@ -699,7 +721,7 @@ public class InstructionFactory {
             case Const.T_VOID:
                 return InstructionConst.NOP;
             default:
-                throw new RuntimeException("Invalid type: " + type);
+                throw new IllegalArgumentException("Invalid type: " + type);
         }
     }
 
@@ -751,7 +773,7 @@ public class InstructionFactory {
             case Const.JSR_W:
                 return new JSR_W(target);
             default:
-                throw new RuntimeException("Invalid opcode: " + opcode);
+                throw new IllegalArgumentException("Invalid opcode: " + opcode);
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionHandle.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -42,7 +42,7 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  * @see Instruction
  * @see BranchHandle
  * @see InstructionList
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class InstructionHandle {
 
@@ -295,7 +295,7 @@ public class InstructionHandle {
 
     /**
      * @param next the next to set
-     * @ since 6.0
+     * @since 6.0
      */
     final InstructionHandle setNext(final InstructionHandle next) {
         this.next = next;
@@ -305,7 +305,7 @@ public class InstructionHandle {
 
     /**
      * @param prev the prev to set
-     * @ since 6.0
+     * @since 6.0
      */
     final InstructionHandle setPrev(final InstructionHandle prev) {
         this.prev = prev;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionList.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/InstructionList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
  /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -47,14 +47,14 @@ import java.util.NoSuchElementException;
  * @see Instruction
  * @see InstructionHandle
  * @see BranchHandle
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class InstructionList implements Iterable<InstructionHandle> {
 
     private InstructionHandle start = null;
     private InstructionHandle end = null;
     private int length = 0; // number of elements in list
-    private int[] byte_positions; // byte code offsets corresponding to instructions
+    private int[] bytePositions; // byte code offsets corresponding to instructions
 
     /**
      * Create (empty) instruction list.
@@ -145,7 +145,7 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * @return target position's instruction handle if available
      */
     public InstructionHandle findHandle(final int pos) {
-        final int[] positions = byte_positions;
+        final int[] positions = bytePositions;
         InstructionHandle ih = start;
         for (int i = 0; i < length; i++) {
             if (positions[i] == pos) {
@@ -193,8 +193,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
         } catch (final IOException e) {
             throw new ClassGenException(e.toString(), e);
         }
-        byte_positions = new int[count]; // Trim to proper size
-        System.arraycopy(pos, 0, byte_positions, 0, count);
+        bytePositions = new int[count]; // Trim to proper size
+        System.arraycopy(pos, 0, bytePositions, 0, count);
         /*
          * Pass 2: Look for BranchInstruction and update their targets, i.e., convert offsets to instruction handles.
          */
@@ -204,7 +204,7 @@ public class InstructionList implements Iterable<InstructionHandle> {
                 int target = bi.getPosition() + bi.getIndex();
                 /*
                  * Byte code position: relative -> absolute.
-                */
+                 */
                 // Search for target position
                 InstructionHandle ih = findHandle(ihs, pos, count, target);
                 if (ih == null) {
@@ -797,10 +797,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
     }
 
     /**
-     * Remove instructions from instruction `from' to instruction `to' contained
-     * in this list. The user must ensure that `from' is an instruction before
-     * `to', or risk havoc. The corresponding Instruction handles must not be
-     * reused!
+     * Remove instructions from instruction `from' to instruction `to' contained in this list. The user must ensure that `from' is an instruction before `to',
+     * or risk havoc. The corresponding Instruction handles must not be reused!
      *
      * @param from
      *            where to start deleting (inclusive)
@@ -960,8 +958,8 @@ public class InstructionList implements Iterable<InstructionHandle> {
             pos[count++] = index;
             index += i.getLength();
         }
-        byte_positions = new int[count]; // Trim to proper size
-        System.arraycopy(pos, 0, byte_positions, 0, count);
+        bytePositions = new int[count]; // Trim to proper size
+        System.arraycopy(pos, 0, bytePositions, 0, count);
     }
 
     /**
@@ -1074,7 +1072,7 @@ public class InstructionList implements Iterable<InstructionHandle> {
      * @return array containing all instruction's offset in byte code
      */
     public int[] getInstructionPositions() {
-        return byte_positions;
+        return bytePositions;
     }
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JsrInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/JsrInstruction.java
@@ -74,7 +74,7 @@ public abstract class JsrInstruction extends BranchInstruction implements Uncond
         while (ih != null) {
             ih = ih.getNext();
             if ((ih != null) && (ih.getInstruction() == this)) {
-                throw new RuntimeException("physicalSuccessor() called on a shared JsrInstruction.");
+                throw new IllegalStateException("physicalSuccessor() called on a shared JsrInstruction.");
             }
         }
         // Return the physical successor

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,7 +31,7 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
  *
  * <PRE>Stack: ... -&gt; ..., item</PRE>
  *
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class LDC extends CPInstruction implements PushInstruction, ExceptionThrower {
 
@@ -112,7 +112,7 @@ public class LDC extends CPInstruction implements PushInstruction, ExceptionThro
                 c = cpg.getConstantPool().getConstant(nameIndex);
                 return new ObjectType(((com.sun.org.apache.bcel.internal.classfile.ConstantUtf8) c).getBytes());
             default: // Never reached
-                throw new RuntimeException("Unknown or invalid constant type at " + super.getIndex());
+                throw new IllegalArgumentException("Unknown or invalid constant type at " + super.getIndex());
         }
     }
 
@@ -129,7 +129,7 @@ public class LDC extends CPInstruction implements PushInstruction, ExceptionThro
             case com.sun.org.apache.bcel.internal.Const.CONSTANT_Class:
                 return Type.CLASS;
             default: // Never reached
-                throw new RuntimeException("Unknown or invalid constant type at " + super.getIndex());
+                throw new IllegalArgumentException("Unknown or invalid constant type at " + super.getIndex());
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC2_W.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LDC2_W.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,7 +25,7 @@ package com.sun.org.apache.bcel.internal.generic;
  *
  * <PRE>Stack: ... -&gt; ..., item.word1, item.word2</PRE>
  *
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class LDC2_W extends CPInstruction implements PushInstruction {
 
@@ -50,7 +50,7 @@ public class LDC2_W extends CPInstruction implements PushInstruction {
             case com.sun.org.apache.bcel.internal.Const.CONSTANT_Double:
                 return Type.DOUBLE;
             default: // Never reached
-                throw new RuntimeException("Unknown constant type " + super.getOpcode());
+                throw new IllegalArgumentException("Unknown constant type " + super.getOpcode());
         }
     }
 
@@ -63,7 +63,7 @@ public class LDC2_W extends CPInstruction implements PushInstruction {
             case com.sun.org.apache.bcel.internal.Const.CONSTANT_Double:
                 return ((com.sun.org.apache.bcel.internal.classfile.ConstantDouble) c).getBytes();
             default: // Never reached
-                throw new RuntimeException("Unknown or invalid constant type at " + super.getIndex());
+                throw new IllegalArgumentException("Unknown or invalid constant type at " + super.getIndex());
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LineNumberGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LineNumberGen.java
@@ -21,6 +21,8 @@
 
 package com.sun.org.apache.bcel.internal.generic;
 
+import java.util.Objects;
+
 import com.sun.org.apache.bcel.internal.classfile.LineNumber;
 
 /**
@@ -33,8 +35,7 @@ import com.sun.org.apache.bcel.internal.classfile.LineNumber;
 public class LineNumberGen implements InstructionTargeter, Cloneable {
 
     private InstructionHandle ih;
-    private int src_line;
-
+    private int srcLine;
 
     /**
      * Create a line number.
@@ -76,16 +77,14 @@ public class LineNumberGen implements InstructionTargeter, Cloneable {
      * or that the `setPositions' methods has been called for the instruction list.
      */
     public LineNumber getLineNumber() {
-        return new LineNumber(ih.getPosition(), src_line);
+        return new LineNumber(ih.getPosition(), srcLine);
     }
 
 
-    public void setInstruction( final InstructionHandle ih ) { // TODO could be package-protected?
-        if (ih == null) {
-            throw new NullPointerException("InstructionHandle may not be null");
-        }
-        BranchInstruction.notifyTarget(this.ih, ih, this);
-        this.ih = ih;
+    public void setInstruction( final InstructionHandle instructionHandle ) { // TODO could be package-protected?
+        Objects.requireNonNull(instructionHandle, "instructionHandle");
+        BranchInstruction.notifyTarget(this.ih, instructionHandle, this);
+        this.ih = instructionHandle;
     }
 
 
@@ -105,11 +104,11 @@ public class LineNumberGen implements InstructionTargeter, Cloneable {
 
 
     public void setSourceLine( final int src_line ) { // TODO could be package-protected?
-        this.src_line = src_line;
+        this.srcLine = src_line;
     }
 
 
     public int getSourceLine() {
-        return src_line;
+        return srcLine;
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableGen.java
@@ -39,8 +39,8 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
     private Type type;
     private InstructionHandle start;
     private InstructionHandle end;
-    private int orig_index; // never changes; used to match up with LocalVariableTypeTable entries
-    private boolean live_to_end;
+    private int origIndex; // never changes; used to match up with LocalVariableTypeTable entries
+    private boolean liveToEnd;
 
 
     /**
@@ -63,8 +63,8 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
         this.index = index;
         setStart(start);
         setEnd(end);
-        this.orig_index = index;
-        this.live_to_end = end == null;
+        this.origIndex = index;
+        this.liveToEnd = end == null;
     }
 
 
@@ -77,12 +77,12 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
      * @param type its type
      * @param start from where the instruction is valid (null means from the start)
      * @param end until where the instruction is valid (null means to the end)
-     * @param orig_index index of local variable prior to any changes to index
+     * @param origIndex index of local variable prior to any changes to index
      */
     public LocalVariableGen(final int index, final String name, final Type type, final InstructionHandle start,
-            final InstructionHandle end, final int orig_index) {
+            final InstructionHandle end, final int origIndex) {
         this(index, name, type, start, end);
-        this.orig_index = orig_index;
+        this.origIndex = origIndex;
     }
 
 
@@ -95,7 +95,7 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
      * Note that due to the conversion from byte code offset to InstructionHandle,
      * it is impossible to tell the difference between a live range that ends BEFORE
      * the last insturction of the method or a live range that ends AFTER the last
-     * instruction of the method.  Hence the live_to_end flag to differentiate
+     * instruction of the method.  Hence the liveToEnd flag to differentiate
      * between these two cases.
      *
      * @param cp constant pool
@@ -106,14 +106,14 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
         if ((start != null) && (end != null)) {
             start_pc = start.getPosition();
             length = end.getPosition() - start_pc;
-            if ((end.getNext() == null) && live_to_end) {
+            if ((end.getNext() == null) && liveToEnd) {
                 length += end.getInstruction().getLength();
             }
         }
         final int name_index = cp.addUtf8(name);
         final int signature_index = cp.addUtf8(type.getSignature());
         return new LocalVariable(start_pc, length, name_index, signature_index, index, cp
-                .getConstantPool(), orig_index);
+                .getConstantPool(), origIndex);
     }
 
 
@@ -128,17 +128,17 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
 
 
     public int getOrigIndex() {
-        return orig_index;
+        return origIndex;
     }
 
 
     public void setLiveToEnd( final boolean live_to_end) {
-        this.live_to_end = live_to_end;
+        this.liveToEnd = live_to_end;
     }
 
 
     public boolean getLiveToEnd() {
-        return live_to_end;
+        return liveToEnd;
     }
 
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableInstruction.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/LocalVariableInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -28,14 +28,14 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * Abstract super class for instructions dealing with local variables.
  *
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public abstract class LocalVariableInstruction extends Instruction implements TypedInstruction,
         IndexedInstruction {
 
     private int n = -1; // index of referenced variable
-    private short c_tag = -1; // compact version, such as ILOAD_0
-    private short canon_tag = -1; // canonical tag such as ILOAD
+    private short cTag = -1; // compact version, such as ILOAD_0
+    private short canonTag = -1; // canonical tag such as ILOAD
 
 
     private boolean wide() {
@@ -50,8 +50,8 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
      */
     LocalVariableInstruction(final short canon_tag, final short c_tag) {
         super();
-        this.canon_tag = canon_tag;
-        this.c_tag = c_tag;
+        this.canonTag = canon_tag;
+        this.cTag = c_tag;
     }
 
 
@@ -65,13 +65,13 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
 
     /**
      * @param opcode Instruction opcode
-     * @param c_tag Instruction number for compact version, ALOAD_0, e.g.
+     * @param cTag Instruction number for compact version, ALOAD_0, e.g.
      * @param n local variable index (unsigned short)
      */
-    protected LocalVariableInstruction(final short opcode, final short c_tag, final int n) {
+    protected LocalVariableInstruction(final short opcode, final short cTag, final int n) {
         super(opcode, (short) 2);
-        this.c_tag = c_tag;
-        canon_tag = opcode;
+        this.cTag = cTag;
+        canonTag = opcode;
         setIndex(n);
     }
 
@@ -167,10 +167,10 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
         this.n = n;
         // Cannot be < 0 as this is checked above
         if (n <= 3) { // Use more compact instruction xLOAD_n
-            super.setOpcode((short) (c_tag + n));
+            super.setOpcode((short) (cTag + n));
             super.setLength(1);
         } else {
-            super.setOpcode(canon_tag);
+            super.setOpcode(canonTag);
             if (wide()) {
                 super.setLength(4);
             } else {
@@ -183,7 +183,7 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
     /** @return canonical tag for instruction, e.g., ALOAD for ALOAD_0
      */
     public short getCanonicalTag() {
-        return canon_tag;
+        return canonTag;
     }
 
 
@@ -197,7 +197,7 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
      */
     @Override
     public Type getType( final ConstantPoolGen cp ) {
-        switch (canon_tag) {
+        switch (canonTag) {
             case Const.ILOAD:
             case Const.ISTORE:
                 return Type.INT;
@@ -214,7 +214,7 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
             case Const.ASTORE:
                 return Type.OBJECT;
             default:
-                throw new ClassGenException("Oops: unknown case in switch" + canon_tag);
+                throw new ClassGenException("Unknown case in switch" + canonTag);
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MethodGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/MethodGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -57,25 +57,25 @@ import java.util.Stack;
  *
  * @see     InstructionList
  * @see     Method
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class MethodGen extends FieldGenOrMethodGen {
 
-    private String class_name;
-    private Type[] arg_types;
-    private String[] arg_names;
-    private int max_locals;
-    private int max_stack;
+    private String className;
+    private Type[] argTypes;
+    private String[] argNames;
+    private int maxLocals;
+    private int maxStack;
     private InstructionList il;
-    private boolean strip_attributes;
-    private LocalVariableTypeTable local_variable_type_table = null;
-    private final List<LocalVariableGen> variable_vec = new ArrayList<>();
-    private final List<LineNumberGen> line_number_vec = new ArrayList<>();
-    private final List<CodeExceptionGen> exception_vec = new ArrayList<>();
-    private final List<String> throws_vec = new ArrayList<>();
-    private final List<Attribute> code_attrs_vec = new ArrayList<>();
+    private boolean stripAttributes;
+    private LocalVariableTypeTable localVariableTypeTable = null;
+    private final List<LocalVariableGen> variableList = new ArrayList<>();
+    private final List<LineNumberGen> lineNumberList = new ArrayList<>();
+    private final List<CodeExceptionGen> exceptionList = new ArrayList<>();
+    private final List<String> throwsList = new ArrayList<>();
+    private final List<Attribute> codeAttrsList = new ArrayList<>();
 
-    private List<AnnotationEntryGen>[] param_annotations; // Array of lists containing AnnotationGen objects
+    private List<AnnotationEntryGen>[] paramAnnotations; // Array of lists containing AnnotationGen objects
     private boolean hasParameterAnnotations = false;
     private boolean haveUnpackedParameterAnnotations = false;
 
@@ -111,23 +111,23 @@ public class MethodGen extends FieldGenOrMethodGen {
      *
      * @param access_flags access qualifiers
      * @param return_type  method type
-     * @param arg_types argument types
-     * @param arg_names argument names (if this is null, default names will be provided
+     * @param argTypes argument types
+     * @param argNames argument names (if this is null, default names will be provided
      * for them)
      * @param method_name name of method
-     * @param class_name class name containing this method (may be null, if you don't care)
+     * @param className class name containing this method (may be null, if you don't care)
      * @param il instruction list associated with this method, may be null only for
      * abstract or native methods
      * @param cp constant pool
      */
-    public MethodGen(final int access_flags, final Type return_type, final Type[] arg_types, String[] arg_names,
-            final String method_name, final String class_name, final InstructionList il, final ConstantPoolGen cp) {
+    public MethodGen(final int access_flags, final Type return_type, final Type[] argTypes, String[] argNames,
+            final String method_name, final String className, final InstructionList il, final ConstantPoolGen cp) {
         super(access_flags);
         setType(return_type);
-        setArgumentTypes(arg_types);
-        setArgumentNames(arg_names);
+        setArgumentTypes(argTypes);
+        setArgumentNames(argNames);
         setName(method_name);
-        setClassName(class_name);
+        setClassName(className);
         setInstructionList(il);
         setConstantPool(cp);
         final boolean abstract_ = isAbstract() || isNative();
@@ -138,32 +138,32 @@ public class MethodGen extends FieldGenOrMethodGen {
             // end == null => live to end of method
             /* Add local variables, namely the implicit `this' and the arguments
              */
-            if (!isStatic() && (class_name != null)) { // Instance method -> `this' is local var 0
-                addLocalVariable("this",  ObjectType.getInstance(class_name), start, end);
+            if (!isStatic() && (className != null)) { // Instance method -> `this' is local var 0
+                addLocalVariable("this",  ObjectType.getInstance(className), start, end);
             }
         }
-        if (arg_types != null) {
-            final int size = arg_types.length;
-            for (final Type arg_type : arg_types) {
+        if (argTypes != null) {
+            final int size = argTypes.length;
+            for (final Type arg_type : argTypes) {
                 if (Type.VOID == arg_type) {
                     throw new ClassGenException("'void' is an illegal argument type for a method");
                 }
             }
-            if (arg_names != null) { // Names for variables provided?
-                if (size != arg_names.length) {
+            if (argNames != null) { // Names for variables provided?
+                if (size != argNames.length) {
                     throw new ClassGenException("Mismatch in argument array lengths: " + size
-                            + " vs. " + arg_names.length);
+                            + " vs. " + argNames.length);
                 }
             } else { // Give them dummy names
-                arg_names = new String[size];
+                argNames = new String[size];
                 for (int i = 0; i < size; i++) {
-                    arg_names[i] = "arg" + i;
+                    argNames[i] = "arg" + i;
                 }
-                setArgumentNames(arg_names);
+                setArgumentNames(argNames);
             }
             if (!abstract_) {
                 for (int i = 0; i < size; i++) {
-                    addLocalVariable(arg_names[i], arg_types[i], start, end);
+                    addLocalVariable(argNames[i], argTypes[i], start, end);
                 }
             }
         }
@@ -173,18 +173,19 @@ public class MethodGen extends FieldGenOrMethodGen {
     /**
      * Instantiate from existing method.
      *
-     * @param m method
-     * @param class_name class name containing this method
+     * @param method method
+     * @param className class name containing this method
      * @param cp constant pool
      */
-    public MethodGen(final Method m, final String class_name, final ConstantPoolGen cp) {
-        this(m.getAccessFlags(), Type.getReturnType(m.getSignature()), Type.getArgumentTypes(m
-                .getSignature()), null /* may be overridden anyway */
-        , m.getName(), class_name,
-                ((m.getAccessFlags() & (Const.ACC_ABSTRACT | Const.ACC_NATIVE)) == 0)
-                        ? new InstructionList(m.getCode().getCode())
-                        : null, cp);
-        final Attribute[] attributes = m.getAttributes();
+    public MethodGen(final Method method, final String className, final ConstantPoolGen cp) {
+        this(method.getAccessFlags(), Type.getReturnType(method.getSignature()),
+            Type.getArgumentTypes(method.getSignature()), null /* may be overridden anyway */
+            , method.getName(), className,
+            ((method.getAccessFlags() & (Const.ACC_ABSTRACT | Const.ACC_NATIVE)) == 0)
+                ? new InstructionList(getByteCodes(method))
+                : null,
+            cp);
+        final Attribute[] attributes = method.getAttributes();
         for (final Attribute attribute : attributes) {
             Attribute a = attribute;
             if (a instanceof Code) {
@@ -197,12 +198,12 @@ public class MethodGen extends FieldGenOrMethodGen {
                         final int type = ce.getCatchType();
                         ObjectType c_type = null;
                         if (type > 0) {
-                            final String cen = m.getConstantPool().getConstantString(type,
+                            final String cen = method.getConstantPool().getConstantString(type,
                                     Const.CONSTANT_Class);
                             c_type =  ObjectType.getInstance(cen);
                         }
                         final int end_pc = ce.getEndPC();
-                        final int length = m.getCode().getCode().length;
+                        final int length = getByteCodes(method).length;
                         InstructionHandle end;
                         if (length == end_pc) { // May happen, because end_pc is exclusive
                             end = il.getEnd();
@@ -210,8 +211,8 @@ public class MethodGen extends FieldGenOrMethodGen {
                             end = il.findHandle(end_pc);
                             end = end.getPrev(); // Make it inclusive
                         }
-                        addExceptionHandler(il.findHandle(ce.getStartPC()), end, il.findHandle(ce
-                                .getHandlerPC()), c_type);
+                        addExceptionHandler(il.findHandle(ce.getStartPC()), end,
+                                il.findHandle(ce.getHandlerPC()), c_type);
                     }
                 }
                 final Attribute[] c_attributes = c.getAttributes();
@@ -228,7 +229,7 @@ public class MethodGen extends FieldGenOrMethodGen {
                     } else if (a instanceof LocalVariableTable) {
                         updateLocalVariableTable((LocalVariableTable) a);
                     } else if (a instanceof LocalVariableTypeTable) {
-                        this.local_variable_type_table = (LocalVariableTypeTable) a.copy(cp.getConstantPool());
+                        this.localVariableTypeTable = (LocalVariableTypeTable) a.copy(cp.getConstantPool());
                     } else {
                         addCodeAttribute(a);
                     }
@@ -250,6 +251,15 @@ public class MethodGen extends FieldGenOrMethodGen {
         }
     }
 
+
+    private static byte[] getByteCodes(final Method method) {
+        final Code code = method.getCode();
+        if (code == null) {
+            throw new IllegalStateException(String.format("The method '%s' has no code.", method));
+        }
+        return code.getCode();
+    }
+
     /**
      * Adds a local variable to this method.
      *
@@ -268,15 +278,15 @@ public class MethodGen extends FieldGenOrMethodGen {
         final byte t = type.getType();
         if (t != Const.T_ADDRESS) {
             final int add = type.getSize();
-            if (slot + add > max_locals) {
-                max_locals = slot + add;
+            if (slot + add > maxLocals) {
+                maxLocals = slot + add;
             }
             final LocalVariableGen l = new LocalVariableGen(slot, name, type, start, end, orig_index);
             int i;
-            if ((i = variable_vec.indexOf(l)) >= 0) {
-                variable_vec.set(i, l);
+            if ((i = variableList.indexOf(l)) >= 0) {
+                variableList.set(i, l);
             } else {
-                variable_vec.add(l);
+                variableList.add(l);
             }
             return l;
         }
@@ -316,7 +326,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      */
     public LocalVariableGen addLocalVariable( final String name, final Type type, final InstructionHandle start,
             final InstructionHandle end ) {
-        return addLocalVariable(name, type, max_locals, start, end);
+        return addLocalVariable(name, type, maxLocals, start, end);
     }
 
 
@@ -325,7 +335,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * addLocalVariable with an explicit index argument.
      */
     public void removeLocalVariable(final LocalVariableGen l) {
-        variable_vec.remove(l);
+        variableList.remove(l);
     }
 
 
@@ -333,7 +343,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove all local variables.
      */
     public void removeLocalVariables() {
-        variable_vec.clear();
+        variableList.clear();
     }
 
 
@@ -344,9 +354,9 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return array of declared local variables sorted by index
      */
     public LocalVariableGen[] getLocalVariables() {
-        final int size = variable_vec.size();
+        final int size = variableList.size();
         final LocalVariableGen[] lg = new LocalVariableGen[size];
-        variable_vec.toArray(lg);
+        variableList.toArray(lg);
         for (int i = 0; i < size; i++) {
             if ((lg[i].getStart() == null) && (il != null)) {
                 lg[i].setStart(il.getStart());
@@ -380,7 +390,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return `LocalVariableTypeTable' attribute of this method.
      */
     public LocalVariableTypeTable getLocalVariableTypeTable() {
-        return local_variable_type_table;
+        return localVariableTypeTable;
     }
 
     /**
@@ -390,9 +400,9 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return new line number object
      * @see LineNumber
      */
-    public LineNumberGen addLineNumber( final InstructionHandle ih, final int src_line ) {
-        final LineNumberGen l = new LineNumberGen(ih, src_line);
-        line_number_vec.add(l);
+    public LineNumberGen addLineNumber( final InstructionHandle ih, final int srcLine ) {
+        final LineNumberGen l = new LineNumberGen(ih, srcLine);
+        lineNumberList.add(l);
         return l;
     }
 
@@ -401,7 +411,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove a line number.
      */
     public void removeLineNumber( final LineNumberGen l ) {
-        line_number_vec.remove(l);
+        lineNumberList.remove(l);
     }
 
 
@@ -409,7 +419,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove all line numbers.
      */
     public void removeLineNumbers() {
-        line_number_vec.clear();
+        lineNumberList.clear();
     }
 
 
@@ -417,8 +427,8 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return array of line numbers
      */
     public LineNumberGen[] getLineNumbers() {
-        final LineNumberGen[] lg = new LineNumberGen[line_number_vec.size()];
-        line_number_vec.toArray(lg);
+        final LineNumberGen[] lg = new LineNumberGen[lineNumberList.size()];
+        lineNumberList.toArray(lg);
         return lg;
     }
 
@@ -427,10 +437,10 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return `LineNumberTable' attribute of all the local variables of this method.
      */
     public LineNumberTable getLineNumberTable( final ConstantPoolGen cp ) {
-        final int size = line_number_vec.size();
+        final int size = lineNumberList.size();
         final LineNumber[] ln = new LineNumber[size];
         for (int i = 0; i < size; i++) {
-            ln[i] = line_number_vec.get(i).getLineNumber();
+            ln[i] = lineNumberList.get(i).getLineNumber();
         }
         return new LineNumberTable(cp.addUtf8("LineNumberTable"), 2 + ln.length * 4, ln, cp
                 .getConstantPool());
@@ -454,7 +464,7 @@ public class MethodGen extends FieldGenOrMethodGen {
             throw new ClassGenException("Exception handler target is null instruction");
         }
         final CodeExceptionGen c = new CodeExceptionGen(start_pc, end_pc, handler_pc, catch_type);
-        exception_vec.add(c);
+        exceptionList.add(c);
         return c;
     }
 
@@ -463,7 +473,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove an exception handler.
      */
     public void removeExceptionHandler( final CodeExceptionGen c ) {
-        exception_vec.remove(c);
+        exceptionList.remove(c);
     }
 
 
@@ -471,7 +481,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove all line numbers.
      */
     public void removeExceptionHandlers() {
-        exception_vec.clear();
+        exceptionList.clear();
     }
 
 
@@ -479,8 +489,8 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return array of declared exception handlers
      */
     public CodeExceptionGen[] getExceptionHandlers() {
-        final CodeExceptionGen[] cg = new CodeExceptionGen[exception_vec.size()];
-        exception_vec.toArray(cg);
+        final CodeExceptionGen[] cg = new CodeExceptionGen[exceptionList.size()];
+        exceptionList.toArray(cg);
         return cg;
     }
 
@@ -489,10 +499,10 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return code exceptions for `Code' attribute
      */
     private CodeException[] getCodeExceptions() {
-        final int size = exception_vec.size();
+        final int size = exceptionList.size();
         final CodeException[] c_exc = new CodeException[size];
         for (int i = 0; i < size; i++) {
-            final CodeExceptionGen c =  exception_vec.get(i);
+            final CodeExceptionGen c =  exceptionList.get(i);
             c_exc[i] = c.getCodeException(super.getConstantPool());
         }
         return c_exc;
@@ -502,10 +512,10 @@ public class MethodGen extends FieldGenOrMethodGen {
     /**
      * Add an exception possibly thrown by this method.
      *
-     * @param class_name (fully qualified) name of exception
+     * @param className (fully qualified) name of exception
      */
-    public void addException( final String class_name ) {
-        throws_vec.add(class_name);
+    public void addException( final String className ) {
+        throwsList.add(className);
     }
 
 
@@ -513,7 +523,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove an exception.
      */
     public void removeException( final String c ) {
-        throws_vec.remove(c);
+        throwsList.remove(c);
     }
 
 
@@ -521,7 +531,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove all exceptions.
      */
     public void removeExceptions() {
-        throws_vec.clear();
+        throwsList.clear();
     }
 
 
@@ -529,9 +539,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return array of thrown exceptions
      */
     public String[] getExceptions() {
-        final String[] e = new String[throws_vec.size()];
-        throws_vec.toArray(e);
-        return e;
+        return throwsList.toArray(new String[0]);
     }
 
 
@@ -539,10 +547,10 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return `Exceptions' attribute of all the exceptions thrown by this method.
      */
     private ExceptionTable getExceptionTable( final ConstantPoolGen cp ) {
-        final int size = throws_vec.size();
+        final int size = throwsList.size();
         final int[] ex = new int[size];
         for (int i = 0; i < size; i++) {
-            ex[i] = cp.addClass(throws_vec.get(i));
+            ex[i] = cp.addClass(throwsList.get(i));
         }
         return new ExceptionTable(cp.addUtf8("Exceptions"), 2 + 2 * size, ex, cp.getConstantPool());
     }
@@ -558,7 +566,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @param a attribute to be added
      */
     public void addCodeAttribute( final Attribute a ) {
-        code_attrs_vec.add(a);
+        codeAttrsList.add(a);
     }
 
 
@@ -566,14 +574,14 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove the LocalVariableTypeTable
      */
     public void removeLocalVariableTypeTable( ) {
-        local_variable_type_table = null;
+        localVariableTypeTable = null;
     }
 
     /**
      * Remove a code attribute.
      */
     public void removeCodeAttribute( final Attribute a ) {
-        code_attrs_vec.remove(a);
+        codeAttrsList.remove(a);
     }
 
 
@@ -581,8 +589,8 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Remove all code attributes.
      */
     public void removeCodeAttributes() {
-        local_variable_type_table = null;
-        code_attrs_vec.clear();
+        localVariableTypeTable = null;
+        codeAttrsList.clear();
     }
 
 
@@ -590,35 +598,63 @@ public class MethodGen extends FieldGenOrMethodGen {
      * @return all attributes of this method.
      */
     public Attribute[] getCodeAttributes() {
-        final Attribute[] attributes = new Attribute[code_attrs_vec.size()];
-        code_attrs_vec.toArray(attributes);
-        return attributes;
+        return codeAttrsList.toArray(new Attribute[0]);
     }
 
     /**
      * @since 6.0
      */
     public void addAnnotationsAsAttribute(final ConstantPoolGen cp) {
-          final Attribute[] attrs = AnnotationEntryGen.getAnnotationAttributes(cp, super.getAnnotationEntries());
+        final Attribute[] attrs = AnnotationEntryGen.getAnnotationAttributes(cp, super.getAnnotationEntries());
         for (final Attribute attr : attrs) {
             addAttribute(attr);
         }
-      }
+    }
 
     /**
      * @since 6.0
      */
-      public void addParameterAnnotationsAsAttribute(final ConstantPoolGen cp) {
-          if (!hasParameterAnnotations) {
-              return;
-          }
-          final Attribute[] attrs = AnnotationEntryGen.getParameterAnnotationAttributes(cp,param_annotations);
-          if (attrs != null) {
-              for (final Attribute attr : attrs) {
-                  addAttribute(attr);
-              }
-          }
-      }
+    public void addParameterAnnotationsAsAttribute(final ConstantPoolGen cp) {
+        if (!hasParameterAnnotations) {
+            return;
+        }
+        final Attribute[] attrs = AnnotationEntryGen.getParameterAnnotationAttributes(cp, paramAnnotations);
+        if (attrs != null) {
+            for (final Attribute attr : attrs) {
+                addAttribute(attr);
+            }
+        }
+    }
+
+    private Attribute[] addRuntimeAnnotationsAsAttribute(final ConstantPoolGen cp) {
+        final Attribute[] attrs = AnnotationEntryGen.getAnnotationAttributes(cp, super.getAnnotationEntries());
+        for (final Attribute attr : attrs) {
+            addAttribute(attr);
+        }
+        return attrs;
+    }
+
+    private Attribute[] addRuntimeParameterAnnotationsAsAttribute(final ConstantPoolGen cp) {
+        if (!hasParameterAnnotations) {
+            return new Attribute[0];
+        }
+        final Attribute[] attrs = AnnotationEntryGen.getParameterAnnotationAttributes(cp, paramAnnotations);
+        for (final Attribute attr : attrs) {
+            addAttribute(attr);
+        }
+        return attrs;
+    }
+
+    /**
+     * Would prefer to make this private, but need a way to test if client is
+     * using BCEL version 6.5.0 or later that contains fix for BCEL-329.
+     * @since 6.5.0
+     */
+    public void removeRuntimeAttributes(final Attribute[] attrs) {
+        for (final Attribute attr : attrs) {
+            removeAttribute(attr);
+        }
+    }
 
 
     /**
@@ -642,18 +678,18 @@ public class MethodGen extends FieldGenOrMethodGen {
         LocalVariableTable lvt = null;
         /* Create LocalVariableTable and LineNumberTable attributes (for debuggers, e.g.)
          */
-        if ((variable_vec.size() > 0) && !strip_attributes) {
+        if ((variableList.size() > 0) && !stripAttributes) {
             updateLocalVariableTable(getLocalVariableTable(_cp));
             addCodeAttribute(lvt = getLocalVariableTable(_cp));
         }
-        if (local_variable_type_table != null) {
+        if (localVariableTypeTable != null) {
             // LocalVariable length in LocalVariableTypeTable is not updated automatically. It's a difference with LocalVariableTable.
             if (lvt != null) {
                 adjustLocalVariableTypeTable(lvt);
             }
-            addCodeAttribute(local_variable_type_table);
+            addCodeAttribute(localVariableTypeTable);
         }
-        if ((line_number_vec.size() > 0) && !strip_attributes) {
+        if ((lineNumberList.size() > 0) && !stripAttributes) {
             addCodeAttribute(lnt = getLineNumberTable(_cp));
         }
         final Attribute[] code_attrs = getCodeAttributes();
@@ -677,13 +713,13 @@ public class MethodGen extends FieldGenOrMethodGen {
             code = new Code(_cp.addUtf8("Code"), 8 + byte_code.length + // prologue byte code
                     2 + exc_len + // exceptions
                     2 + attrs_len, // attributes
-                    max_stack, max_locals, byte_code, c_exc, code_attrs, _cp.getConstantPool());
+                    maxStack, maxLocals, byte_code, c_exc, code_attrs, _cp.getConstantPool());
             addAttribute(code);
         }
-        addAnnotationsAsAttribute(_cp);
-        addParameterAnnotationsAsAttribute(_cp);
+        final Attribute[] annotations = addRuntimeAnnotationsAsAttribute(_cp);
+        final Attribute[] parameterAnnotations = addRuntimeParameterAnnotationsAsAttribute(_cp);
         ExceptionTable et = null;
-        if (throws_vec.size() > 0) {
+        if (throwsList.size() > 0) {
             addAttribute(et = getExceptionTable(_cp));
             // Add `Exceptions' if there are "throws" clauses
         }
@@ -693,8 +729,8 @@ public class MethodGen extends FieldGenOrMethodGen {
         if (lvt != null) {
             removeCodeAttribute(lvt);
         }
-        if (local_variable_type_table != null) {
-            removeCodeAttribute(local_variable_type_table);
+        if (localVariableTypeTable != null) {
+            removeCodeAttribute(localVariableTypeTable);
         }
         if (lnt != null) {
             removeCodeAttribute(lnt);
@@ -705,6 +741,8 @@ public class MethodGen extends FieldGenOrMethodGen {
         if (et != null) {
             removeAttribute(et);
         }
+        removeRuntimeAttributes(annotations);
+        removeRuntimeAttributes(parameterAnnotations);
         return m;
     }
 
@@ -728,7 +766,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
     private void adjustLocalVariableTypeTable(final LocalVariableTable lvt) {
         final LocalVariable[] lv = lvt.getLocalVariableTable();
-        final LocalVariable[] lvg = local_variable_type_table.getLocalVariableTypeTable();
+        final LocalVariable[] lvg = localVariableTypeTable.getLocalVariableTypeTable();
 
         for (final LocalVariable element : lvg) {
             for (final LocalVariable l : lv) {
@@ -775,12 +813,12 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Set maximum number of local variables.
      */
     public void setMaxLocals( final int m ) {
-        max_locals = m;
+        maxLocals = m;
     }
 
 
     public int getMaxLocals() {
-        return max_locals;
+        return maxLocals;
     }
 
 
@@ -788,24 +826,24 @@ public class MethodGen extends FieldGenOrMethodGen {
      * Set maximum stack size for this method.
      */
     public void setMaxStack( final int m ) { // TODO could be package-protected?
-        max_stack = m;
+        maxStack = m;
     }
 
 
     public int getMaxStack() {
-        return max_stack;
+        return maxStack;
     }
 
 
     /** @return class that contains this method
      */
     public String getClassName() {
-        return class_name;
+        return className;
     }
 
 
     public void setClassName( final String class_name ) { // TODO could be package-protected?
-        this.class_name = class_name;
+        this.className = class_name;
     }
 
 
@@ -820,42 +858,42 @@ public class MethodGen extends FieldGenOrMethodGen {
 
 
     public void setArgumentTypes( final Type[] arg_types ) {
-        this.arg_types = arg_types;
+        this.argTypes = arg_types;
     }
 
 
     public Type[] getArgumentTypes() {
-        return arg_types.clone();
+        return argTypes.clone();
     }
 
 
     public void setArgumentType( final int i, final Type type ) {
-        arg_types[i] = type;
+        argTypes[i] = type;
     }
 
 
     public Type getArgumentType( final int i ) {
-        return arg_types[i];
+        return argTypes[i];
     }
 
 
     public void setArgumentNames( final String[] arg_names ) {
-        this.arg_names = arg_names;
+        this.argNames = arg_names;
     }
 
 
     public String[] getArgumentNames() {
-        return arg_names.clone();
+        return argNames.clone();
     }
 
 
     public void setArgumentName( final int i, final String name ) {
-        arg_names[i] = name;
+        argNames[i] = name;
     }
 
 
     public String getArgumentName( final int i ) {
-        return arg_names[i];
+        return argNames[i];
     }
 
 
@@ -871,7 +909,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
     @Override
     public String getSignature() {
-        return Type.getMethodSignature(super.getType(), arg_types);
+        return Type.getMethodSignature(super.getType(), argTypes);
     }
 
 
@@ -880,9 +918,9 @@ public class MethodGen extends FieldGenOrMethodGen {
      */
     public void setMaxStack() { // TODO could be package-protected? (some tests would need repackaging)
         if (il != null) {
-            max_stack = getMaxStack(super.getConstantPool(), il, getExceptionHandlers());
+            maxStack = getMaxStack(super.getConstantPool(), il, getExceptionHandlers());
         } else {
-            max_stack = 0;
+            maxStack = 0;
         }
     }
 
@@ -893,8 +931,8 @@ public class MethodGen extends FieldGenOrMethodGen {
     public void setMaxLocals() { // TODO could be package-protected? (some tests would need repackaging)
         if (il != null) {
             int max = isStatic() ? 0 : 1;
-            if (arg_types != null) {
-                for (final Type arg_type : arg_types) {
+            if (argTypes != null) {
+                for (final Type arg_type : argTypes) {
                     max += arg_type.getSize();
                 }
             }
@@ -909,9 +947,9 @@ public class MethodGen extends FieldGenOrMethodGen {
                     }
                 }
             }
-            max_locals = max;
+            maxLocals = max;
         } else {
-            max_locals = 0;
+            maxLocals = 0;
         }
     }
 
@@ -920,7 +958,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      * LocalVariableTable, like javac -O
      */
     public void stripAttributes( final boolean flag ) {
-        strip_attributes = flag;
+        stripAttributes = flag;
     }
 
     static final class BranchTarget {
@@ -1091,7 +1129,7 @@ public class MethodGen extends FieldGenOrMethodGen {
     @Override
     public final String toString() {
         final String access = Utility.accessToString(super.getAccessFlags());
-        String signature = Type.getMethodSignature(super.getType(), arg_types);
+        String signature = Type.getMethodSignature(super.getType(), argTypes);
         signature = Utility.methodSignatureToString(signature, super.getName(), access, true,
                 getLocalVariableTable(super.getConstantPool()));
         final StringBuilder buf = new StringBuilder(signature);
@@ -1101,8 +1139,8 @@ public class MethodGen extends FieldGenOrMethodGen {
             }
         }
 
-        if (throws_vec.size() > 0) {
-            for (final String throwsDescriptor : throws_vec) {
+        if (throwsList.size() > 0) {
+            for (final String throwsDescriptor : throwsList) {
                 buf.append("\n\t\tthrows ").append(throwsDescriptor);
             }
         }
@@ -1112,9 +1150,9 @@ public class MethodGen extends FieldGenOrMethodGen {
 
     /** @return deep copy of this method
      */
-    public MethodGen copy( final String class_name, final ConstantPoolGen cp ) {
+    public MethodGen copy( final String className, final ConstantPoolGen cp ) {
         final Method m = ((MethodGen) clone()).getMethod();
-        final MethodGen mg = new MethodGen(m, class_name, super.getConstantPool());
+        final MethodGen mg = new MethodGen(m, className, super.getConstantPool());
         if (super.getConstantPool() != cp) {
             mg.setConstantPool(cp);
             mg.getInstructionList().replaceConstantPool(super.getConstantPool(), cp);
@@ -1122,7 +1160,7 @@ public class MethodGen extends FieldGenOrMethodGen {
         return mg;
     }
 
-    //J5TODO: Should param_annotations be an array of arrays? Rather than an array of lists, this
+    //J5TODO: Should paramAnnotations be an array of arrays? Rather than an array of lists, this
     // is more likely to suggest to the caller it is readonly (which a List does not).
     /**
      * Return a list of AnnotationGen objects representing parameter annotations
@@ -1130,10 +1168,10 @@ public class MethodGen extends FieldGenOrMethodGen {
      */
     public List<AnnotationEntryGen> getAnnotationsOnParameter(final int i) {
         ensureExistingParameterAnnotationsUnpacked();
-        if (!hasParameterAnnotations || i > arg_types.length) {
+        if (!hasParameterAnnotations || i > argTypes.length) {
             return null;
         }
-        return param_annotations[i];
+        return paramAnnotations[i];
     }
 
     /**
@@ -1156,14 +1194,14 @@ public class MethodGen extends FieldGenOrMethodGen {
         for (final Attribute attribute : attrs) {
             if (attribute instanceof ParameterAnnotations)
             {
-                // Initialize param_annotations
+                // Initialize paramAnnotations
                 if (!hasParameterAnnotations)
                 {
-                    @SuppressWarnings({"rawtypes", "unchecked"})
-                    final List<AnnotationEntryGen>[] parmList = new List[arg_types.length];
-                    param_annotations = parmList;
-                    for (int j = 0; j < arg_types.length; j++) {
-                        param_annotations[j] = new ArrayList<>();
+                    @SuppressWarnings({"rawtypes", "unchecked"}) // OK
+                    final List<AnnotationEntryGen>[] parmList = new List[argTypes.length];
+                    paramAnnotations = parmList;
+                    for (int j = 0; j < argTypes.length; j++) {
+                        paramAnnotations[j] = new ArrayList<>();
                     }
                 }
                 hasParameterAnnotations = true;
@@ -1181,7 +1219,7 @@ public class MethodGen extends FieldGenOrMethodGen {
                     // ... which needs transforming into an AnnotationGen[] ...
                     final List<AnnotationEntryGen> mutable = makeMutableVersion(immutableArray.getAnnotationEntries());
                     // ... then add these to any we already know about
-                    param_annotations[j].addAll(mutable);
+                    paramAnnotations[j].addAll(mutable);
                 }
             }
         }
@@ -1211,11 +1249,11 @@ public class MethodGen extends FieldGenOrMethodGen {
         if (!hasParameterAnnotations)
         {
             @SuppressWarnings({"rawtypes", "unchecked"})
-            final List<AnnotationEntryGen>[] parmList = new List[arg_types.length];
-            param_annotations = parmList;
+            final List<AnnotationEntryGen>[] parmList = new List[argTypes.length];
+            paramAnnotations = parmList;
             hasParameterAnnotations = true;
         }
-        final List<AnnotationEntryGen> existingAnnotations = param_annotations[parameterIndex];
+        final List<AnnotationEntryGen> existingAnnotations = paramAnnotations[parameterIndex];
         if (existingAnnotations != null)
         {
             existingAnnotations.add(annotation);
@@ -1224,7 +1262,7 @@ public class MethodGen extends FieldGenOrMethodGen {
         {
             final List<AnnotationEntryGen> l = new ArrayList<>();
             l.add(annotation);
-            param_annotations[parameterIndex] = l;
+            paramAnnotations[parameterIndex] = l;
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ObjectType.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/ObjectType.java
@@ -31,28 +31,28 @@ import com.sun.org.apache.bcel.internal.classfile.JavaClass;
  */
 public class ObjectType extends ReferenceType {
 
-    private final String class_name; // Class name of type
+    private final String className; // Class name of type
 
     /**
      * @since 6.0
      */
-    public static ObjectType getInstance(final String class_name) {
-        return new ObjectType(class_name);
+    public static ObjectType getInstance(final String className) {
+        return new ObjectType(className);
     }
 
     /**
-     * @param class_name fully qualified class name, e.g. java.lang.String
+     * @param className fully qualified class name, e.g. java.lang.String
      */
-    public ObjectType(final String class_name) {
-        super(Const.T_REFERENCE, "L" + class_name.replace('.', '/') + ";");
-        this.class_name = class_name.replace('/', '.');
+    public ObjectType(final String className) {
+        super(Const.T_REFERENCE, "L" + className.replace('.', '/') + ";");
+        this.className = className.replace('/', '.');
     }
 
 
     /** @return name of referenced class
      */
     public String getClassName() {
-        return class_name;
+        return className;
     }
 
 
@@ -60,7 +60,7 @@ public class ObjectType extends ReferenceType {
      */
     @Override
     public int hashCode() {
-        return class_name.hashCode();
+        return className.hashCode();
     }
 
 
@@ -69,7 +69,7 @@ public class ObjectType extends ReferenceType {
     @Override
     public boolean equals( final Object type ) {
         return (type instanceof ObjectType)
-                ? ((ObjectType) type).class_name.equals(class_name)
+                ? ((ObjectType) type).className.equals(className)
                 : false;
     }
 
@@ -84,7 +84,7 @@ public class ObjectType extends ReferenceType {
     @Deprecated
     public boolean referencesClass() {
         try {
-            final JavaClass jc = Repository.lookupClass(class_name);
+            final JavaClass jc = Repository.lookupClass(className);
             return jc.isClass();
         } catch (final ClassNotFoundException e) {
             return false;
@@ -102,7 +102,7 @@ public class ObjectType extends ReferenceType {
     @Deprecated
     public boolean referencesInterface() {
         try {
-            final JavaClass jc = Repository.lookupClass(class_name);
+            final JavaClass jc = Repository.lookupClass(className);
             return !jc.isClass();
         } catch (final ClassNotFoundException e) {
             return false;
@@ -119,7 +119,7 @@ public class ObjectType extends ReferenceType {
      *   referenced by this type can't be found
      */
     public boolean referencesClassExact() throws ClassNotFoundException {
-        final JavaClass jc = Repository.lookupClass(class_name);
+        final JavaClass jc = Repository.lookupClass(className);
         return jc.isClass();
     }
 
@@ -133,7 +133,7 @@ public class ObjectType extends ReferenceType {
      *   referenced by this type can't be found
      */
     public boolean referencesInterfaceExact() throws ClassNotFoundException {
-        final JavaClass jc = Repository.lookupClass(class_name);
+        final JavaClass jc = Repository.lookupClass(className);
         return !jc.isClass();
     }
 
@@ -147,7 +147,7 @@ public class ObjectType extends ReferenceType {
         if (this.referencesInterfaceExact() || superclass.referencesInterfaceExact()) {
             return false;
         }
-        return Repository.instanceOf(this.class_name, superclass.class_name);
+        return Repository.instanceOf(this.className, superclass.className);
     }
 
 
@@ -157,11 +157,11 @@ public class ObjectType extends ReferenceType {
      *   can't be found
      */
     public boolean accessibleTo( final ObjectType accessor ) throws ClassNotFoundException {
-        final JavaClass jc = Repository.lookupClass(class_name);
+        final JavaClass jc = Repository.lookupClass(className);
         if (jc.isPublic()) {
             return true;
         }
-        final JavaClass acc = Repository.lookupClass(accessor.class_name);
+        final JavaClass acc = Repository.lookupClass(accessor.className);
         return acc.getPackageName().equals(jc.getPackageName());
     }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SWITCH.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SWITCH.java
@@ -32,7 +32,7 @@ public final class SWITCH implements CompoundInstruction {
     private int[] match;
     private InstructionHandle[] targets;
     private Select instruction;
-    private int match_length;
+    private int matchLength;
 
 
     /**
@@ -53,10 +53,10 @@ public final class SWITCH implements CompoundInstruction {
     public SWITCH(final int[] match, final InstructionHandle[] targets, final InstructionHandle target, final int max_gap) {
         this.match = match.clone();
         this.targets = targets.clone();
-        if ((match_length = match.length) < 2) {
+        if ((matchLength = match.length) < 2) {
             instruction = new TABLESWITCH(match, targets, target);
         } else {
-            sort(0, match_length - 1);
+            sort(0, matchLength - 1);
             if (matchIsOrdered(max_gap)) {
                 fillup(max_gap, target);
                 instruction = new TABLESWITCH(this.match, this.targets, target);
@@ -73,13 +73,13 @@ public final class SWITCH implements CompoundInstruction {
 
 
     private void fillup( final int max_gap, final InstructionHandle target ) {
-        final int max_size = match_length + match_length * max_gap;
+        final int max_size = matchLength + matchLength * max_gap;
         final int[] m_vec = new int[max_size];
         final InstructionHandle[] t_vec = new InstructionHandle[max_size];
         int count = 1;
         m_vec[0] = match[0];
         t_vec[0] = targets[0];
-        for (int i = 1; i < match_length; i++) {
+        for (int i = 1; i < matchLength; i++) {
             final int prev = match[i - 1];
             final int gap = match[i] - prev;
             for (int j = 1; j < gap; j++) {
@@ -138,7 +138,7 @@ public final class SWITCH implements CompoundInstruction {
      * @return match is sorted in ascending order with no gap bigger than max_gap?
      */
     private boolean matchIsOrdered( final int max_gap ) {
-        for (int i = 1; i < match_length; i++) {
+        for (int i = 1; i < matchLength; i++) {
             if (match[i] - match[i - 1] > max_gap) {
                 return false;
             }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Select.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Select.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -27,12 +27,12 @@ import com.sun.org.apache.bcel.internal.util.ByteSequence;
 /**
  * Select - Abstract super class for LOOKUPSWITCH and TABLESWITCH instructions.
  *
- * <p>We use our super's <code>target</code> property as the default target.
+ * <p>We use our super's {@code target} property as the default target.
  *
  * @see LOOKUPSWITCH
  * @see TABLESWITCH
  * @see InstructionList
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public abstract class Select extends BranchInstruction implements VariableLengthInstruction,
         StackConsumer /* @since 6.0 */, StackProducer {

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SimpleElementValueGen.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/SimpleElementValueGen.java
@@ -166,7 +166,7 @@ public class SimpleElementValueGen extends ElementValueGen
                 idx = cpool.addInteger(value.getValueShort());
                 break;
             default:
-                throw new RuntimeException(
+                throw new IllegalArgumentException(
                     "SimpleElementValueGen class does not know how to copy this type " + super.getElementValueType());
             }
         }
@@ -189,7 +189,7 @@ public class SimpleElementValueGen extends ElementValueGen
     public String getValueString()
     {
         if (super.getElementValueType() != STRING) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueString() on a non STRING ElementValue");
         }
         final ConstantUtf8 c = (ConstantUtf8) getConstantPool().getConstant(idx);
@@ -199,7 +199,7 @@ public class SimpleElementValueGen extends ElementValueGen
     public int getValueInt()
     {
         if (super.getElementValueType() != PRIMITIVE_INT) {
-            throw new RuntimeException(
+            throw new IllegalStateException(
                     "Dont call getValueString() on a non STRING ElementValue");
         }
         final ConstantInteger c = (ConstantInteger) getConstantPool().getConstant(idx);
@@ -243,7 +243,7 @@ public class SimpleElementValueGen extends ElementValueGen
             final ConstantUtf8 cu8 = (ConstantUtf8) getConstantPool().getConstant(idx);
             return cu8.getBytes();
         default:
-            throw new RuntimeException(
+            throw new IllegalStateException(
                 "SimpleElementValueGen class does not know how to stringify type " + super.getElementValueType());
         }
     }
@@ -266,7 +266,7 @@ public class SimpleElementValueGen extends ElementValueGen
             dos.writeShort(idx);
             break;
         default:
-            throw new RuntimeException(
+            throw new IllegalStateException(
                 "SimpleElementValueGen doesnt know how to write out type " + super.getElementValueType());
         }
     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Type.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/generic/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -30,7 +30,7 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  * Abstract super class for all possible java types, namely basic types
  * such as int, object types like String and array types, e.g. int[]
  *
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public abstract class Type {
 
@@ -295,7 +295,7 @@ public abstract class Type {
             } else if (cl == Character.TYPE) {
                 return CHAR;
             } else {
-                throw new IllegalStateException("Ooops, what primitive type is " + cl);
+                throw new IllegalStateException("Unknown primitive type " + cl);
             }
         } else { // "Real" class
             return ObjectType.getInstance(cl.getName());

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/BCELFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -64,7 +64,7 @@ import com.sun.org.apache.bcel.internal.generic.Type;
  * A helper class for BCELifier.
  *
  * @see BCELifier
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 class BCELFactory extends EmptyVisitor {
 
@@ -201,7 +201,7 @@ class BCELFactory extends EmptyVisitor {
                         + ", (short) " + dim + "));");
                 break;
             default:
-                throw new RuntimeException("Oops: " + opcode);
+                throw new IllegalArgumentException("Unhandled opcode: " + opcode);
         }
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/CodeHTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/CodeHTML.java
@@ -48,21 +48,21 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  */
 final class CodeHTML {
 
-    private final String class_name; // name of current class
+    private final String className; // name of current class
 //    private Method[] methods; // Methods to print
     private final PrintWriter file; // file to write to
-    private BitSet goto_set;
-    private final ConstantPool constant_pool;
-    private final ConstantHTML constant_html;
+    private BitSet gotoSet;
+    private final ConstantPool constantPool;
+    private final ConstantHTML constantHtml;
     private static boolean wide = false;
 
 
     CodeHTML(final String dir, final String class_name, final Method[] methods, final ConstantPool constant_pool,
             final ConstantHTML constant_html) throws IOException {
-        this.class_name = class_name;
+        this.className = class_name;
 //        this.methods = methods;
-        this.constant_pool = constant_pool;
-        this.constant_html = constant_html;
+        this.constantPool = constant_pool;
+        this.constantHtml = constant_html;
         file = new PrintWriter(new FileOutputStream(dir + class_name + "_code.html"));
         file.println("<HTML><BODY BGCOLOR=\"#C0C0C0\">");
         for (int i = 0; i < methods.length; i++) {
@@ -231,19 +231,19 @@ final class CodeHTML {
             case Const.PUTFIELD:
             case Const.PUTSTATIC:
                 index = bytes.readShort();
-                final ConstantFieldref c1 = (ConstantFieldref) constant_pool.getConstant(index,
+                final ConstantFieldref c1 = (ConstantFieldref) constantPool.getConstant(index,
                         Const.CONSTANT_Fieldref);
                 class_index = c1.getClassIndex();
-                name = constant_pool.getConstantString(class_index, Const.CONSTANT_Class);
+                name = constantPool.getConstantString(class_index, Const.CONSTANT_Class);
                 name = Utility.compactClassName(name, false);
                 index = c1.getNameAndTypeIndex();
-                final String field_name = constant_pool.constantToString(index, Const.CONSTANT_NameAndType);
-                if (name.equals(class_name)) { // Local field
-                    buf.append("<A HREF=\"").append(class_name).append("_methods.html#field")
+                final String field_name = constantPool.constantToString(index, Const.CONSTANT_NameAndType);
+                if (name.equals(className)) { // Local field
+                    buf.append("<A HREF=\"").append(className).append("_methods.html#field")
                             .append(field_name).append("\" TARGET=Methods>").append(field_name)
                             .append("</A>\n");
                 } else {
-                    buf.append(constant_html.referenceConstant(class_index)).append(".").append(
+                    buf.append(constantHtml.referenceConstant(class_index)).append(".").append(
                             field_name);
                 }
                 break;
@@ -253,7 +253,7 @@ final class CodeHTML {
             case Const.INSTANCEOF:
             case Const.NEW:
                 index = bytes.readShort();
-                buf.append(constant_html.referenceConstant(index));
+                buf.append(constantHtml.referenceConstant(index));
                 break;
             /* Operands are references to methods in constant pool
              */
@@ -269,7 +269,7 @@ final class CodeHTML {
                     bytes.readUnsignedByte(); // Reserved
 //                    int nargs = bytes.readUnsignedByte(); // Redundant
 //                    int reserved = bytes.readUnsignedByte(); // Reserved
-                    final ConstantInterfaceMethodref c = (ConstantInterfaceMethodref) constant_pool
+                    final ConstantInterfaceMethodref c = (ConstantInterfaceMethodref) constantPool
                             .getConstant(m_index, Const.CONSTANT_InterfaceMethodref);
                     class_index = c.getClassIndex();
                     index = c.getNameAndTypeIndex();
@@ -277,7 +277,7 @@ final class CodeHTML {
                 } else if (opcode == Const.INVOKEDYNAMIC) { // Special treatment needed
                     bytes.readUnsignedByte(); // Reserved
                     bytes.readUnsignedByte(); // Reserved
-                    final ConstantInvokeDynamic c = (ConstantInvokeDynamic) constant_pool
+                    final ConstantInvokeDynamic c = (ConstantInvokeDynamic) constantPool
                             .getConstant(m_index, Const.CONSTANT_InvokeDynamic);
                     index = c.getNameAndTypeIndex();
                     name = "#" + c.getBootstrapMethodAttrIndex();
@@ -285,21 +285,21 @@ final class CodeHTML {
                     // UNDONE: Java8 now allows INVOKESPECIAL and INVOKESTATIC to
                     // reference EITHER a Methodref OR an InterfaceMethodref.
                     // Not sure if that affects this code or not.  (markro)
-                    final ConstantMethodref c = (ConstantMethodref) constant_pool.getConstant(m_index,
+                    final ConstantMethodref c = (ConstantMethodref) constantPool.getConstant(m_index,
                             Const.CONSTANT_Methodref);
                     class_index = c.getClassIndex();
                     index = c.getNameAndTypeIndex();
                 name = Class2HTML.referenceClass(class_index);
                 }
-                str = Class2HTML.toHTML(constant_pool.constantToString(constant_pool.getConstant(
+                str = Class2HTML.toHTML(constantPool.constantToString(constantPool.getConstant(
                         index, Const.CONSTANT_NameAndType)));
                 // Get signature, i.e., types
-                final ConstantNameAndType c2 = (ConstantNameAndType) constant_pool.getConstant(index,
+                final ConstantNameAndType c2 = (ConstantNameAndType) constantPool.getConstant(index,
                         Const.CONSTANT_NameAndType);
-                signature = constant_pool.constantToString(c2.getSignatureIndex(), Const.CONSTANT_Utf8);
+                signature = constantPool.constantToString(c2.getSignatureIndex(), Const.CONSTANT_Utf8);
                 final String[] args = Utility.methodSignatureArgumentTypes(signature, false);
                 final String type = Utility.methodSignatureReturnType(signature, false);
-                buf.append(name).append(".<A HREF=\"").append(class_name).append("_cp.html#cp")
+                buf.append(name).append(".<A HREF=\"").append(className).append("_cp.html#cp")
                         .append(m_index).append("\" TARGET=ConstantPool>").append(str).append(
                                 "</A>").append("(");
                 // List arguments
@@ -317,30 +317,30 @@ final class CodeHTML {
             case Const.LDC_W:
             case Const.LDC2_W:
                 index = bytes.readShort();
-                buf.append("<A HREF=\"").append(class_name).append("_cp.html#cp").append(index)
+                buf.append("<A HREF=\"").append(className).append("_cp.html#cp").append(index)
                         .append("\" TARGET=\"ConstantPool\">").append(
-                                Class2HTML.toHTML(constant_pool.constantToString(index,
-                                        constant_pool.getConstant(index).getTag()))).append("</a>");
+                                Class2HTML.toHTML(constantPool.constantToString(index,
+                                        constantPool.getConstant(index).getTag()))).append("</a>");
                 break;
             case Const.LDC:
                 index = bytes.readUnsignedByte();
-                buf.append("<A HREF=\"").append(class_name).append("_cp.html#cp").append(index)
+                buf.append("<A HREF=\"").append(className).append("_cp.html#cp").append(index)
                         .append("\" TARGET=\"ConstantPool\">").append(
-                                Class2HTML.toHTML(constant_pool.constantToString(index,
-                                        constant_pool.getConstant(index).getTag()))).append("</a>");
+                                Class2HTML.toHTML(constantPool.constantToString(index,
+                                        constantPool.getConstant(index).getTag()))).append("</a>");
                 break;
             /* Array of references.
              */
             case Const.ANEWARRAY:
                 index = bytes.readShort();
-                buf.append(constant_html.referenceConstant(index));
+                buf.append(constantHtml.referenceConstant(index));
                 break;
             /* Multidimensional array of references.
              */
             case Const.MULTIANEWARRAY:
                 index = bytes.readShort();
                 final int dimensions = bytes.readByte();
-                buf.append(constant_html.referenceConstant(index)).append(":").append(dimensions)
+                buf.append(constantHtml.referenceConstant(index)).append(":").append(dimensions)
                         .append("-dimensional");
                 break;
             /* Increment local variable.
@@ -389,7 +389,7 @@ final class CodeHTML {
      */
     private void findGotos( final ByteSequence bytes, final Code code ) throws IOException {
         int index;
-        goto_set = new BitSet(bytes.available());
+        gotoSet = new BitSet(bytes.available());
         int opcode;
         /* First get Code attribute from method and the exceptions handled
          * (try .. catch) in this method. We only need the line number here.
@@ -397,9 +397,9 @@ final class CodeHTML {
         if (code != null) {
             final CodeException[] ce = code.getExceptionTable();
             for (final CodeException cex : ce) {
-                goto_set.set(cex.getStartPC());
-                goto_set.set(cex.getEndPC());
-                goto_set.set(cex.getHandlerPC());
+                gotoSet.set(cex.getStartPC());
+                gotoSet.set(cex.getEndPC());
+                gotoSet.set(cex.getHandlerPC());
             }
             // Look for local variables and their range
             final Attribute[] attributes = code.getAttributes();
@@ -410,8 +410,8 @@ final class CodeHTML {
                     for (final LocalVariable var : vars) {
                         final int start = var.getStartPC();
                         final int end = start + var.getLength();
-                        goto_set.set(start);
-                        goto_set.set(end);
+                        gotoSet.set(start);
+                        gotoSet.set(end);
                     }
                     break;
                 }
@@ -439,21 +439,21 @@ final class CodeHTML {
                         final int high = bytes.readInt();
                         offset = bytes.getIndex() - 12 - no_pad_bytes - 1;
                         default_offset += offset;
-                        goto_set.set(default_offset);
+                        gotoSet.set(default_offset);
                         for (int j = 0; j < (high - low + 1); j++) {
                             index = offset + bytes.readInt();
-                            goto_set.set(index);
+                            gotoSet.set(index);
                         }
                     } else { // LOOKUPSWITCH
                         final int npairs = bytes.readInt();
                         offset = bytes.getIndex() - 8 - no_pad_bytes - 1;
                         default_offset += offset;
-                        goto_set.set(default_offset);
+                        gotoSet.set(default_offset);
                         for (int j = 0; j < npairs; j++) {
 //                            int match = bytes.readInt();
                             bytes.readInt();
                             index = offset + bytes.readInt();
-                            goto_set.set(index);
+                            gotoSet.set(index);
                         }
                     }
                     break;
@@ -477,13 +477,13 @@ final class CodeHTML {
                 case Const.JSR:
                     //bytes.readByte(); // Skip already read byte
                     index = bytes.getIndex() + bytes.readShort() - 1;
-                    goto_set.set(index);
+                    gotoSet.set(index);
                     break;
                 case Const.GOTO_W:
                 case Const.JSR_W:
                     //bytes.readByte(); // Skip already read byte
                     index = bytes.getIndex() + bytes.readInt() - 1;
-                    goto_set.set(index);
+                    gotoSet.set(index);
                     break;
                 default:
                     bytes.unreadByte();
@@ -513,7 +513,7 @@ final class CodeHTML {
         final Attribute[] attributes = method.getAttributes();
         file.print("<P><B><FONT COLOR=\"#FF0000\">" + access + "</FONT>&nbsp;" + "<A NAME=method"
                 + method_number + ">" + Class2HTML.referenceType(type) + "</A>&nbsp<A HREF=\""
-                + class_name + "_methods.html#method" + method_number + "\" TARGET=Methods>"
+                + className + "_methods.html#method" + method_number + "\" TARGET=Methods>"
                 + html_name + "</A>(");
         for (int i = 0; i < args.length; i++) {
             file.print(Class2HTML.referenceType(args[i]));
@@ -529,7 +529,7 @@ final class CodeHTML {
             for (int i = 0; i < attributes.length; i++) {
                 byte tag = attributes[i].getTag();
                 if (tag != Const.ATTR_UNKNOWN) {
-                    file.print("<LI><A HREF=\"" + class_name + "_attributes.html#method"
+                    file.print("<LI><A HREF=\"" + className + "_attributes.html#method"
                             + method_number + "@" + i + "\" TARGET=Attributes>"
                             + Const.getAttributeName(tag) + "</A></LI>\n");
                 } else {
@@ -542,7 +542,7 @@ final class CodeHTML {
                     file.print("<UL>");
                     for (int j = 0; j < attributes2.length; j++) {
                         tag = attributes2[j].getTag();
-                        file.print("<LI><A HREF=\"" + class_name + "_attributes.html#" + "method"
+                        file.print("<LI><A HREF=\"" + className + "_attributes.html#" + "method"
                                 + method_number + "@" + i + "@" + j + "\" TARGET=Attributes>"
                                 + Const.getAttributeName(tag) + "</A></LI>\n");
                     }
@@ -552,7 +552,7 @@ final class CodeHTML {
             file.println("</UL>");
         }
         if (code != null) { // No code, an abstract method, e.g.
-            //System.out.println(name + "\n" + Utility.codeToString(code, constant_pool, 0, -1));
+            //System.out.println(name + "\n" + Utility.codeToString(code, constantPool, 0, -1));
             // Print the byte code
             try (ByteSequence stream = new ByteSequence(code)) {
                 stream.mark(stream.available());
@@ -568,7 +568,7 @@ final class CodeHTML {
                      * Set an anchor mark if this line is targetted by a goto, jsr, etc. Defining an anchor for every
                      * line is very inefficient!
                      */
-                    if (goto_set.get(offset)) {
+                    if (gotoSet.get(offset)) {
                         anchor = "<A NAME=code" + method_number + "@" + offset + "></A>";
                     }
                     String anchor2;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ConstantHTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/ConstantHTML.java
@@ -44,25 +44,25 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  */
 final class ConstantHTML {
 
-    private final String class_name; // name of current class
-    private final String class_package; // name of package
-    private final ConstantPool constant_pool; // reference to constant pool
+    private final String className; // name of current class
+    private final String classPackage; // name of package
+    private final ConstantPool constantPool; // reference to constant pool
     private final PrintWriter file; // file to write to
-    private final String[] constant_ref; // String to return for cp[i]
+    private final String[] constantRef; // String to return for cp[i]
     private final Constant[] constants; // The constants in the cp
     private final Method[] methods;
 
 
     ConstantHTML(final String dir, final String class_name, final String class_package, final Method[] methods,
             final ConstantPool constant_pool) throws IOException {
-        this.class_name = class_name;
-        this.class_package = class_package;
-        this.constant_pool = constant_pool;
+        this.className = class_name;
+        this.classPackage = class_package;
+        this.constantPool = constant_pool;
         this.methods = methods;
         constants = constant_pool.getConstantPool();
         file = new PrintWriter(new FileOutputStream(dir + class_name + "_cp.html"));
-        constant_ref = new String[constants.length];
-        constant_ref[0] = "&lt;unknown&gt;";
+        constantRef = new String[constants.length];
+        constantRef[0] = "&lt;unknown&gt;";
         file.println("<HTML><BODY BGCOLOR=\"#C0C0C0\"><TABLE BORDER=0>");
         // Loop through constants, constants[0] is reserved
         for (int i = 1; i < constants.length; i++) {
@@ -82,7 +82,7 @@ final class ConstantHTML {
 
 
     String referenceConstant( final int index ) {
-        return constant_ref[index];
+        return constantRef[index];
     }
 
 
@@ -101,29 +101,29 @@ final class ConstantHTML {
             case Const.CONSTANT_Methodref:
                 // Get class_index and name_and_type_index, depending on type
                 if (tag == Const.CONSTANT_Methodref) {
-                    final ConstantMethodref c = (ConstantMethodref) constant_pool.getConstant(index,
+                    final ConstantMethodref c = (ConstantMethodref) constantPool.getConstant(index,
                             Const.CONSTANT_Methodref);
                     class_index = c.getClassIndex();
                     name_index = c.getNameAndTypeIndex();
                 } else {
-                    final ConstantInterfaceMethodref c1 = (ConstantInterfaceMethodref) constant_pool
+                    final ConstantInterfaceMethodref c1 = (ConstantInterfaceMethodref) constantPool
                             .getConstant(index, Const.CONSTANT_InterfaceMethodref);
                     class_index = c1.getClassIndex();
                     name_index = c1.getNameAndTypeIndex();
                 }
                 // Get method name and its class
-                final String method_name = constant_pool.constantToString(name_index,
+                final String method_name = constantPool.constantToString(name_index,
                         Const.CONSTANT_NameAndType);
                 final String html_method_name = Class2HTML.toHTML(method_name);
                 // Partially compacted class name, i.e., / -> .
-                final String method_class = constant_pool.constantToString(class_index, Const.CONSTANT_Class);
+                final String method_class = constantPool.constantToString(class_index, Const.CONSTANT_Class);
                 String short_method_class = Utility.compactClassName(method_class); // I.e., remove java.lang.
-                short_method_class = Utility.compactClassName(short_method_class, class_package
+                short_method_class = Utility.compactClassName(short_method_class, classPackage
                         + ".", true); // Remove class package prefix
                 // Get method signature
-                final ConstantNameAndType c2 = (ConstantNameAndType) constant_pool.getConstant(
+                final ConstantNameAndType c2 = (ConstantNameAndType) constantPool.getConstant(
                         name_index, Const.CONSTANT_NameAndType);
-                final String signature = constant_pool.constantToString(c2.getSignatureIndex(),
+                final String signature = constantPool.constantToString(c2.getSignatureIndex(),
                         Const.CONSTANT_Utf8);
                 // Get array of strings containing the argument types
                 final String[] args = Utility.methodSignatureArgumentTypes(signature, false);
@@ -139,17 +139,17 @@ final class ConstantHTML {
                 }
                 buf.append(")");
                 final String arg_types = buf.toString();
-                if (method_class.equals(class_name)) {
-                    ref = "<A HREF=\"" + class_name + "_code.html#method"
+                if (method_class.equals(className)) {
+                    ref = "<A HREF=\"" + className + "_code.html#method"
                             + getMethodNumber(method_name + signature) + "\" TARGET=Code>"
                             + html_method_name + "</A>";
                 } else {
                     ref = "<A HREF=\"" + method_class + ".html" + "\" TARGET=_top>"
                             + short_method_class + "</A>." + html_method_name;
                 }
-                constant_ref[index] = ret_type + "&nbsp;<A HREF=\"" + class_name + "_cp.html#cp"
+                constantRef[index] = ret_type + "&nbsp;<A HREF=\"" + className + "_cp.html#cp"
                         + class_index + "\" TARGET=Constants>" + short_method_class
-                        + "</A>.<A HREF=\"" + class_name + "_cp.html#cp" + index
+                        + "</A>.<A HREF=\"" + className + "_cp.html#cp" + index
                         + "\" TARGET=ConstantPool>" + html_method_name + "</A>&nbsp;" + arg_types;
                 file.println("<P><TT>" + ret_type + "&nbsp;" + ref + arg_types
                         + "&nbsp;</TT>\n<UL>" + "<LI><A HREF=\"#cp" + class_index
@@ -158,27 +158,27 @@ final class ConstantHTML {
                 break;
             case Const.CONSTANT_Fieldref:
                 // Get class_index and name_and_type_index
-                final ConstantFieldref c3 = (ConstantFieldref) constant_pool.getConstant(index,
+                final ConstantFieldref c3 = (ConstantFieldref) constantPool.getConstant(index,
                         Const.CONSTANT_Fieldref);
                 class_index = c3.getClassIndex();
                 name_index = c3.getNameAndTypeIndex();
                 // Get method name and its class (compacted)
-                final String field_class = constant_pool.constantToString(class_index, Const.CONSTANT_Class);
+                final String field_class = constantPool.constantToString(class_index, Const.CONSTANT_Class);
                 String short_field_class = Utility.compactClassName(field_class); // I.e., remove java.lang.
                 short_field_class = Utility.compactClassName(short_field_class,
-                        class_package + ".", true); // Remove class package prefix
-                final String field_name = constant_pool
+                        classPackage + ".", true); // Remove class package prefix
+                final String field_name = constantPool
                         .constantToString(name_index, Const.CONSTANT_NameAndType);
-                if (field_class.equals(class_name)) {
+                if (field_class.equals(className)) {
                     ref = "<A HREF=\"" + field_class + "_methods.html#field" + field_name
                             + "\" TARGET=Methods>" + field_name + "</A>";
                 } else {
                     ref = "<A HREF=\"" + field_class + ".html\" TARGET=_top>" + short_field_class
                             + "</A>." + field_name + "\n";
                 }
-                constant_ref[index] = "<A HREF=\"" + class_name + "_cp.html#cp" + class_index
+                constantRef[index] = "<A HREF=\"" + className + "_cp.html#cp" + class_index
                         + "\" TARGET=Constants>" + short_field_class + "</A>.<A HREF=\""
-                        + class_name + "_cp.html#cp" + index + "\" TARGET=ConstantPool>"
+                        + className + "_cp.html#cp" + index + "\" TARGET=ConstantPool>"
                         + field_name + "</A>";
                 file.println("<P><TT>" + ref + "</TT><BR>\n" + "<UL>" + "<LI><A HREF=\"#cp"
                         + class_index + "\">Class(" + class_index + ")</A><BR>\n"
@@ -186,40 +186,40 @@ final class ConstantHTML {
                         + ")</A></UL>");
                 break;
             case Const.CONSTANT_Class:
-                final ConstantClass c4 = (ConstantClass) constant_pool.getConstant(index, Const.CONSTANT_Class);
+                final ConstantClass c4 = (ConstantClass) constantPool.getConstant(index, Const.CONSTANT_Class);
                 name_index = c4.getNameIndex();
-                final String class_name2 = constant_pool.constantToString(index, tag); // / -> .
+                final String class_name2 = constantPool.constantToString(index, tag); // / -> .
                 String short_class_name = Utility.compactClassName(class_name2); // I.e., remove java.lang.
-                short_class_name = Utility.compactClassName(short_class_name, class_package + ".",
+                short_class_name = Utility.compactClassName(short_class_name, classPackage + ".",
                         true); // Remove class package prefix
                 ref = "<A HREF=\"" + class_name2 + ".html\" TARGET=_top>" + short_class_name
                         + "</A>";
-                constant_ref[index] = "<A HREF=\"" + class_name + "_cp.html#cp" + index
+                constantRef[index] = "<A HREF=\"" + className + "_cp.html#cp" + index
                         + "\" TARGET=ConstantPool>" + short_class_name + "</A>";
                 file.println("<P><TT>" + ref + "</TT><UL>" + "<LI><A HREF=\"#cp" + name_index
                         + "\">Name index(" + name_index + ")</A></UL>\n");
                 break;
             case Const.CONSTANT_String:
-                final ConstantString c5 = (ConstantString) constant_pool.getConstant(index,
+                final ConstantString c5 = (ConstantString) constantPool.getConstant(index,
                         Const.CONSTANT_String);
                 name_index = c5.getStringIndex();
-                final String str = Class2HTML.toHTML(constant_pool.constantToString(index, tag));
+                final String str = Class2HTML.toHTML(constantPool.constantToString(index, tag));
                 file.println("<P><TT>" + str + "</TT><UL>" + "<LI><A HREF=\"#cp" + name_index
                         + "\">Name index(" + name_index + ")</A></UL>\n");
                 break;
             case Const.CONSTANT_NameAndType:
-                final ConstantNameAndType c6 = (ConstantNameAndType) constant_pool.getConstant(index,
+                final ConstantNameAndType c6 = (ConstantNameAndType) constantPool.getConstant(index,
                         Const.CONSTANT_NameAndType);
                 name_index = c6.getNameIndex();
                 final int signature_index = c6.getSignatureIndex();
                 file.println("<P><TT>"
-                        + Class2HTML.toHTML(constant_pool.constantToString(index, tag))
+                        + Class2HTML.toHTML(constantPool.constantToString(index, tag))
                         + "</TT><UL>" + "<LI><A HREF=\"#cp" + name_index + "\">Name index("
                         + name_index + ")</A>\n" + "<LI><A HREF=\"#cp" + signature_index
                         + "\">Signature index(" + signature_index + ")</A></UL>\n");
                 break;
             default:
-                file.println("<P><TT>" + Class2HTML.toHTML(constant_pool.constantToString(index, tag)) + "</TT>\n");
+                file.println("<P><TT>" + Class2HTML.toHTML(constantPool.constantToString(index, tag)) + "</TT>\n");
         } // switch
     }
 

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/InstructionFinder.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/InstructionFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -64,7 +64,7 @@ import java.util.regex.Pattern;
  *
  * @see com.sun.org.apache.bcel.internal.generic.Instruction
  * @see InstructionList
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class InstructionFinder {
 
@@ -72,7 +72,7 @@ public class InstructionFinder {
     private static final int NO_OPCODES = 256; // Potential number, some are not used
     private static final Map<String, String> map = new HashMap<>();
     private final InstructionList il;
-    private String il_string; // instruction list as string
+    private String ilString; // instruction list as string
     private InstructionHandle[] handles; // map instruction
 
 
@@ -99,7 +99,7 @@ public class InstructionFinder {
         for (int i = 0; i < size; i++) {
             buf[i] = makeChar(handles[i].getInstruction().getOpcode());
         }
-        il_string = new String(buf);
+        ilString = new String(buf);
     }
 
 
@@ -120,7 +120,7 @@ public class InstructionFinder {
                 return "" + makeChar(i);
             }
         }
-        throw new RuntimeException("Instruction unknown: " + pattern);
+        throw new IllegalArgumentException("Instruction unknown: " + pattern);
     }
 
 
@@ -221,8 +221,8 @@ public class InstructionFinder {
         }
         final Pattern regex = Pattern.compile(search);
         final List<InstructionHandle[]> matches = new ArrayList<>();
-        final Matcher matcher = regex.matcher(il_string);
-        while (start < il_string.length() && matcher.find(start)) {
+        final Matcher matcher = regex.matcher(ilString);
+        while (start < ilString.length() && matcher.find(start)) {
             final int startExpr = matcher.start();
             final int endExpr = matcher.end();
             final int lenExpr = endExpr - startExpr;

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/MethodHTML.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/MethodHTML.java
@@ -41,17 +41,17 @@ import com.sun.org.apache.bcel.internal.classfile.Utility;
  */
 final class MethodHTML {
 
-    private final String class_name; // name of current class
+    private final String className; // name of current class
     private final PrintWriter file; // file to write to
-    private final ConstantHTML constant_html;
+    private final ConstantHTML constantHtml;
     private final AttributeHTML attribute_html;
 
 
     MethodHTML(final String dir, final String class_name, final Method[] methods, final Field[] fields,
             final ConstantHTML constant_html, final AttributeHTML attribute_html) throws IOException {
-        this.class_name = class_name;
+        this.className = class_name;
         this.attribute_html = attribute_html;
-        this.constant_html = constant_html;
+        this.constantHtml = constant_html;
         file = new PrintWriter(new FileOutputStream(dir + class_name + "_methods.html"));
         file.println("<HTML><BODY BGCOLOR=\"#C0C0C0\"><TABLE BORDER=0>");
         file.println("<TR><TH ALIGN=LEFT>Access&nbsp;flags</TH><TH ALIGN=LEFT>Type</TH>"
@@ -95,7 +95,7 @@ final class MethodHTML {
             if (attributes[i].getTag() == Const.ATTR_CONSTANT_VALUE) { // Default value
                 final String str = ((ConstantValue) attributes[i]).toString();
                 // Reference attribute in _attributes.html
-                file.print("<TD>= <A HREF=\"" + class_name + "_attributes.html#" + name + "@" + i
+                file.print("<TD>= <A HREF=\"" + className + "_attributes.html#" + name + "@" + i
                         + "\" TARGET=\"Attributes\">" + str + "</TD>\n");
                 break;
             }
@@ -125,7 +125,7 @@ final class MethodHTML {
         html_name = Class2HTML.toHTML(name);
         file.print("<TR VALIGN=TOP><TD><FONT COLOR=\"#FF0000\"><A NAME=method" + method_number
                 + ">" + access + "</A></FONT></TD>");
-        file.print("<TD>" + Class2HTML.referenceType(type) + "</TD><TD>" + "<A HREF=" + class_name
+        file.print("<TD>" + Class2HTML.referenceType(type) + "</TD><TD>" + "<A HREF=" + className
                 + "_code.html#method" + method_number + " TARGET=Code>" + html_name
                 + "</A></TD>\n<TD>(");
         for (int i = 0; i < args.length; i++) {
@@ -144,7 +144,7 @@ final class MethodHTML {
                 file.print("<TR VALIGN=TOP><TD COLSPAN=2></TD><TH ALIGN=LEFT>throws</TH><TD>");
                 final int[] exceptions = ((ExceptionTable) attributes[i]).getExceptionIndexTable();
                 for (int j = 0; j < exceptions.length; j++) {
-                    file.print(constant_html.referenceConstant(exceptions[j]));
+                    file.print(constantHtml.referenceConstant(exceptions[j]));
                     if (j < exceptions.length - 1) {
                         file.print(", ");
                     }

--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/SyntheticRepository.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/util/SyntheticRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,7 +39,7 @@ import java.util.Map;
  *
  * @see com.sun.org.apache.bcel.internal.Repository
  *
- * @LastModified: Jan 2020
+ * @LastModified: May 2021
  */
 public class SyntheticRepository implements Repository {
 
@@ -60,7 +60,7 @@ public class SyntheticRepository implements Repository {
     public void storeClass(final JavaClass clazz) {
         loadedClasses.put(clazz.getClassName(), new SoftReference<>(clazz));
         clazz.setRepository(this);
-    }
+        }
 
     /**
      * Remove class from repository
@@ -78,7 +78,7 @@ public class SyntheticRepository implements Repository {
         final SoftReference<JavaClass> ref = loadedClasses.get(className);
         if (ref == null) {
             return null;
-        }
+}
         return ref.get();
     }
 

--- a/src/java.xml/share/legal/bcel.md
+++ b/src/java.xml/share/legal/bcel.md
@@ -1,4 +1,4 @@
-## Apache Commons Byte Code Engineering Library (BCEL) Version 6.4.1
+## Apache Commons Byte Code Engineering Library (BCEL) Version 6.5.0
 
 ### Apache Commons BCEL Notice
 <pre>


### PR DESCRIPTION
I'd like to backport this update for parity with major releases. The backport is clean with only two old copyrights differ.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255035](https://bugs.openjdk.java.net/browse/JDK-8255035): Update BCEL to Version 6.5.0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk13u-dev pull/355/head:pull/355` \
`$ git checkout pull/355`

Update a local copy of the PR: \
`$ git checkout pull/355` \
`$ git pull https://git.openjdk.java.net/jdk13u-dev pull/355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 355`

View PR using the GUI difftool: \
`$ git pr show -t 355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk13u-dev/pull/355.diff">https://git.openjdk.java.net/jdk13u-dev/pull/355.diff</a>

</details>
