### PR TITLE
8296957: One more cast in SAFE_SIZE_NEW_ARRAY2

### DIFF
--- a/src/java.desktop/share/native/common/awt/utility/sizecalc.h
+++ b/src/java.desktop/share/native/common/awt/utility/sizecalc.h
@@ -91,7 +91,7 @@
     (IS_SAFE_SIZE_MUL(sizeof(type), (n)) ? (new type[(size_t)(n)]) : throw std::bad_alloc())
 
 #define SAFE_SIZE_NEW_ARRAY2(type, n, m) \
-    (IS_SAFE_SIZE_MUL((m), (n)) && IS_SAFE_SIZE_MUL(sizeof(type), (n) * (m)) ? \
+    (IS_SAFE_SIZE_MUL((m), (n)) && IS_SAFE_SIZE_MUL(sizeof(type), (size_t)(n) * (size_t)(m)) ? \
      (new type[(size_t)(n) * (size_t)(m)]) : throw std::bad_alloc())
 
 /*


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [fb6c992f](https://github.com/openjdk/jdk/commit/fb6c992f325981c42c7f75109a6c9db7ca8715d8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 22 Nov 2022 and was reviewed by Alexey Ivanov.

This pull request replaces this [one](https://github.com/openjdk/jdk13u-dev/pull/434)

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296957](https://bugs.openjdk.org/browse/JDK-8296957): One more cast in SAFE_SIZE_NEW_ARRAY2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/436.diff">https://git.openjdk.org/jdk13u-dev/pull/436.diff</a>

</details>
