### PR TITLE
8247818: GCC 10 warning stringop-overflow with symbol code

### DIFF
--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -52,9 +52,7 @@ uint32_t Symbol::pack_length_and_refcount(int length, int refcount) {
 Symbol::Symbol(const u1* name, int length, int refcount) {
   _length_and_refcount =  pack_length_and_refcount(length, refcount);
   _identity_hash = (short)os::random();
-  for (int i = 0; i < length; i++) {
-    byte_at_put(i, name[i]);
-  }
+  memcpy(_body, name, length);
 }
 
 void* Symbol::operator new(size_t sz, int len) throw() {

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -126,11 +126,6 @@ class Symbol : public MetaspaceObj {
     return (int)heap_word_size(byte_size(length));
   }
 
-  void byte_at_put(int index, u1 value) {
-    assert(index >=0 && index < length(), "symbol index overflow");
-    _body[index] = value;
-  }
-
   Symbol(const u1* name, int length, int refcount);
   void* operator new(size_t size, int len) throw();
   void* operator new(size_t size, int len, Arena* arena) throw();


### PR DESCRIPTION
backporting this useful fix which is already in mainstream for long time. Not clean backport for 13u in symbol.cpp: context differs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247818](https://bugs.openjdk.org/browse/JDK-8247818): GCC 10 warning stringop-overflow with symbol code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/401/head:pull/401` \
`$ git checkout pull/401`

Update a local copy of the PR: \
`$ git checkout pull/401` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 401`

View PR using the GUI difftool: \
`$ git pr show -t 401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/401.diff">https://git.openjdk.org/jdk13u-dev/pull/401.diff</a>

</details>
