### PR TITLE
8294357: (tz) Update Timezone Data to 2022d

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2022c
+tzdata2022d

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -3398,10 +3398,6 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # The winter time in 2015 started on October 23 at 01:00.
 # https://wafa.ps/ar_page.aspx?id=CgpCdYa670694628582aCgpCdY
 # http://www.palestinecabinet.gov.ps/portal/meeting/details/27583
-#
-# From Paul Eggert (2019-04-10):
-# For now, guess spring-ahead transitions are at 00:00 on the Saturday
-# preceding March's last Sunday (i.e., Sat>=24).
 
 # From P Chan (2021-10-18):
 # http://wafa.ps/Pages/Details/34701
@@ -3417,6 +3413,18 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 
 # From Heba Hamad (2022-03-10):
 # summer time will begin in Palestine from Sunday 03-27-2022, 00:00 AM.
+
+# From Heba Hamad (2022-08-30):
+# winter time will begin in Palestine from Saturday 10-29, 02:00 AM by
+# 60 minutes backwards.  Also the state of Palestine adopted the summer
+# and winter time for the years: 2023,2024,2025,2026 ...
+# https://mm.icann.org/pipermail/tz/attachments/20220830/9f024566/Time-0001.pdf
+# (2022-08-31): ... the Saturday before the last Sunday in March and October
+# at 2:00 AM ,for the years from 2023 to 2026.
+# (2022-09-05): https://mtit.pna.ps/Site/New/1453
+#
+# From Paul Eggert (2022-08-31):
+# For now, assume that this rule will also be used after 2026.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule EgyptAsia	1957	only	-	May	10	0:00	1:00	S
@@ -3448,14 +3456,16 @@ Rule Palestine	2013	only	-	Sep	27	0:00	0	-
 Rule Palestine	2014	only	-	Oct	24	0:00	0	-
 Rule Palestine	2015	only	-	Mar	28	0:00	1:00	S
 Rule Palestine	2015	only	-	Oct	23	1:00	0	-
-Rule Palestine	2016	2018	-	Mar	Sat>=24	1:00	1:00	S
-Rule Palestine	2016	2018	-	Oct	Sat>=24	1:00	0	-
+Rule Palestine	2016	2018	-	Mar	Sat<=30	1:00	1:00	S
+Rule Palestine	2016	2018	-	Oct	Sat<=30	1:00	0	-
 Rule Palestine	2019	only	-	Mar	29	0:00	1:00	S
-Rule Palestine	2019	only	-	Oct	Sat>=24	0:00	0	-
-Rule Palestine	2020	2021	-	Mar	Sat>=24	0:00	1:00	S
+Rule Palestine	2019	only	-	Oct	Sat<=30	0:00	0	-
+Rule Palestine	2020	2021	-	Mar	Sat<=30	0:00	1:00	S
 Rule Palestine	2020	only	-	Oct	24	1:00	0	-
-Rule Palestine	2021	max	-	Oct	Fri>=23	1:00	0	-
-Rule Palestine	2022	max	-	Mar	Sun>=25	0:00	1:00	S
+Rule Palestine	2021	only	-	Oct	29	1:00	0	-
+Rule Palestine	2022	only	-	Mar	27	0:00	1:00	S
+Rule Palestine	2022	max	-	Oct	Sat<=30	2:00	0	-
+Rule Palestine	2023	max	-	Mar	Sat<=30	2:00	1:00	S
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Gaza	2:17:52	-	LMT	1900 Oct

--- a/make/data/tzdata/backward
+++ b/make/data/tzdata/backward
@@ -113,6 +113,8 @@ Link	Etc/UTC			Etc/UCT
 Link	Europe/London		Europe/Belfast
 Link	Europe/Kyiv		Europe/Kiev
 Link	Europe/Chisinau		Europe/Tiraspol
+Link	Europe/Kyiv		Europe/Uzhgorod
+Link	Europe/Kyiv		Europe/Zaporozhye
 Link	Europe/London		GB
 Link	Europe/London		GB-Eire
 Link	Etc/GMT			GMT+0

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -2638,10 +2638,14 @@ Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 # From Alexander Krivenyshev (2014-03-17):
 # time change at 2:00 (2am) on March 30, 2014
 # https://vz.ru/news/2014/3/17/677464.html
-# From Paul Eggert (2014-03-30):
-# Simferopol and Sevastopol reportedly changed their central town clocks
-# late the previous day, but this appears to have been ceremonial
-# and the discrepancies are small enough to not worry about.
+# From Tim Parenti (2022-07-01), per Paul Eggert (2014-03-30):
+# The clocks at the railway station in Simferopol were put forward from 22:00
+# to 24:00 the previous day in a "symbolic ceremony"; however, per
+# contemporaneous news reports, "ordinary Crimeans [made] the daylight savings
+# time switch at 2am" on Sunday.
+# https://www.business-standard.com/article/pti-stories/crimea-to-set-clocks-to-russia-time-114033000014_1.html
+# https://www.reuters.com/article/us-ukraine-crisis-crimea-time/crimea-switches-to-moscow-time-amid-incorporation-frenzy-idUKBREA2S0LT20140329
+# https://www.bbc.com/news/av/world-europe-26806583
 			 2:00	EU	EE%sT	2014 Mar 30  2:00
 			 4:00	-	MSK	2014 Oct 26  2:00s
 			 3:00	-	MSK
@@ -3774,8 +3778,8 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # US colleague David Cochrane) are still trying to get more
 # information upon these local deviations from Kiev rules.
 #
-# From Paul Eggert (2022-02-08):
-# For now, assume that Ukraine's other three zones followed the same rules,
+# From Paul Eggert (2022-08-27):
+# For now, assume that Ukraine's zones all followed the same rules,
 # except that Crimea switched to Moscow time in 1994 as described elsewhere.
 
 # From Igor Karpov, who works for the Ukrainian Ministry of Justice,
@@ -3845,21 +3849,7 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # * Ukrainian Government's Resolution of 20.03.1992, No. 139.
 # http://www.uazakon.com/documents/date_8u/pg_grcasa.htm
 
-# From Paul Eggert (2022-04-12):
-# As is usual in tzdb, Ukrainian zones use the most common English spellings.
-# In particular, tzdb's name Europe/Kyiv uses the most common spelling in
-# English for Ukraine's capital.  Although tzdb's former name was Europe/Kiev,
-# "Kyiv" is now more common due to widespread reporting of the current conflict.
-# Conversely, tzdb continues to use the names Europe/Uzhgorod and
-# Europe/Zaporozhye; this is similar to tzdb's use of Europe/Prague, which is
-# certainly wrong as a transliteration of the Czech "Praha".
-# English-language spelling of Ukrainian names is in flux, and
-# some day "Uzhhorod" or "Zaporizhzhia" may become substantially more
-# common in English; in the meantime, do not change these
-# English spellings as that means less disruption for our users.
-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-# This represents most of Ukraine.  See above for the spelling of "Kyiv".
 Zone Europe/Kyiv	2:02:04 -	LMT	1880
 			2:02:04	-	KMT	1924 May  2 # Kyiv Mean Time
 			2:00	-	EET	1930 Jun 21
@@ -3867,34 +3857,6 @@ Zone Europe/Kyiv	2:02:04 -	LMT	1880
 			1:00	C-Eur	CE%sT	1943 Nov  6
 			3:00	Russia	MSK/MSD	1990 Jul  1  2:00
 			2:00	1:00	EEST	1991 Sep 29  3:00
-			2:00	C-Eur	EE%sT	1996 May 13
-			2:00	EU	EE%sT
-# Transcarpathia used CET 1990/1991.
-# "Uzhhorod" is the transliteration of the Rusyn/Ukrainian pronunciation, but
-# "Uzhgorod" is more common in English.
-Zone Europe/Uzhgorod	1:29:12 -	LMT	1890 Oct
-			1:00	-	CET	1940
-			1:00	C-Eur	CE%sT	1944 Oct
-			1:00	1:00	CEST	1944 Oct 26
-			1:00	-	CET	1945 Jun 29
-			3:00	Russia	MSK/MSD	1990
-			3:00	-	MSK	1990 Jul  1  2:00
-			1:00	-	CET	1991 Mar 31  3:00
-			2:00	-	EET	1992 Mar 20
-			2:00	C-Eur	EE%sT	1996 May 13
-			2:00	EU	EE%sT
-# Zaporozh'ye and eastern Lugansk oblasts observed DST 1990/1991.
-# "Zaporizhzhia" is the transliteration of the Ukrainian name, but
-# "Zaporozh'ye" is more common in English.  Use the common English
-# spelling, except omit the apostrophe as it is not allowed in
-# portable Posix file names.
-Zone Europe/Zaporozhye	2:20:40 -	LMT	1880
-			2:20	-	+0220	1924 May  2
-			2:00	-	EET	1930 Jun 21
-			3:00	-	MSK	1941 Aug 25
-			1:00	C-Eur	CE%sT	1943 Oct 25
-			3:00	Russia	MSK/MSD	1991 Mar 31  2:00
-			2:00	E-Eur	EE%sT	1992 Mar 20
 			2:00	C-Eur	EE%sT	1996 May 13
 			2:00	EU	EE%sT
 

--- a/make/data/tzdata/southamerica
+++ b/make/data/tzdata/southamerica
@@ -1332,8 +1332,14 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # for America/Santiago will start on midnight of September 11th;
 # and will end on April 1st, 2023. Magallanes region (America/Punta_Arenas)
 # will keep UTC -3 "indefinitely"...  This is because on September 4th
-# we will have a voting whether to approve a new Constitution....
-# https://www.interior.gob.cl/noticias/2022/08/09/comunicado-el-proximo-sabado-10-de-septiembre-los-relojes-se-deben-adelantar-una-hora/
+# we will have a voting whether to approve a new Constitution.
+#
+# From Eduardo Romero Urra (2022-08-17):
+# https://www.diariooficial.interior.gob.cl/publicaciones/2022/08/13/43327/01/2172567.pdf
+#
+# From Paul Eggert (2022-08-17):
+# Although the presidential decree stops at fall 2026, assume that
+# similar DST rules will continue thereafter.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Chile	1927	1931	-	Sep	 1	0:00	1:00	-

--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -424,8 +424,6 @@ TV	-0831+17913	Pacific/Funafuti
 TW	+2503+12130	Asia/Taipei
 TZ	-0648+03917	Africa/Dar_es_Salaam
 UA	+5026+03031	Europe/Kyiv	Ukraine (most areas)
-UA	+4837+02218	Europe/Uzhgorod	Transcarpathia
-UA	+4750+03510	Europe/Zaporozhye	Zaporozhye and east Lugansk
 UG	+0019+03225	Africa/Kampala
 UM	+2813-17722	Pacific/Midway	Midway Islands
 UM	+1917+16637	Pacific/Wake	Wake Island

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -573,12 +573,8 @@ public final class ZoneInfoFile {
                     // we can then pass in the dom = -1, dow > 0 into ZoneInfo
                     //
                     // hacking, assume the >=24 is the result of ZRB optimization for
-                    // "last", it works for now. From tzdata2020d this hacking
-                    // will not work for Asia/Gaza and Asia/Hebron which follow
-                    // Palestine DST rules.
-                    if (dom < 0 || dom >= 24 &&
-                                   !(zoneId.equals("Asia/Gaza") ||
-                                     zoneId.equals("Asia/Hebron"))) {
+                    // "last", it works for now.
+                    if (dom < 0 || dom >= 24) {
                         params[1] = -1;
                         params[2] = toCalendarDOW[dow];
                     } else {
@@ -600,7 +596,6 @@ public final class ZoneInfoFile {
                     params[7] = 0;
                 } else {
                     // hacking: see comment above
-                    // No need of hacking for Asia/Gaza and Asia/Hebron from tz2021e
                     if (dom < 0 || dom >= 24) {
                         params[6] = -1;
                         params[7] = toCalendarDOW[dow];

--- a/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
@@ -1,1 +1,1 @@
-tzdata2022c
+tzdata2022d

--- a/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
@@ -183,6 +183,8 @@ Link	Etc/UTC			Etc/UCT
 Link	Europe/London		Europe/Belfast
 Link	Europe/Kyiv		Europe/Kiev
 Link	Europe/Chisinau		Europe/Tiraspol
+Link	Europe/Kyiv		Europe/Uzhgorod
+Link	Europe/Kyiv		Europe/Zaporozhye
 Link	Europe/London		GB
 Link	Europe/London		GB-Eire
 Link	Etc/GMT			GMT+0

--- a/test/jdk/java/util/TimeZone/TimeZoneData/displaynames.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/displaynames.txt
@@ -163,11 +163,9 @@ Europe/Simferopol MSK
 Europe/Sofia EET EEST
 Europe/Tallinn EET EEST
 Europe/Tirane CET CEST
-Europe/Uzhgorod EET EEST
 Europe/Vienna CET CEST
 Europe/Vilnius EET EEST
 Europe/Warsaw CET CEST
-Europe/Zaporozhye EET EEST
 Europe/Zurich CET CEST
 HST HST
 MET MET MEST

--- a/test/jdk/sun/util/calendar/zi/TestZoneInfo310.java
+++ b/test/jdk/sun/util/calendar/zi/TestZoneInfo310.java
@@ -176,11 +176,12 @@ public class TestZoneInfo310 {
              * save time in IANA tzdata. This bug is tracked via JDK-8223388.
              *
              * These are the zones/rules that employ negative DST in vanguard
-             * format (as of 2019a):
+             * format (as of 2019a), Palestine added in 2022d:
              *
              *  - Rule "Eire"
              *  - Rule "Morocco"
              *  - Rule "Namibia"
+             *  - Rule "Palestine"
              *  - Zone "Europe/Prague"
              *
              * Tehran/Iran rule has rules beyond 2037, in which javazic assumes
@@ -196,6 +197,8 @@ public class TestZoneInfo310 {
                 zid.equals("Europe/Dublin") || // uses "Eire" rule
                 zid.equals("Europe/Prague") ||
                 zid.equals("Asia/Tehran") || // last rule mismatch
+                zid.equals("Asia/Gaza") || // uses "Palestine" rule
+                zid.equals("Asia/Hebron") || // uses "Palestine" rule
                 zid.equals("Iran")) { // last rule mismatch
                     continue;
             }


### PR DESCRIPTION
It is the necessary regular backport. Clean barring the files location. All relevant tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294357](https://bugs.openjdk.org/browse/JDK-8294357): (tz) Update Timezone Data to 2022d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/415/head:pull/415` \
`$ git checkout pull/415`

Update a local copy of the PR: \
`$ git checkout pull/415` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 415`

View PR using the GUI difftool: \
`$ git pr show -t 415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/415.diff">https://git.openjdk.org/jdk13u-dev/pull/415.diff</a>

</details>
