### PR TITLE
8249875: GCC 10 warnings -Wtype-limits with JFR code

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrDoublyLinkedList.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrDoublyLinkedList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,6 @@ T* JfrDoublyLinkedList<T>::remove(T* const node) {
     prev->set_next(next);
   }
   --_count;
-  assert(_count >= 0, "invariant");
   assert(!in_list(node), "still in list error");
   return node;
 }

--- a/src/hotspot/share/jfr/utilities/jfrHashtable.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrHashtable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ class JfrBasicHashtable : public CHeapObj<mtTracing> {
 
   size_t hash_to_index(uintptr_t full_hash) const {
     const uintptr_t h = full_hash % _table_size;
-    assert(h >= 0 && h < _table_size, "Illegal hash value");
+    assert(h < _table_size, "Illegal hash value");
     return (size_t)h;
   }
   size_t entry_size() const { return _entry_size; }


### PR DESCRIPTION
We need this fix in 13u, too. Risk is low. Skara-clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249875](https://bugs.openjdk.org/browse/JDK-8249875): GCC 10 warnings -Wtype-limits with JFR code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/399/head:pull/399` \
`$ git checkout pull/399`

Update a local copy of the PR: \
`$ git checkout pull/399` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 399`

View PR using the GUI difftool: \
`$ git pr show -t 399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/399.diff">https://git.openjdk.org/jdk13u-dev/pull/399.diff</a>

</details>
