### PR TITLE
8296480: java/security/cert/pkix/policyChanges/TestPolicy.java is failing

### DIFF
--- a/test/jdk/java/security/cert/pkix/policyChanges/TestPolicy.java
+++ b/test/jdk/java/security/cert/pkix/policyChanges/TestPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  */
 
 import java.io.*;
+import java.text.DateFormat;
 import java.util.*;
 
 import java.security.Security;
@@ -96,6 +97,10 @@ public class TestPolicy {
             PKIXParameters params = new PKIXParameters(Collections.singleton(new TrustAnchor(anchor, null)));
             params.setRevocationEnabled(false);
             params.setInitialPolicies(testCase.initialPolicies);
+
+            // Certs expired on 7th Nov 2022
+            params.setDate(DateFormat.getDateInstance(DateFormat.MEDIUM,
+                    Locale.US).parse("June 01, 2022"));
 
             CertPath path = factory.generateCertPath(Arrays.asList(new X509Certificate[] {ee, ca}));
 


### PR DESCRIPTION
Clean backport of the fix to a test failing because of just expired certificates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296480](https://bugs.openjdk.org/browse/JDK-8296480): java/security/cert/pkix/policyChanges/TestPolicy.java is failing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/433/head:pull/433` \
`$ git checkout pull/433`

Update a local copy of the PR: \
`$ git checkout pull/433` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 433`

View PR using the GUI difftool: \
`$ git pr show -t 433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/433.diff">https://git.openjdk.org/jdk13u-dev/pull/433.diff</a>

</details>
