### PR TITLE
8284549: JFR: FieldTable leaks FieldInfoTable member

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleWriter.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleWriter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -616,11 +616,11 @@ ObjectSampleWriter::ObjectSampleWriter(JfrCheckpointWriter& writer, EdgeStore* s
   assert(store != NULL, "invariant");
   assert(!store->is_empty(), "invariant");
   register_serializers();
-  sample_infos = NULL;
-  ref_infos = NULL;
-  array_infos = NULL;
-  field_infos = NULL;
-  root_infos = NULL;
+  assert(field_infos == NULL, "Invariant");
+  assert(sample_infos == NULL, "Invariant");
+  assert(ref_infos == NULL, "Invariant");
+  assert(array_infos == NULL, "Invariant");
+  assert(root_infos == NULL, "Invariant");
 }
 
 ObjectSampleWriter::~ObjectSampleWriter() {
@@ -629,6 +629,16 @@ ObjectSampleWriter::~ObjectSampleWriter() {
   write_array_infos(_writer);
   write_field_infos(_writer);
   write_root_descriptors(_writer);
+
+  // Followings are RA allocated, memory will be released automatically.
+  if (field_infos != NULL) {
+    field_infos->~FieldTable();
+    field_infos = NULL;
+  }
+  sample_infos = NULL;
+  ref_infos = NULL;
+  array_infos = NULL;
+  root_infos = NULL;
 }
 
 bool ObjectSampleWriter::operator()(StoredEdge& e) {


### PR DESCRIPTION
I'd like to backport JDK-8284549 to 13u to fix a memory leak in jfr.
The patch applies cleanly.
Tested with jdk/jfr and tier1 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284549](https://bugs.openjdk.org/browse/JDK-8284549): JFR: FieldTable leaks FieldInfoTable member


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/381/head:pull/381` \
`$ git checkout pull/381`

Update a local copy of the PR: \
`$ git checkout pull/381` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 381`

View PR using the GUI difftool: \
`$ git pr show -t 381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/381.diff">https://git.openjdk.org/jdk13u-dev/pull/381.diff</a>

</details>
