### PR TITLE
8297027: Fix broken aarch64 build of 13u/15u after bad backport of 8293044

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1320,7 +1320,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* thread, Runtime1::StubID stub_i
   frame runtime_frame = thread->last_frame();
   frame caller_frame = runtime_frame.sender(&reg_map);
 
-  if (is_patching_needed(current, stub_id)) {
+  if (is_patching_needed(thread, stub_id)) {
     // Make sure the nmethod is invalidated, i.e. made not entrant.
     nmethod* nm = CodeCache::find_nmethod(caller_frame.pc());
     if (nm != NULL) {


### PR DESCRIPTION
Change argument of is_patching_needed() to thread, in this release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297027](https://bugs.openjdk.org/browse/JDK-8297027): Fix broken aarch64 build of 13u/15u after bad backport of 8293044


### Reviewers
 * [Andrew Brygin](https://openjdk.org/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/430/head:pull/430` \
`$ git checkout pull/430`

Update a local copy of the PR: \
`$ git checkout pull/430` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 430`

View PR using the GUI difftool: \
`$ git pr show -t 430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/430.diff">https://git.openjdk.org/jdk13u-dev/pull/430.diff</a>

</details>
