### PR TITLE
8266082: AssertionError in Annotate.fromAnnotations with -Xdoclint

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -30,6 +30,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.sun.source.doctree.AttributeTree.ValueKind;
+import com.sun.source.tree.AnnotatedTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.parser.DocCommentParser.TagParser.Kind;
 import com.sun.tools.javac.parser.Tokens.Comment;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
@@ -576,7 +579,22 @@ public class DocCommentParser {
         if (p.token().kind != TokenKind.EOF)
             throw new ParseException("dc.ref.unexpected.input");
 
+            if (new TypeAnnotationFinder().scan(paramTypes, null) != null)
+            throw new ParseException("dc.ref.annotations.not.allowed");
+
         return paramTypes.toList();
+    }
+
+    static class TypeAnnotationFinder extends TreeScanner<Tree, Void> {
+        @Override
+        public Tree visitAnnotatedType(AnnotatedTypeTree t, Void ignore) {
+            return t;
+        }
+
+        @Override
+        public Tree reduce(Tree t1, Tree t2) {
+            return t1 != null ? t1 : t2;
+        }
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3136,6 +3136,9 @@ compiler.err.dc.unterminated.signature=\
 compiler.err.dc.unterminated.string=\
     unterminated string
 
+compiler.err.dc.ref.annotations.not.allowed=\
+    annotations not allowed
+
 ###
 # errors related to modules
 

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.java
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.java
@@ -1,0 +1,31 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8266082
+ * @summary javac should not crash when seeing type annotations in links
+ * @compile/fail/ref=CrashInAnnotateTest.out -Xdoclint -XDrawDiagnostics CrashInAnnotateTest.java
+ */
+
+import java.util.List;
+
+/** {@link #equals(@Deprecated Object)}
+ *  {@link java.util.Map.@Deprecated Entry#getKey()}
+ */
+class CrashInAnnotateTest {
+}
+
+/** {@link #compare(Object, List<List<@Deprecated Object>>)} */
+class CrashInAnnotateTest2 {
+    void compare(Object o, List<List<Object>> l) {}
+}
+
+/** {@link @Deprecated java.lang.Object#hashCode()} */
+class CrashInAnnotateTest3 { }
+
+/** {@link CrashInAnnotateTest4.@java.lang.Deprecated Inner#aField}
+ *  {@link java.util.Map.@Deprecated#getKey()}
+ */
+class CrashInAnnotateTest4 {
+    class Inner {
+        Object aField;
+    }
+}

--- a/test/langtools/tools/doclint/CrashInAnnotateTest.out
+++ b/test/langtools/tools/doclint/CrashInAnnotateTest.out
@@ -1,0 +1,11 @@
+CrashInAnnotateTest.java:10:5: compiler.err.proc.messager: annotations not allowed
+CrashInAnnotateTest.java:11:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:16:5: compiler.err.proc.messager: annotations not allowed
+CrashInAnnotateTest.java:18:10: compiler.warn.proc.messager: no comment
+CrashInAnnotateTest.java:21:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:24:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:25:5: compiler.err.proc.messager: syntax error in reference
+CrashInAnnotateTest.java:28:5: compiler.warn.proc.messager: no comment
+CrashInAnnotateTest.java:29:16: compiler.warn.proc.messager: no comment
+6 errors
+3 warnings

--- a/test/langtools/tools/javac/diags/examples/NoAnnotationsInLink.java
+++ b/test/langtools/tools/javac/diags/examples/NoAnnotationsInLink.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.dc.ref.annotations.not.allowed
+// key: compiler.note.note
+// key: compiler.note.proc.messager
+// run: backdoor
+// options: -processor DocCommentProcessor -proc:only
+
+/** {@link #equals(@Deprecated Object)} */
+class NoAnnotationsInLink {
+}


### PR DESCRIPTION
Hi! Here is backport of JDK-8266082 that fixes javac crash on unallowed annotation usage when running with -Xdoclint option. Original patch applied with the following changes:

- it patches DocCommentParser.parseParams() method instead of ReferenceParser.parseParams() cuz up to 13u class DocCommentParser relays on own implementation of the method

Verification (amd64/20.04LTS): tools/doclint/CrashInAnnotateTest.java (new test)
Regression (amd64/20.04LTS): test/langtools

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266082](https://bugs.openjdk.org/browse/JDK-8266082): AssertionError in Annotate.fromAnnotations with -Xdoclint


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/410/head:pull/410` \
`$ git checkout pull/410`

Update a local copy of the PR: \
`$ git checkout pull/410` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 410`

View PR using the GUI difftool: \
`$ git pr show -t 410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/410.diff">https://git.openjdk.org/jdk13u-dev/pull/410.diff</a>

</details>
