### PR TITLE
8252051: Make mlvmJvmtiUtils strncpy uses GCC 10.x friendly

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,8 +96,11 @@ struct MethodName * getMethodName(jvmtiEnv * pJvmtiEnv, jmethodID method) {
       return NULL;
     }
 
-    strncpy(mn->methodName, szName, sizeof(mn->methodName));
-    strncpy(mn->classSig, szSignature, sizeof(mn->classSig));
+    strncpy(mn->methodName, szName, sizeof(mn->methodName) - 1);
+    mn->methodName[sizeof(mn->methodName) - 1] = '\0';
+
+    strncpy(mn->classSig, szSignature, sizeof(mn->classSig) - 1);
+    mn->classSig[sizeof(mn->classSig) - 1] = '\0';
 
     return mn;
 }


### PR DESCRIPTION
low-risk necessary fix for gcc10. Works fine to me.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252051](https://bugs.openjdk.org/browse/JDK-8252051): Make mlvmJvmtiUtils strncpy uses GCC 10.x friendly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/400/head:pull/400` \
`$ git checkout pull/400`

Update a local copy of the PR: \
`$ git checkout pull/400` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 400`

View PR using the GUI difftool: \
`$ git pr show -t 400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/400.diff">https://git.openjdk.org/jdk13u-dev/pull/400.diff</a>

</details>
