### PR TITLE
8261354: SIGSEGV at MethodIteratorHost

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -723,12 +723,11 @@ class MethodIteratorHost {
   bool operator()(KlassPtr klass) {
     if (_method_used_predicate(klass)) {
       const InstanceKlass* ik = InstanceKlass::cast(klass);
-      const int len = ik->methods()->length();
-      Filter filter(ik->previous_versions() != NULL ? len : 0);
       while (ik != NULL) {
+        const int len = ik->methods()->length();
         for (int i = 0; i < len; ++i) {
           MethodPtr method = ik->methods()->at(i);
-          if (_method_flag_predicate(method) && filter(i)) {
+          if (_method_flag_predicate(method)) {
             _method_cb(method);
           }
         }


### PR DESCRIPTION
I'd like to backport JDK-8261354 to 13u for parity with 11u.
The patch applies cleanly.
Tested with jdk/jfr and tier1 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261354](https://bugs.openjdk.org/browse/JDK-8261354): SIGSEGV at MethodIteratorHost


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/390/head:pull/390` \
`$ git checkout pull/390`

Update a local copy of the PR: \
`$ git checkout pull/390` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 390`

View PR using the GUI difftool: \
`$ git pr show -t 390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/390.diff">https://git.openjdk.org/jdk13u-dev/pull/390.diff</a>

</details>
