### PR TITLE
Backport 309acbf0e86a0d248294503fccc7a936fa0a846e

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -86,6 +86,7 @@ else
   BUILD_JDK_JTREG_EXCLUDE += libTestMainKeyWindow.m
   BUILD_JDK_JTREG_EXCLUDE += exeJniInvocationTest.c
   BUILD_JDK_JTREG_EXCLUDE += libTestDynamicStore.m
+  BUILD_JDK_JTREG_EXCLUDE += exeLibraryCache.c
 endif
 
 ifeq ($(call isTargetOs, linux), true)

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -162,7 +162,7 @@ JNIEXPORT jboolean JNICALL
 JVM_IsUseContainerSupport(void);
 
 JNIEXPORT void * JNICALL
-JVM_LoadLibrary(const char *name);
+JVM_LoadLibrary(const char *name, jboolean throwException);
 
 JNIEXPORT void JNICALL
 JVM_UnloadLibrary(void * handle);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3343,7 +3343,7 @@ JVM_END
 
 // Library support ///////////////////////////////////////////////////////////////////////////
 
-JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name))
+JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name, jboolean throwException))
   //%note jvm_ct
   JVMWrapper("JVM_LoadLibrary");
   char ebuf[1024];
@@ -3353,18 +3353,22 @@ JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name))
     load_result = os::dll_load(name, ebuf, sizeof ebuf);
   }
   if (load_result == NULL) {
-    char msg[1024];
-    jio_snprintf(msg, sizeof msg, "%s: %s", name, ebuf);
-    // Since 'ebuf' may contain a string encoded using
-    // platform encoding scheme, we need to pass
-    // Exceptions::unsafe_to_utf8 to the new_exception method
-    // as the last argument. See bug 6367357.
-    Handle h_exception =
-      Exceptions::new_exception(thread,
-                                vmSymbols::java_lang_UnsatisfiedLinkError(),
-                                msg, Exceptions::unsafe_to_utf8);
+    if (throwException) {
+      char msg[1024];
+      jio_snprintf(msg, sizeof msg, "%s: %s", name, ebuf);
+      // Since 'ebuf' may contain a string encoded using
+      // platform encoding scheme, we need to pass
+      // Exceptions::unsafe_to_utf8 to the new_exception method
+      // as the last argument. See bug 6367357.
+      Handle h_exception =
+        Exceptions::new_exception(thread,
+                                  vmSymbols::java_lang_UnsatisfiedLinkError(),
+                                  msg, Exceptions::unsafe_to_utf8);
 
-    THROW_HANDLE_0(h_exception);
+      THROW_HANDLE_0(h_exception);
+    } else {
+      return load_result;
+    }
   }
   return load_result;
 JVM_END

--- a/src/java.base/macosx/classes/java/lang/ClassLoaderHelper.java
+++ b/src/java.base/macosx/classes/java/lang/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,36 @@
 package java.lang;
 
 import java.io.File;
+import sun.security.action.GetPropertyAction;
 
 class ClassLoaderHelper {
+    private static final boolean hasDynamicLoaderCache;
+    static {
+        String osVersion = GetPropertyAction.privilegedGetProperty("os.version");
+        // dynamic linker cache support on os.version >= 11.x
+        int major = 11;
+        int i = osVersion.indexOf('.');
+        try {
+            major = Integer.parseInt(i < 0 ? osVersion : osVersion.substring(0, i));
+        } catch (NumberFormatException e) {}
+        hasDynamicLoaderCache = major >= 11;
+    }
 
     private ClassLoaderHelper() {}
+
+    /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     *
+     * @implNote
+     * On macOS 11.x or later which supports dynamic linker cache,
+     * the dynamic library is not present on the filesystem.  The
+     * library cannot determine if a dynamic library exists on a
+     * given path or not and so this method returns false.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return !hasDynamicLoaderCache;
+    }
 
     /**
      * Indicates, whether PATH env variable is allowed to contain quoted entries.

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -2416,6 +2416,8 @@ public abstract class ClassLoader {
      * @since    1.2
      */
     static class NativeLibrary {
+        private static final boolean loadLibraryOnlyIfPresent = ClassLoaderHelper.loadLibraryOnlyIfPresent();
+
         // the class from which the library is loaded, also indicates
         // the loader this native library belongs.
         final Class<?> fromClass;
@@ -2430,7 +2432,8 @@ public abstract class ClassLoader {
         // the version of JNI environment the native library requires.
         int jniVersion;
 
-        native boolean load0(String name, boolean isBuiltin);
+        native boolean load0(String name, boolean isBuiltin,
+                             boolean throwExceptionIfFail);
 
         native long findEntry(String name);
 
@@ -2449,7 +2452,7 @@ public abstract class ClassLoader {
                 throw new InternalError("Native library " + name + " has been loaded");
             }
 
-            if (!load0(name, isBuiltin)) return false;
+            if (!load0(name, isBuiltin, loadLibraryOnlyIfPresent)) return false;
 
             // register the class loader for cleanup when unloaded
             // builtin class loaders are never unloaded
@@ -2691,7 +2694,10 @@ public abstract class ClassLoader {
                 new PrivilegedAction<>() {
                     public String run() {
                         try {
-                            return file.exists() ? file.getCanonicalPath() : null;
+                            if (NativeLibrary.loadLibraryOnlyIfPresent && !file.exists()) {
+                                return null;
+                            }
+                            return file.getCanonicalPath();
                         } catch (IOException e) {
                             return null;
                         }

--- a/src/java.base/share/native/libjava/ClassLoader.c
+++ b/src/java.base/share/native/libjava/ClassLoader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -336,7 +336,8 @@ static void *findJniFunction(JNIEnv *env, void *handle,
  */
 JNIEXPORT jboolean JNICALL
 Java_java_lang_ClassLoader_00024NativeLibrary_load0
-  (JNIEnv *env, jobject this, jstring name, jboolean isBuiltin)
+  (JNIEnv *env, jobject this, jstring name,
+   jboolean isBuiltin, jboolean throwExceptionIfFail)
 {
     const char *cname;
     jint jniVersion;
@@ -350,7 +351,7 @@ Java_java_lang_ClassLoader_00024NativeLibrary_load0
     cname = JNU_GetStringPlatformChars(env, name, 0);
     if (cname == 0)
         return JNI_FALSE;
-    handle = isBuiltin ? procHandle : JVM_LoadLibrary(cname);
+    handle = isBuiltin ? procHandle : JVM_LoadLibrary(cname, throwExceptionIfFail);
     if (handle) {
         JNI_OnLoad_t JNI_OnLoad;
         JNI_OnLoad = (JNI_OnLoad_t)findJniFunction(env, handle,

--- a/src/java.base/unix/classes/java/lang/ClassLoaderHelper.java
+++ b/src/java.base/unix/classes/java/lang/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,14 @@ class ClassLoaderHelper {
      * Indicates, whether PATH env variable is allowed to contain quoted entries.
      */
     static final boolean allowsQuotedPathElements = false;
+
+    /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return true;
+    }
 
     /**
      * Returns an alternate path name for the given file

--- a/src/java.base/windows/classes/java/lang/ClassLoaderHelper.java
+++ b/src/java.base/windows/classes/java/lang/ClassLoaderHelper.java
@@ -37,6 +37,14 @@ class ClassLoaderHelper {
     static final boolean allowsQuotedPathElements = true;
 
     /**
+     * Returns true if loading a native library only if
+     * it's present on the file system.
+     */
+    static boolean loadLibraryOnlyIfPresent() {
+        return true;
+    }
+
+    /**
      * Returns an alternate path name for the given file
      * such that if the original pathname did not exist, then the
      * file may be located at the alternate location.

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8275703
+ * @library /test/lib
+ * @requires os.family == "mac"
+ * @run main/native/othervm -Djava.library.path=/usr/lib LibraryFromCache blas
+ * @run main/native/othervm -Djava.library.path=/usr/lib LibraryFromCache BLAS
+ * @summary Test System::loadLibrary to be able to load a library even
+ *          if it's not present on the filesystem on macOS which supports
+ *          dynamic library cache
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class LibraryFromCache {
+    public static void main(String[] args) throws IOException {
+        String libname = args[0];
+        if (!systemHasLibrary(libname)) {
+            System.out.println("Test skipped. Library " + libname + " not found");
+            return;
+        }
+
+        System.loadLibrary(libname);
+    }
+
+    /*
+     * Returns true if dlopen successfully loads the specified library
+     */
+    private static boolean systemHasLibrary(String libname) throws IOException {
+        Path launcher = Paths.get(System.getProperty("test.nativepath"), "LibraryCache");
+        ProcessBuilder pb = new ProcessBuilder(launcher.toString(), "lib" + libname + ".dylib");
+        OutputAnalyzer outputAnalyzer = new OutputAnalyzer(pb.start());
+        System.out.println(outputAnalyzer.getOutput());
+        return outputAnalyzer.getExitValue() == 0;
+    }
+}

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/exeLibraryCache.c
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/exeLibraryCache.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+int main(int argc, char** argv)
+{
+    void *handle;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <lib_filename_or_full_path>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    printf("Attempting to load library '%s'...\n", argv[1]);
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+
+    if (handle == NULL) {
+       fprintf(stderr, "Unable to load library!\n");
+       return EXIT_FAILURE;
+    }
+
+    printf("Library successfully loaded!\n");
+
+    return dlclose(handle);
+}


### PR DESCRIPTION
I'd like to backport JDK-8275703 to jdk13u for parity with jdk11u. The same issue is observed here.
The original patch needs a lot of changes because of the code reworking in jdk15u by "8228336: Refactor native library loading implementation" but the patch for jdk11u applies cleanly.
