### PR TITLE
8282071: Update java.xml module-info

### DIFF
--- a/src/java.xml/share/classes/module-info.java
+++ b/src/java.xml/share/classes/module-info.java
@@ -235,7 +235,7 @@
  * <td>17</td>
  * </tr>
  * <tr>
- * <td id="extensionClassLoader">jdk.xml.xpathExprGrpLimit</td>
+ * <td id="xpathExprGrpLimit">jdk.xml.xpathExprGrpLimit</td>
  * <td>Limits the number of groups an XPath expression can contain.
  * </td>
  * <td style="text-align:center" rowspan="3">yes</td>
@@ -253,14 +253,14 @@
  * <td style="text-align:center" rowspan="3">19</td>
  * </tr>
  * <tr>
- * <td id="extensionClassLoader">jdk.xml.xpathExprOpLimit</td>
+ * <td id="xpathExprOpLimit">jdk.xml.xpathExprOpLimit</td>
  * <td>Limits the number of operators an XPath expression can contain.
  * </td>
  * <td style="text-align:center">100</td>
  * <td style="text-align:center">100</td>
  * </tr>
  * <tr>
- * <td id="extensionClassLoader">jdk.xml.xpathTotalOpLimit</td>
+ * <td id="xpathTotalOpLimit">jdk.xml.xpathTotalOpLimit</td>
  * <td>Limits the total number of XPath operators in an XSL Stylesheet.
  * </td>
  * <td style="text-align:center">10000</td>


### PR DESCRIPTION
Fix of a cut/paste typo in module-info.java file. First hunk is dropped as not applicable, and all the environment of that document in older releases is completely different, so the change applied manually, all its three lines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282071](https://bugs.openjdk.org/browse/JDK-8282071): Update java.xml module-info


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/391/head:pull/391` \
`$ git checkout pull/391`

Update a local copy of the PR: \
`$ git checkout pull/391` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 391`

View PR using the GUI difftool: \
`$ git pr show -t 391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/391.diff">https://git.openjdk.org/jdk13u-dev/pull/391.diff</a>

</details>
