### PR TITLE
8257569: Failure observed with JfrVirtualMemory::initialize

### DIFF
--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -214,6 +214,7 @@ class JfrVirtualMemoryManager : public JfrCHeapObj {
     return reserved_high() == committed_high();
   }
 
+  u1* top() const { return reinterpret_cast<u1*>(_current_segment->top()); }
   const u1* committed_low() const { return _current_segment->committed_low(); }
   const u1* committed_high() const { return _current_segment->committed_high(); }
   const u1* reserved_low() const { return _current_segment->reserved_low(); }
@@ -444,11 +445,10 @@ void* JfrVirtualMemory::initialize(size_t reservation_size_request_bytes,
   }
   _reserved_low = (const u1*)_vmm->reserved_low();
   _reserved_high = (const u1*)_vmm->reserved_high();
+  assert(static_cast<size_t>(_reserved_high - _reserved_low) == reservation_size_request_bytes, "invariant");
   // reservation complete
-  _top = (u1*)_vmm->committed_high();
-  _commit_point = _top;
+  _top = _vmm->top();
   assert(_reserved_low == _top, "invariant"); // initial empty state
-  assert((size_t)(_reserved_high - _reserved_low) == reservation_size_request_bytes, "invariant");
   // initial commit
   commit_memory_block();
   return _top;
@@ -471,8 +471,6 @@ bool JfrVirtualMemory::is_empty() const {
 bool JfrVirtualMemory::commit_memory_block() {
   assert(_vmm != NULL, "invariant");
   assert(!is_full(), "invariant");
-  assert(_top == _commit_point, "invariant");
-
   void* const block = _vmm->commit(_physical_commit_size_request_words);
   if (block != NULL) {
     _commit_point = _vmm->committed_high();


### PR DESCRIPTION
I'd like to backport JDK-8257569 to 13u for parity with 11u.
The patch applies cleanly.
Tested with jdk/jfr and tier1 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257569](https://bugs.openjdk.org/browse/JDK-8257569): Failure observed with JfrVirtualMemory::initialize


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/383/head:pull/383` \
`$ git checkout pull/383`

Update a local copy of the PR: \
`$ git checkout pull/383` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 383`

View PR using the GUI difftool: \
`$ git pr show -t 383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/383.diff">https://git.openjdk.org/jdk13u-dev/pull/383.diff</a>

</details>
