### PR TITLE
8286855: javac error on invalid jar should only print filename

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -568,7 +568,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 try {
                     this.fileSystem = jarFSProvider.newFileSystem(archivePath, env);
                 } catch (ZipException ze) {
-                    throw new IOException("ZipException opening \"" + archivePath + "\": " + ze.getMessage(), ze);
+                    throw new IOException("ZipException opening \"" + archivePath.getFileName() + "\": " + ze.getMessage(), ze);
                 }
             } else {
                 this.fileSystem = FileSystems.newFileSystem(archivePath, (ClassLoader)null);


### PR DESCRIPTION
should backport the necessary follow-up to 8286444. Clean backport. All relevant tests (all run) run OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286855](https://bugs.openjdk.org/browse/JDK-8286855): javac error on invalid jar should only print filename


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/366/head:pull/366` \
`$ git checkout pull/366`

Update a local copy of the PR: \
`$ git checkout pull/366` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 366`

View PR using the GUI difftool: \
`$ git pr show -t 366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/366.diff">https://git.openjdk.org/jdk13u-dev/pull/366.diff</a>

</details>
