### PR TITLE
8238388: libj2gss/NativeFunc.o  "multiple definition" link errors with GCC10

### DIFF
--- a/src/java.security.jgss/share/native/libj2gss/NativeFunc.c
+++ b/src/java.security.jgss/share/native/libj2gss/NativeFunc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "NativeFunc.h"
+
+/* global GSS function table */
+GSS_FUNCTION_TABLE_PTR ftab;
 
 /* standard GSS method names (ordering is from mapfile) */
 static const char RELEASE_NAME[]                = "gss_release_name";

--- a/src/java.security.jgss/share/native/libj2gss/NativeFunc.h
+++ b/src/java.security.jgss/share/native/libj2gss/NativeFunc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,6 +277,6 @@ typedef struct GSS_FUNCTION_TABLE {
 typedef GSS_FUNCTION_TABLE *GSS_FUNCTION_TABLE_PTR;
 
 /* global GSS function table */
-GSS_FUNCTION_TABLE_PTR ftab;
+extern GSS_FUNCTION_TABLE_PTR ftab;
 
 #endif


### PR DESCRIPTION
Need to have it in 13u, too. Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238388](https://bugs.openjdk.org/browse/JDK-8238388): libj2gss/NativeFunc.o  "multiple definition" link errors with GCC10


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/362/head:pull/362` \
`$ git checkout pull/362`

Update a local copy of the PR: \
`$ git checkout pull/362` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 362`

View PR using the GUI difftool: \
`$ git pr show -t 362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/362.diff">https://git.openjdk.org/jdk13u-dev/pull/362.diff</a>

</details>
