### PR TITLE
8293816: CI: ciBytecodeStream::get_klass() is not consistent

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -317,7 +317,7 @@ void ciInstanceKlass::print_impl(outputStream* st) {
   ciKlass::print_impl(st);
   GUARDED_VM_ENTRY(st->print(" loader=" INTPTR_FORMAT, p2i((address)loader()));)
   if (is_loaded()) {
-    st->print(" loaded=true initialized=%s finalized=%s subklass=%s size=%d flags=",
+    st->print(" initialized=%s finalized=%s subklass=%s size=%d flags=",
               bool_to_str(is_initialized()),
               bool_to_str(has_finalizer()),
               bool_to_str(has_subklass()),
@@ -332,8 +332,6 @@ void ciInstanceKlass::print_impl(outputStream* st) {
     if (_java_mirror) {
       st->print(" mirror=PRESENT");
     }
-  } else {
-    st->print(" loaded=false");
   }
 }
 

--- a/src/hotspot/share/ci/ciKlass.cpp
+++ b/src/hotspot/share/ci/ciKlass.cpp
@@ -223,6 +223,7 @@ jint ciKlass::access_flags() {
 void ciKlass::print_impl(outputStream* st) {
   st->print(" name=");
   print_name_on(st);
+  st->print(" loaded=%s", (is_loaded() ? "true" : "false"));
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -200,12 +200,8 @@ ciKlass* ciBytecodeStream::get_klass() {
   bool will_link;
   ciKlass* klass = get_klass(will_link);
   if (!will_link && klass->is_loaded()) { // klass not accessible
-    if (klass->is_array_klass()) {
-      assert(!klass->is_type_array_klass(), "");
-      klass = ciEnv::unloaded_ciobjarrayklass();
-    } else {
-      klass = ciEnv::unloaded_ciinstance_klass();
-    }
+    VM_ENTRY_MARK;
+    klass = CURRENT_ENV->get_unloaded_klass(_holder, klass->name());
   }
   return klass;
 }


### PR DESCRIPTION
Backporting as a follow-up to JDK-8293044. Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293816](https://bugs.openjdk.org/browse/JDK-8293816): CI: ciBytecodeStream::get_klass() is not consistent


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/426/head:pull/426` \
`$ git checkout pull/426`

Update a local copy of the PR: \
`$ git checkout pull/426` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 426`

View PR using the GUI difftool: \
`$ git pr show -t 426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/426.diff">https://git.openjdk.org/jdk13u-dev/pull/426.diff</a>

</details>
