### PR TITLE
8287180: Update IANA Language Subtag Registry to Version 2022-08-08

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2022-03-02
+File-Date: 2022-08-08
 %%
 Type: language
 Subtag: aa
@@ -46970,6 +46970,7 @@ Preferred-Value: TL
 %%
 Type: region
 Subtag: TR
+Description: Türkiye
 Description: Turkey
 Added: 2005-10-16
 %%
@@ -47764,6 +47765,19 @@ Added: 2007-08-11
 Prefix: sl-rozaj
 Comments: The dialect of Lipovaz/Lipovec is one of the minor local
   dialects of Resian
+%%
+Type: variant
+Subtag: ltg1929
+Description: The Latgalian language orthography codified in 1929
+Added: 2022-08-05
+Prefix: ltg
+%%
+Type: variant
+Subtag: ltg2007
+Description: The Latgalian language orthography codified in the language
+  law in 2007
+Added: 2022-06-23
+Prefix: ltg
 %%
 Type: variant
 Subtag: luna1918

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -26,7 +26,7 @@
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2022-03-02) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2022-08-08) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
Backporting this update for parity with Oracle and general consistency. All relevant tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287180](https://bugs.openjdk.org/browse/JDK-8287180): Update IANA Language Subtag Registry to Version 2022-08-08


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk13u-dev pull/438/head:pull/438` \
`$ git checkout pull/438`

Update a local copy of the PR: \
`$ git checkout pull/438` \
`$ git pull https://git.openjdk.org/jdk13u-dev pull/438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 438`

View PR using the GUI difftool: \
`$ git pr show -t 438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk13u-dev/pull/438.diff">https://git.openjdk.org/jdk13u-dev/pull/438.diff</a>

</details>
