### PR TITLE
8286277: CDS VerifyError when calling clone() on object array

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -2962,15 +2962,15 @@ void ClassVerifier::verify_invoke_instructions(
                   _klass, ref_class, method_name, method_sig, true)) {
               // It's protected access, check if stack object is
               // assignable to current class.
-              bool is_assignable = current_type().is_assignable_from(
-                stack_object_type, this, true, CHECK_VERIFY(this));
-              if (!is_assignable) {
-                if (ref_class_type.name() == vmSymbols::java_lang_Object()
-                    && stack_object_type.is_array()
-                    && method_name == vmSymbols::clone_name()) {
-                  // Special case: arrays pretend to implement public Object
-                  // clone().
-                } else {
+              if (ref_class_type.name() == vmSymbols::java_lang_Object()
+                  && stack_object_type.is_array()
+                  && method_name == vmSymbols::clone_name()) {
+                // Special case: arrays pretend to implement public Object
+                // clone().
+              } else {
+                bool is_assignable = current_type().is_assignable_from(
+                  stack_object_type, this, true, CHECK_VERIFY(this));
+                if (!is_assignable) {
                   verify_error(ErrorContext::bad_type(bci,
                       current_frame->stack_top_ctx(),
                       TypeOrigin::implicit(current_type())),

--- a/test/hotspot/jtreg/runtime/appcds/VerifyObjArrayCloneTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/VerifyObjArrayCloneTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test Verifier handling of invoking java/lang/Object::clone() on object arrays.
+ * @bug 8286277
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/verifier /test/hotspot/jtreg/runtime/appcds/test-classes
+ * @build InvokeCloneValid InvokeCloneInvalid VerifyObjArrayCloneTestApp
+ * @run driver ClassFileInstaller -jar app.jar VerifyObjArrayCloneTestApp
+ * @run driver ClassFileInstaller -jar tests.jar InvokeCloneValid InvokeCloneInvalid
+ * @run driver VerifyObjArrayCloneTest
+ */
+
+import java.io.File;
+import jdk.test.lib.Platform;
+
+public class VerifyObjArrayCloneTest {
+    private static String appJar = ClassFileInstaller.getJarPath("app.jar");
+    private static String testsJar = ClassFileInstaller.getJarPath("tests.jar");
+    private static String mainAppClass = "VerifyObjArrayCloneTestApp";
+
+    public static void main(String... args) throws Exception {
+        testInAppPath();
+        if (Platform.areCustomLoadersSupportedForCDS()) {
+            testInCustomLoader();
+        }
+    }
+
+    // Try to load InvokeCloneValid and InvokeCloneInvalid from the AppClassLoader
+    static void testInAppPath() throws Exception {
+        String cp = appJar + File.pathSeparator + testsJar;
+        TestCommon.dump(cp, TestCommon.list(mainAppClass,
+                                            "InvokeCloneValid",
+                                            "InvokeCloneInvalid"));
+
+        TestCommon.run("-cp", cp, "-Xlog:cds+verification=trace",
+                       mainAppClass)
+            .assertNormalExit();
+    }
+
+    // Try to load InvokeCloneValid and InvokeCloneInvalid from a custom class loader
+    static void testInCustomLoader() throws Exception {
+        String cp = appJar;
+
+        String classlist[] = new String[] {
+            mainAppClass,
+            "java/lang/Object id: 1",
+            "InvokeCloneValid id: 2 super: 1 source: " + testsJar,
+            "InvokeCloneInvalid id: 3 super: 1 source: " + testsJar,
+        };
+
+        TestCommon.dump(cp, classlist);
+        TestCommon.run("-cp", cp, "-Xlog:cds+verification=trace",
+                       mainAppClass, testsJar)
+            .assertNormalExit();
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/dynamicArchive/VerifyObjArrayCloneTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/dynamicArchive/VerifyObjArrayCloneTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test Verifier handling of invoking java/lang/Object::clone() on object arrays.
+ * @bug 8286277
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/verifier
+ *          /test/hotspot/jtreg/runtime/appcds
+ *          /test/hotspot/jtreg/runtime/appcds/test-classes
+ * @build sun.hotspot.WhiteBox
+ * @build InvokeCloneValid InvokeCloneInvalid VerifyObjArrayCloneTestApp
+ * @run driver ClassFileInstaller -jar app.jar VerifyObjArrayCloneTestApp
+ * @run driver ClassFileInstaller -jar tests.jar InvokeCloneValid InvokeCloneInvalid
+ * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:./WhiteBox.jar VerifyObjArrayCloneTest
+ */
+
+import java.io.File;
+
+public class VerifyObjArrayCloneTest extends DynamicArchiveTestBase {
+    private static String appJar = ClassFileInstaller.getJarPath("app.jar");
+    private static String testsJar = ClassFileInstaller.getJarPath("tests.jar");
+    private static String mainAppClass = "VerifyObjArrayCloneTestApp";
+
+    public static void main(String[] args) throws Exception {
+        runTest(VerifyObjArrayCloneTest::testInAppPath);
+        runTest(VerifyObjArrayCloneTest::testInCustomLoader);
+    }
+
+    // Try to load InvokeCloneValid and InvokeCloneInvalid from the AppClassLoader
+    private static void testInAppPath() throws Exception {
+        String cp = appJar + File.pathSeparator + testsJar;
+        String topArchiveName = getNewArchiveName("top");
+        dump(topArchiveName,
+             "-cp", cp,
+             mainAppClass)
+             .assertNormalExit();
+
+        run(topArchiveName,
+            "-cp", cp,
+             mainAppClass)
+            .assertNormalExit();
+    }
+
+    // Try to load InvokeCloneValid and InvokeCloneInvalid from a custom class loader
+    private static void testInCustomLoader() throws Exception {
+        String cp = appJar;
+        String topArchiveName = getNewArchiveName("top");
+        dump(topArchiveName,
+             "-cp", cp,
+             "-Xlog:cds+class=debug",
+             mainAppClass, testsJar)
+             .assertNormalExit();
+
+        run(topArchiveName,
+            "-cp", cp,
+             mainAppClass, testsJar)
+            .assertNormalExit();
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/test-classes/VerifyObjArrayCloneTestApp.java
+++ b/test/hotspot/jtreg/runtime/appcds/test-classes/VerifyObjArrayCloneTestApp.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class VerifyObjArrayCloneTestApp {
+    public static void main(String args[]) throws Exception {
+        ClassLoader appLoader = VerifyObjArrayCloneTestApp.class.getClassLoader();
+        if (args.length == 0) {
+            // Load the test classes from the classpath
+            doTest(appLoader);
+        } else {
+            File f = new File(args[0]);
+            URL[] classLoaderUrls = new URL[] {f.getAbsoluteFile().toURI().toURL()};
+            URLClassLoader customLoader = new URLClassLoader(classLoaderUrls, appLoader);
+            doTest(customLoader);
+        }
+    }
+
+    public static void doTest(ClassLoader loader) throws Exception {
+        try {
+            Class.forName("InvokeCloneValid", /*initialize=*/true, loader);
+        }  catch (VerifyError e) {
+            throw new RuntimeException("Unexpected VerifyError", e);
+        }
+
+        try {
+            Class.forName("InvokeCloneInvalid", /*initialize=*/true, loader);
+            throw new RuntimeException("VerifyError expected but not thrown");
+        } catch (VerifyError e) {
+            System.out.println("Expected: " + e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/verifier/InvokeClone.java
+++ b/test/hotspot/jtreg/runtime/verifier/InvokeClone.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test Verifier handling of invoking java/lang/Object::clone() on object arrays.
+ * @bug 8286277
+ * @build InvokeCloneValid InvokeCloneInvalid
+ * @run main/othervm -Xverify InvokeClone
+ */
+
+public class InvokeClone {
+    public static void main(String[] args) throws ClassNotFoundException {
+        try {
+            Class.forName("InvokeCloneValid");
+        }  catch (VerifyError e) {
+            throw new RuntimeException("Unexpected VerifyError", e);
+        }
+
+        try {
+            Class.forName("InvokeCloneInvalid");
+            throw new RuntimeException("VerifyError expected but not thrown");
+        } catch (VerifyError e) {
+            System.out.println("Expected: " + e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/verifier/InvokeCloneInvalid.jasm
+++ b/test/hotspot/jtreg/runtime/verifier/InvokeCloneInvalid.jasm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class InvokeCloneInvalid
+    version 52:0
+{
+  public static Method test:"(Ljava/lang/String;)V"
+    stack 1 locals 1
+  {
+    aload_0;
+    invokevirtual Method "java/lang/Object".clone:"()Ljava/lang/Object;";
+    return;
+  }
+}

--- a/test/hotspot/jtreg/runtime/verifier/InvokeCloneValid.jasm
+++ b/test/hotspot/jtreg/runtime/verifier/InvokeCloneValid.jasm
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class InvokeCloneValid
+    version 52:0
+{
+  public static Method test:"([Ljava/lang/Object;)V"
+    stack 1 locals 1
+  {
+    aload_0;
+    invokevirtual Method "java/lang/Object".clone:"()Ljava/lang/Object;";
+    return;
+  }
+
+  public static Method test2:"([Ljava/lang/String;)V"
+    stack 1 locals 1
+  {
+    aload_0;
+    invokevirtual Method "java/lang/Object".clone:"()Ljava/lang/Object;";
+    return;
+  }
+}


### PR DESCRIPTION
There was [a backport to OpenJDK-15](https://github.com/openjdk/jdk15u-dev/pull/236).

OpenJDK-13 backport: Moved files from
> test/hotspot/jtreg/runtime/cds/appcds/

to
> test/hotspot/jtreg/runtime/appcds/

as OpenJDK-13 is missing:
- [8202339](https://bugs.openjdk.java.net/browse/JDK-8202339): [TESTBUG] Consolidate the tests in runtime/SharedArchiveFile and runtime/appcds

### Issues
 * [JDK-8286277](https://bugs.openjdk.org/browse/JDK-8286277): CDS VerifyError when calling clone() on object array

I am not yet an Author - I do not have JBS account.
There are 3 new testcases and the first 2 ones to be tested require the testsuite to be run with `TEST="hotspot_appcds tier1"`.
 * runtime/appcds/VerifyObjArrayCloneTest.java
 * runtime/appcds/dynamicArchive/VerifyObjArrayCloneTest.java
 * runtime/verifier/InvokeClone.java

I have run the testsuite on _linux-musl-x64_, _linux32_, _linux64_, _macosx_ and _win64_ and there is no change of the results. The testcases are still Passing after backporting them to 13u-dev."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286277](https://bugs.openjdk.org/browse/JDK-8286277): CDS VerifyError when calling clone() on object array


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/376/head:pull/376` \
`$ git checkout pull/376`

Update a local copy of the PR: \
`$ git checkout pull/376` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 376`

View PR using the GUI difftool: \
`$ git pr show -t 376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/376.diff">https://git.openjdk.org/jdk13u-dev/pull/376.diff</a>

</details>
