### PR TITLE
8272472: StackGuardPages test doesn't build with glibc 2.34

### DIFF
--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,8 +67,17 @@ static void handler(int sig, siginfo_t *si, void *unused) {
   longjmp(context, 1);
 }
 
+static char* altstack = NULL;
+
 void set_signal_handler() {
-  static char altstack[SIGSTKSZ];
+  if (altstack == NULL) {
+    // Dynamically allocated in case SIGSTKSZ is not constant
+    altstack = malloc(SIGSTKSZ);
+    if (altstack == NULL) {
+      fprintf(stderr, "Test ERROR. Unable to malloc altstack space\n");
+      exit(7);
+    }
+  }
 
   stack_t ss = {
     .ss_size = SIGSTKSZ,


### PR DESCRIPTION
a simple test fix necessary to build test-image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272472](https://bugs.openjdk.org/browse/JDK-8272472): StackGuardPages test doesn't build with glibc 2.34


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/407/head:pull/407` \
`$ git checkout pull/407`

Update a local copy of the PR: \
`$ git checkout pull/407` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 407`

View PR using the GUI difftool: \
`$ git pr show -t 407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/407.diff">https://git.openjdk.org/jdk13u-dev/pull/407.diff</a>

</details>
