### PR TITLE
8266174: -Wmisleading-indentation happens in libmlib_image sources

### DIFF
--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.h
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,7 @@ typedef union {
     SRC = MLIB_S32_MAX;                                        \
   if (SRC <= MLIB_S32_MIN)                                     \
     SRC = MLIB_S32_MIN;                                        \
-    DST = (mlib_s32) SRC
+  DST = (mlib_s32) SRC
 
 #endif /* MLIB_USE_FTOI_CLAMPING */
 


### PR DESCRIPTION
Backport JDK-8266174

Clean backport, not tier1 regression

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266174](https://bugs.openjdk.org/browse/JDK-8266174): -Wmisleading-indentation happens in libmlib_image sources


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/412/head:pull/412` \
`$ git checkout pull/412`

Update a local copy of the PR: \
`$ git checkout pull/412` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 412`

View PR using the GUI difftool: \
`$ git pr show -t 412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/412.diff">https://git.openjdk.org/jdk13u-dev/pull/412.diff</a>

</details>
