### PR TITLE
Backport 29c4b8e80d1860249a79cfd1941354150468fc5b

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipException;
 
 import javax.lang.model.SourceVersion;
 import javax.tools.FileObject;
@@ -564,7 +565,11 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 Map<String,String> env = Collections.singletonMap("multi-release", multiReleaseValue);
                 FileSystemProvider jarFSProvider = fsInfo.getJarFSProvider();
                 Assert.checkNonNull(jarFSProvider, "should have been caught before!");
-                this.fileSystem = jarFSProvider.newFileSystem(archivePath, env);
+                try {
+                    this.fileSystem = jarFSProvider.newFileSystem(archivePath, env);
+                } catch (ZipException ze) {
+                    throw new IOException("ZipException opening \"" + archivePath + "\": " + ze.getMessage(), ze);
+                }
             } else {
                 this.fileSystem = FileSystems.newFileSystem(archivePath, (ClassLoader)null);
             }


### PR DESCRIPTION
Useful improvement made by Christoph Langer following JDK-8251329. Regtests run fine; expecting to add JDK-8286855 as a follow-up. Clean backport with only copyright date difference.