### PR TITLE
8266170: -Wnonnull happens in classLoaderData.inline.hpp

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -523,9 +523,8 @@ void Dictionary::verify() {
   ClassLoaderData* cld = loader_data();
   // class loader must be present;  a null class loader is the
   // boostrap loader
-  guarantee(cld != NULL ||
-            cld->class_loader() == NULL ||
-            cld->class_loader()->is_instance(),
+  guarantee(cld != NULL &&
+            (cld->the_null_class_loader_data() || cld->class_loader()->is_instance()),
             "checking type of class_loader");
 
   ResourceMark rm;


### PR DESCRIPTION
Backport of JDK-8272720 to 13u
Applied cleanely, no tier1 tests regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266170](https://bugs.openjdk.org/browse/JDK-8266170): -Wnonnull happens in classLoaderData.inline.hpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/405/head:pull/405` \
`$ git checkout pull/405`

Update a local copy of the PR: \
`$ git checkout pull/405` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 405`

View PR using the GUI difftool: \
`$ git pr show -t 405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/405.diff">https://git.openjdk.org/jdk13u-dev/pull/405.diff</a>

</details>
