### PR TITLE
8268361: Fix the infinite loop in next_line

### DIFF
--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -60,8 +60,13 @@ static struct perfbuf {
 
 #define DEC_64 "%"SCNd64
 
-static void next_line(FILE *f) {
-    while (fgetc(f) != '\n');
+static int next_line(FILE *f) {
+    int c;
+    do {
+        c = fgetc(f);
+    } while (c != '\n' && c != EOF);
+
+    return c;
 }
 
 /**
@@ -90,7 +95,10 @@ static int get_totalticks(int which, ticks *pticks) {
            &iowTicks, &irqTicks, &sirqTicks);
 
     // Move to next line
-    next_line(fh);
+    if (next_line(fh) == EOF) {
+        fclose(fh);
+        return -2;
+    }
 
     //find the line for requested cpu faster to just iterate linefeeds?
     if (which != -1) {
@@ -103,7 +111,10 @@ static int get_totalticks(int which, ticks *pticks) {
                 fclose(fh);
                 return -2;
             }
-            next_line(fh);
+            if (next_line(fh) == EOF) {
+                fclose(fh);
+                return -2;
+            }
         }
         n = fscanf(fh, "cpu%*d " DEC_64 " " DEC_64 " " DEC_64 " " DEC_64 " "
                        DEC_64 " " DEC_64 " " DEC_64 "\n",


### PR DESCRIPTION
Backport of JDK-8268361 to 13u.
It needs to be ported due to similar problems as 17u has.
Fix applies cleanly. Tests tier1 passed after the fix without regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268361](https://bugs.openjdk.org/browse/JDK-8268361): Fix the infinite loop in next_line


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/397/head:pull/397` \
`$ git checkout pull/397`

Update a local copy of the PR: \
`$ git checkout pull/397` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 397`

View PR using the GUI difftool: \
`$ git pr show -t 397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/397.diff">https://git.openjdk.org/jdk13u-dev/pull/397.diff</a>

</details>
