### PR TITLE
8266172: -Wstringop-overflow happens in vmError.cpp

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1756,8 +1756,8 @@ static void crash_with_sigfpe() {
 // crash with sigsegv at non-null address.
 static void crash_with_segfault() {
 
-  char* const crash_addr = (char*) VMError::get_segfault_address();
-  *crash_addr = 'X';
+  int* crash_addr = reinterpret_cast<int*>(VMError::get_segfault_address());
+  *crash_addr = 1;
 
 } // end: crash_with_segfault
 


### PR DESCRIPTION
Backport JDK-8266172 to 13u
A part of GCC11 compliance.
Applied with a small modification - "VMError::segfault_address" class member field is absent in 15u and 13u, so "VMError::get_segfault_address()" is still used..
No tier1 regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266172](https://bugs.openjdk.org/browse/JDK-8266172): -Wstringop-overflow happens in vmError.cpp


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/406/head:pull/406` \
`$ git checkout pull/406`

Update a local copy of the PR: \
`$ git checkout pull/406` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 406`

View PR using the GUI difftool: \
`$ git pr show -t 406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/406.diff">https://git.openjdk.org/jdk13u-dev/pull/406.diff</a>

</details>
