### PR TITLE
8242565: Policy initialization issues when the denyAfter constraint is enabled

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,7 @@ public class Providers {
         // Note: when SunEC is in a signed JAR file, it's not signed
         // by EC algorithms. So it's still safe to be listed here.
         "SunEC",
+        "SunJCE",
     };
 
     // Return Sun provider.

--- a/src/java.base/share/classes/sun/security/tools/KeyStoreUtil.java
+++ b/src/java.base/share/classes/sun/security/tools/KeyStoreUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.ServiceLoader;
 
 import sun.security.util.PropertyExpander;
@@ -62,12 +63,6 @@ public class KeyStoreUtil {
     private KeyStoreUtil() {
         // this class is not meant to be instantiated
     }
-
-    private static final Collator collator = Collator.getInstance();
-    static {
-        // this is for case insensitive string comparisons
-        collator.setStrength(Collator.PRIMARY);
-    };
 
     /**
      * Returns true if the certificate is self-signed, false otherwise.
@@ -133,7 +128,8 @@ public class KeyStoreUtil {
     }
 
     public static char[] getPassWithModifier(String modifier, String arg,
-                                             java.util.ResourceBundle rb) {
+                                             ResourceBundle rb,
+                                             Collator collator) {
         if (modifier == null) {
             return arg.toCharArray();
         } else if (collator.compare(modifier, "env") == 0) {

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -4812,7 +4812,8 @@ public final class Main {
     }
 
     private char[] getPass(String modifier, String arg) {
-        char[] output = KeyStoreUtil.getPassWithModifier(modifier, arg, rb);
+        char[] output =
+            KeyStoreUtil.getPassWithModifier(modifier, arg, rb, collator);
         if (output != null) return output;
         tinyHelp();
         return null;    // Useless, tinyHelp() already exits.

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -565,7 +565,8 @@ public class Main {
     }
 
     static char[] getPass(String modifier, String arg) {
-        char[] output = KeyStoreUtil.getPassWithModifier(modifier, arg, rb);
+        char[] output =
+            KeyStoreUtil.getPassWithModifier(modifier, arg, rb, collator);
         if (output != null) return output;
         usage();
         return null;    // Useless, usage() already exit

--- a/test/jdk/java/security/Policy/SignedJar/SignedJarTest.java
+++ b/test/jdk/java/security/Policy/SignedJar/SignedJarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
- * @bug 8048360
+ * @bug 8048360 8242565
  * @summary test policy entry with signedBy alias
  * @library /test/lib
  * @run main/othervm SignedJarTest
@@ -52,6 +52,7 @@ public class SignedJarTest {
     private static final String POLICY2 = "SignedJarTest_2.policy";
     private static final String KEYSTORE1 = "both.jks";
     private static final String KEYSTORE2 = "first.jks";
+    private static final String SECPROPS = TESTSRC + FS + "java.security";
 
     public static void main(String args[]) throws Throwable {
         //copy PrivilegeTest.class, policy files and keystore password file into current direcotry
@@ -147,6 +148,7 @@ public class SignedJarTest {
             "-classpath", classpath,
             "-Djava.security.manager",
             "-Djava.security.policy=" + policy,
+            "-Djava.security.properties=" + SECPROPS,
             "PrivilegeTest",
             arg1, arg2};
         return cmd;

--- a/test/jdk/java/security/Policy/SignedJar/java.security
+++ b/test/jdk/java/security/Policy/SignedJar/java.security
@@ -1,0 +1,3 @@
+jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
+      DSA keySize < 1024, include jdk.disabled.namedCurves, \
+      SHA1 jdkCA & denyAfter 2019-01-01


### PR DESCRIPTION
Almost clean backports instead of copyright year in the KeyStoreUtil.java and SignedJarTest.java

java/security tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8242565](https://bugs.openjdk.org/browse/JDK-8242565): Policy initialization issues when the denyAfter constraint is enabled


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/416/head:pull/416` \
`$ git checkout pull/416`

Update a local copy of the PR: \
`$ git checkout pull/416` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 416`

View PR using the GUI difftool: \
`$ git pr show -t 416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/416.diff">https://git.openjdk.org/jdk13u-dev/pull/416.diff</a>

</details>
